### PR TITLE
v0.0.3 - pipeline ioxide.pg and ioxide.redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 One ring per reactor thread - run one per core. HTTP, Postgres, and file I/O submit on that
 ring and resume inline on the same thread. No thread pool on the hot path. No native dependencies - raw syscalls, nothing else.
 
-> Linux 6.1+ · .NET 10 · status `0.0.2` - experimental
+> Linux 6.1+ · .NET 10 · status `0.0.3` - experimental
 
 **[Documentation →](https://mda2av.github.io/ioxide/)** - architecture, guides, the full picture
 

--- a/ioxide.file/ioxide.file.csproj
+++ b/ioxide.file/ioxide.file.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.file</RootNamespace>
 
     <PackageId>ioxide.file</PackageId>
-    <Version>0.0.2</Version>
+    <Version>0.0.3</Version>
     <Authors>MDA2AV</Authors>
     <Description>File serving for the ioxide io_uring runtime: immutable asset snapshots with baked responses, pooled positional ring reads, atomic reloads.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.pg/PgConnection.cs
+++ b/ioxide.pg/PgConnection.cs
@@ -1,18 +1,21 @@
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading.Tasks.Sources;
 
 namespace ioxide.pg;
 
 /// <summary>
 /// A Postgres connection that runs entirely on the host's ring - connect and handshake included,
-/// so opening one never blocks the reactor. One query in flight at a time; concurrency comes from
-/// <see cref="PgPool"/>. A server ErrorResponse throws but leaves the connection usable (the
+/// so opening one never blocks the reactor. Commands are pipelined - many in flight at once,
+/// sent back to back, replies routed to waiters in FIFO order - so one connection stays busy under
+/// load instead of one round trip at a time. A server ErrorResponse throws but leaves the connection usable (the
 /// stream resyncs at ReadyForQuery); a transport failure marks it <see cref="IsBroken"/> and the
 /// pool replaces it.
 /// </summary>
 public sealed class PgConnection : IDisposable
 {
     private const int InitialBufferSize = 64 * 1024;
+    private const int SendBufferSize = 512 * 1024;   // fixed: a pipelined send holds _send's address, so it is never realloc'd
     private const int MaxBufferSize = 1 << 20;
 
     private readonly RingSocket _socket;
@@ -27,14 +30,22 @@ public sealed class PgConnection : IDisposable
     private int _received;   // valid bytes in _recv
     private int _scan;       // start of the first unparsed message
 
+    // Pipelining: commands sent back to back, replies routed FIFO. Single-threaded per reactor,
+    // so the queue and flags need no locks. _send is staged at [_sendOffset, _sendEnd).
+    private readonly Queue<Pending> _inflight = new();
+    private bool _sending;
+    private bool _reading;
+    private int _sendOffset;
+    private int _sendEnd;
+
     /// <summary>Transport-level failure happened; the connection must be discarded, not reused.</summary>
     public bool IsBroken { get; private set; }
 
     private unsafe PgConnection(RingSocket socket)
     {
         _socket = socket;
-        _send = (nint)NativeMemory.Alloc(InitialBufferSize);
-        _sendCapacity = InitialBufferSize;
+        _send = (nint)NativeMemory.Alloc(SendBufferSize);
+        _sendCapacity = SendBufferSize;
         _recv = (nint)NativeMemory.Alloc(InitialBufferSize);
         _recvCapacity = InitialBufferSize;
     }
@@ -136,55 +147,148 @@ public sealed class PgConnection : IDisposable
     /// and the command tag). Throws <see cref="PgException"/> on a server error - after consuming
     /// the rest of the response, so the connection stays usable.
     /// </summary>
-    public async ValueTask<PgResult> QueryAsync(string sql)
+    /// <summary>Run one simple query, pipelined onto this connection. Resumes inline on the reactor.</summary>
+    public ValueTask<PgResult> QueryAsync(string sql) => SubmitAsync(sql, null);
+
+    // Stage the command, enqueue its waiter, and make sure the sender and reader are running.
+    private ValueTask<PgResult> SubmitAsync(string sql, PgRowHandler? onRow)
     {
         if (IsBroken)
         {
-            throw new PgException("connection is broken");
+            return ValueTask.FromException<PgResult>(new PgException("connection is broken"));
         }
 
-        int length = WriteQuery(sql);
-        await SendAllAsync(length);
-
-        string? value = null;
-        bool valueCaptured = false;
-        int rows = 0;
-        string commandTag = "";
-        PgException? serverError = null;
-
-        while (true)
+        try
         {
-            Message message = await ReceiveMessageAsync();
-
-            switch (message.Tag)
-            {
-                case PgProtocol.DataRow:
-                    rows++;
-                    if (!valueCaptured)
-                    {
-                        valueCaptured = true;
-                        value = ReadFirstField(message);
-                    }
-                    break;
-
-                case PgProtocol.CommandComplete:
-                    commandTag = ReadBodyCString(message);
-                    break;
-
-                case PgProtocol.ErrorResponse:
-                    // Don't throw yet: consume until ReadyForQuery so the stream
-                    // is resynchronized and the connection can serve the next query.
-                    serverError = ReadServerError(message);
-                    break;
-
-                case PgProtocol.ReadyForQuery:
-                    if (serverError != null)
-                    {
-                        throw serverError;
-                    }
-                    return new PgResult(value, rows, commandTag);
-            }
+            WriteQueryAt(sql);   // append to _send; throws on overflow before any state changes
         }
+        catch (PgException ex)
+        {
+            return ValueTask.FromException<PgResult>(ex);
+        }
+
+        var pending = new Pending(onRow);
+        _inflight.Enqueue(pending);
+
+        if (!_sending) { _sending = true; _ = SenderLoopAsync(); }
+        if (!_reading) { _reading = true; _ = ReaderLoopAsync(); }
+
+        return new ValueTask<PgResult>(pending, pending.Version);
+    }
+
+    // Drains the staged send buffer; picks up commands appended while a send was in flight.
+    private async Task SenderLoopAsync()
+    {
+        try
+        {
+            while (_sendOffset < _sendEnd)
+            {
+                int n = await _socket.SendAsync(_send + _sendOffset, _sendEnd - _sendOffset);
+                if (n <= 0)
+                {
+                    IsBroken = true;
+                    throw PgException.Transport("send", n);
+                }
+                _sendOffset += n;
+            }
+            _sendOffset = 0;   // all staged bytes sent; reuse the buffer from the front
+            _sendEnd = 0;
+            _sending = false;
+        }
+        catch (Exception ex)
+        {
+            IsBroken = true;
+            _sending = false;
+            FailAll(ex);
+        }
+    }
+
+    // Reads replies and routes each to the front in-flight command; completes it at ReadyForQuery.
+    private async Task ReaderLoopAsync()
+    {
+        try
+        {
+            while (_inflight.Count > 0)
+            {
+                Message message = await ReceiveMessageAsync();
+                Pending front = _inflight.Peek();
+
+                switch (message.Tag)
+                {
+                    case PgProtocol.DataRow:
+                        front.Rows++;
+                        if (front.OnRow != null)
+                        {
+                            InvokeRow(front.OnRow, in message);
+                        }
+                        else if (!front.ValueCaptured)
+                        {
+                            front.ValueCaptured = true;
+                            front.Value = ReadFirstField(message);
+                        }
+                        break;
+
+                    case PgProtocol.CommandComplete:
+                        front.CommandTag = ReadBodyCString(message);
+                        break;
+
+                    case PgProtocol.ErrorResponse:
+                        // Per-query in the simple protocol: the next pipelined query still runs.
+                        front.Error = ReadServerError(message);
+                        break;
+
+                    case PgProtocol.ReadyForQuery:
+                        _inflight.Dequeue();
+                        front.Complete();
+                        break;
+                }
+            }
+            _reading = false;
+        }
+        catch (Exception ex)
+        {
+            IsBroken = true;
+            _reading = false;
+            FailAll(ex is PgException p ? p : new PgException(ex.Message));
+        }
+    }
+
+    private void FailAll(Exception ex)
+    {
+        PgException pe = ex as PgException ?? new PgException(ex.Message);
+        while (_inflight.TryDequeue(out Pending? p))
+        {
+            p.Fail(pe);
+        }
+    }
+
+    // One pipelined command: accumulates its reply and completes its waiter (inline on the reactor).
+    private sealed class Pending : IValueTaskSource<PgResult>
+    {
+        private ManualResetValueTaskSourceCore<PgResult> _core = new() { RunContinuationsAsynchronously = false };
+
+        public readonly PgRowHandler? OnRow;
+        public string? Value;
+        public bool ValueCaptured;
+        public int Rows;
+        public string CommandTag = "";
+        public PgException? Error;
+
+        public Pending(PgRowHandler? onRow) => OnRow = onRow;
+        public short Version => _core.Version;
+
+        public void Complete()
+        {
+            if (Error != null) _core.SetException(Error);
+            else _core.SetResult(new PgResult(Value, Rows, CommandTag));
+        }
+
+        public void Fail(PgException ex) => _core.SetException(ex);
+
+        public PgResult GetResult(short token) => _core.GetResult(token);
+        public ValueTaskSourceStatus GetStatus(short token) => _core.GetStatus(token);
+        public void OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
+            => _core.OnCompleted(continuation, state, token, flags);
     }
 
     private readonly record struct Message(byte Tag, int BodyStart, int BodyLength);
@@ -290,45 +394,11 @@ public sealed class PgConnection : IDisposable
     /// reactor) and returning the row count. Server errors throw after the stream resyncs at
     /// ReadyForQuery, same as <see cref="QueryAsync"/>.
     /// </summary>
+    /// <summary>Run one simple query, streaming each DataRow to <paramref name="onRow"/>; pipelined.</summary>
     public async ValueTask<int> QueryRowsAsync(string sql, PgRowHandler onRow)
     {
-        if (IsBroken)
-        {
-            throw new PgException("connection is broken");
-        }
-
-        int length = WriteQuery(sql);
-        await SendAllAsync(length);
-
-        int rows = 0;
-        PgException? serverError = null;
-
-        while (true)
-        {
-            Message message = await ReceiveMessageAsync();
-
-            switch (message.Tag)
-            {
-                case PgProtocol.DataRow:
-                    rows++;
-                    if (serverError == null)
-                    {
-                        InvokeRow(onRow, in message);
-                    }
-                    break;
-
-                case PgProtocol.ErrorResponse:
-                    serverError = ReadServerError(message);
-                    break;
-
-                case PgProtocol.ReadyForQuery:
-                    if (serverError != null)
-                    {
-                        throw serverError;
-                    }
-                    return rows;
-            }
-        }
+        PgResult result = await SubmitAsync(sql, onRow);
+        return result.Rows;
     }
 
     private unsafe void InvokeRow(PgRowHandler onRow, in Message message)
@@ -365,25 +435,21 @@ public sealed class PgConnection : IDisposable
         return PgProtocol.WriteStartup(new Span<byte>((void*)_send, _sendCapacity), user, database);
     }
 
-    private unsafe int WriteQuery(string sql)
+    // Append a Query message to the pipelined send buffer. Fixed buffer (an in-flight send holds its
+    // address), so this never realloc's - it throws on overflow instead.
+    private unsafe void WriteQueryAt(string sql)
     {
         int needed = PgProtocol.QueryLength(sql);
         if (needed > _sendCapacity)
         {
-            if (needed > MaxBufferSize)
-            {
-                throw new PgException($"query exceeds {MaxBufferSize} bytes");
-            }
-            int newCapacity = _sendCapacity;
-            while (newCapacity < needed)
-            {
-                newCapacity *= 2;
-            }
-            _send = (nint)NativeMemory.Realloc((void*)_send, (nuint)newCapacity);
-            _sendCapacity = newCapacity;
+            throw new PgException($"query exceeds send buffer ({_sendCapacity} bytes)");
         }
-
-        return PgProtocol.WriteQuery(new Span<byte>((void*)_send, _sendCapacity), sql);
+        if (_sendEnd + needed > _sendCapacity)
+        {
+            throw new PgException("pipelined send buffer full");
+        }
+        int written = PgProtocol.WriteQuery(new Span<byte>((void*)(_send + _sendEnd), _sendCapacity - _sendEnd), sql);
+        _sendEnd += written;
     }
 
     private unsafe ReadOnlySpan<byte> Body(in Message message)

--- a/ioxide.pg/PgPool.cs
+++ b/ioxide.pg/PgPool.cs
@@ -1,16 +1,18 @@
 namespace ioxide.pg;
 
 /// <summary>
-/// N Postgres connections on one reactor's ring. Handlers rent, query, return; when all are busy,
-/// renters queue and resume inline as connections come back. Warmup opens connections
-/// concurrently over the ring; broken ones are discarded on return and replaced in the
-/// background. One pool per reactor - create from <c>Reactor.OnStart</c>.
+/// N Postgres connections on one reactor's ring, with pipelining. Commands round-robin across the
+/// connections and each connection multiplexes many in flight, so the connections stay busy under
+/// load instead of one round trip at a time. Broken connections are evicted and replaced. One pool
+/// per reactor - create from <c>Reactor.OnStart</c>.
 /// </summary>
 public sealed class PgPool
 {
-    private readonly RingPool<PgConnection> _pool = new();
+    private readonly List<PgConnection> _connections = new();
     private readonly IRingHost _host;
     private readonly PgOptions _options;
+    private int _next;
+    private TaskCompletionSource<bool>? _opened;   // signalled when a connection becomes available
 
     private PgPool(IRingHost host, PgOptions options)
     {
@@ -22,12 +24,10 @@ public sealed class PgPool
     public static PgPool Start(Reactor reactor, PgOptions options)
     {
         var pool = new PgPool(reactor, options);
-
         for (int i = 0; i < options.PoolSize; i++)
         {
             _ = pool.OpenOneAsync();
         }
-
         reactor.AddService(pool);
         return pool;
     }
@@ -37,65 +37,69 @@ public sealed class PgPool
         try
         {
             PgConnection connection = await PgConnection.ConnectAsync(_host, _options);
-            _pool.Return(connection);
+            _connections.Add(connection);
+            _opened?.TrySetResult(true);
         }
         catch (Exception e)
         {
-            // The pool runs one connection short; queries queue on the remaining ones.
             Console.Error.WriteLine($"[pg] connect to {_options.Host}:{_options.Port} failed: {e.Message}");
         }
     }
 
-    /// <summary>Connections currently idle (for diagnostics).</summary>
-    public int IdleCount => _pool.IdleCount;
+    /// <summary>Live connections (for diagnostics).</summary>
+    public int ConnectionCount => _connections.Count;
 
-    /// <summary>
-    /// Rent a connection for several operations (e.g. a transaction). Pair with
-    /// <see cref="Return"/> in a finally block.
-    /// </summary>
-    public ValueTask<PgConnection> RentAsync()
+    /// <summary>Run one simple query on the next connection (pipelined).</summary>
+    public ValueTask<PgResult> QueryAsync(string sql)
     {
-        return _pool.RentAsync();
+        PgConnection? c = Pick();
+        return c != null ? c.QueryAsync(sql) : QuerySlowAsync(sql);
     }
 
-    /// <summary>Return a rented connection; a broken one is replaced instead of pooled.</summary>
-    public void Return(PgConnection connection)
+    /// <summary>Run one simple query, streaming rows through <paramref name="onRow"/> (pipelined).</summary>
+    public ValueTask<int> QueryRowsAsync(string sql, PgRowHandler onRow)
     {
-        if (connection.IsBroken)
+        PgConnection? c = Pick();
+        return c != null ? c.QueryRowsAsync(sql, onRow) : QueryRowsSlowAsync(sql, onRow);
+    }
+
+    private async ValueTask<PgResult> QuerySlowAsync(string sql)
+        => await (await WaitForConnectionAsync()).QueryAsync(sql);
+
+    private async ValueTask<int> QueryRowsSlowAsync(string sql, PgRowHandler onRow)
+        => await (await WaitForConnectionAsync()).QueryRowsAsync(sql, onRow);
+
+    // Round-robin over healthy connections; evict and replace any found broken.
+    private PgConnection? Pick()
+    {
+        while (_connections.Count > 0)
         {
-            connection.Dispose();
+            int index = (_next++ & 0x7fffffff) % _connections.Count;
+            PgConnection c = _connections[index];
+            if (!c.IsBroken)
+            {
+                return c;
+            }
+            _connections.RemoveAt(index);
+            c.Dispose();
             _ = OpenOneAsync();
-            return;
         }
-
-        _pool.Return(connection);
+        return null;
     }
 
-    /// <summary>Rent → stream a query's rows through <paramref name="onRow"/> → return.</summary>
-    public async ValueTask<int> QueryRowsAsync(string sql, PgRowHandler onRow)
+    // Startup-only: no connection is open yet; wait for the first one.
+    private async ValueTask<PgConnection> WaitForConnectionAsync()
     {
-        PgConnection connection = await RentAsync();
-        try
+        while (true)
         {
-            return await connection.QueryRowsAsync(sql, onRow);
-        }
-        finally
-        {
-            Return(connection);
-        }
-    }
-
-    /// <summary>Rent → run one simple query → return. The everyday path.</summary>
-    public async ValueTask<PgResult> QueryAsync(string sql)
-    {
-        PgConnection connection = await RentAsync();
-        try
-        {
-            return await connection.QueryAsync(sql);
-        }
-        finally
-        {
-            Return(connection);
+            PgConnection? c = Pick();
+            if (c != null)
+            {
+                return c;
+            }
+            _opened ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            await _opened.Task;
+            _opened = null;
         }
     }
 }

--- a/ioxide.pg/ioxide.pg.csproj
+++ b/ioxide.pg/ioxide.pg.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.pg</RootNamespace>
 
     <PackageId>ioxide.pg</PackageId>
-    <Version>0.0.2</Version>
+    <Version>0.0.3</Version>
     <Authors>MDA2AV</Authors>
     <Description>Postgres driver for the ioxide io_uring runtime: pooled ring-native connections per reactor, ring-native connect and handshake, inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.redis/RedisConnection.cs
+++ b/ioxide.redis/RedisConnection.cs
@@ -1,16 +1,19 @@
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading.Tasks.Sources;
 
 namespace ioxide.redis;
 
 /// <summary>
 /// One Redis connection on a reactor's ring. Connect, auth, and every command run as ring ops with
 /// inline completion resume. The protocol surface is generic - <see cref="ExecuteAsync(string, RedisArg[])"/>
-/// runs any command - with typed helpers (in RedisConnection.Commands.cs) layered on top.
+/// runs any command - with typed helpers (in RedisConnection.Commands.cs) layered on top. Commands are
+/// pipelined: many in flight at once, replies routed FIFO, so one connection stays busy under load.
 /// </summary>
 public sealed partial class RedisConnection : IDisposable
 {
     private const int InitialBufferSize = 16 * 1024;
+    private const int SendBufferSize = 512 * 1024;   // fixed: a pipelined send holds _send's address, so never realloc'd
     private const int MaxBufferSize = 64 * 1024 * 1024;
 
     private readonly RingSocket _socket;
@@ -22,13 +25,21 @@ public sealed partial class RedisConnection : IDisposable
     private int _received;   // valid bytes in _recv
     private int _scan;       // start of the first unparsed reply
 
+    // Pipelining: commands sent back to back, one RESP reply each, routed FIFO. Single-threaded
+    // per reactor, so no locks. _send staged at [_sendOffset, _sendEnd).
+    private readonly Queue<Pending> _inflight = new();
+    private bool _sending;
+    private bool _reading;
+    private int _sendOffset;
+    private int _sendEnd;
+
     public bool IsBroken { get; private set; }
 
     private unsafe RedisConnection(RingSocket socket)
     {
         _socket = socket;
-        _send = (nint)NativeMemory.Alloc(InitialBufferSize);
-        _sendCapacity = InitialBufferSize;
+        _send = (nint)NativeMemory.Alloc(SendBufferSize);
+        _sendCapacity = SendBufferSize;
         _recv = (nint)NativeMemory.Alloc(InitialBufferSize);
         _recvCapacity = InitialBufferSize;
     }
@@ -69,20 +80,37 @@ public sealed partial class RedisConnection : IDisposable
     /// <summary>Run any command and return its reply. Throws on a top-level error reply.</summary>
     public async ValueTask<RespValue> ExecuteAsync(string command, params RedisArg[] args)
     {
-        if (IsBroken)
-        {
-            throw new RedisException("connection is broken");
-        }
-
-        WriteCommand(command, args);
-        await SendAllAsync(_pendingSend);
-
-        RespValue reply = await ReceiveReplyAsync();
+        RespValue reply = await SubmitCore(Encoding.ASCII.GetBytes(command), args);
         if (reply.IsError)
         {
             throw new RedisException(reply.AsString() ?? "redis error");
         }
         return reply;
+    }
+
+    // Stage a command, enqueue its waiter, ensure the sender and reader are running.
+    private ValueTask<RespValue> SubmitCore(ReadOnlySpan<byte> name, RedisArg[] args)
+    {
+        if (IsBroken)
+        {
+            return ValueTask.FromException<RespValue>(new RedisException("connection is broken"));
+        }
+        try
+        {
+            AppendCommand(name, args);
+        }
+        catch (RedisException ex)
+        {
+            return ValueTask.FromException<RespValue>(ex);
+        }
+
+        var pending = new Pending();
+        _inflight.Enqueue(pending);
+
+        if (!_sending) { _sending = true; _ = SenderLoopAsync(); }
+        if (!_reading) { _reading = true; _ = ReaderLoopAsync(); }
+
+        return new ValueTask<RespValue>(pending, pending.Version);
     }
 
     /// <summary>
@@ -97,71 +125,106 @@ public sealed partial class RedisConnection : IDisposable
             throw new RedisException("connection is broken");
         }
 
-        int total = 0;
-        foreach (RedisCommand c in commands)
+        var pending = new ValueTask<RespValue>[commands.Length];
+        for (int i = 0; i < commands.Length; i++)
         {
-            total += RespProtocol.CommandSize(c.NameBytes, c.Args);
+            pending[i] = SubmitCore(commands[i].NameBytes, commands[i].Args);
         }
-        EnsureSendCapacity(total);
-
-        int p = 0;
-        foreach (RedisCommand c in commands)
-        {
-            p += WriteCommandAt(p, c.NameBytes, c.Args);
-        }
-        await SendAllAsync(p);
 
         var replies = new RespValue[commands.Length];
         for (int i = 0; i < commands.Length; i++)
         {
-            replies[i] = await ReceiveReplyAsync();
+            replies[i] = await pending[i];
         }
         return replies;
     }
 
     // -- wire I/O ---------------------------------------------------------
 
-    private int _pendingSend;
-
-    private unsafe void WriteCommand(string command, RedisArg[] args)
+    // Append a RESP command to the pipelined send buffer. Fixed buffer (an in-flight send holds its
+    // address), so this never realloc's - it throws on overflow instead.
+    private unsafe void AppendCommand(ReadOnlySpan<byte> name, RedisArg[] args)
     {
-        ReadOnlySpan<byte> name = Encoding.ASCII.GetBytes(command);
         int size = RespProtocol.CommandSize(name, args);
-        EnsureSendCapacity(size);
-        _pendingSend = RespProtocol.WriteCommand(new Span<byte>((void*)_send, _sendCapacity), name, args);
+        if (size > _sendCapacity)
+        {
+            throw new RedisException($"command exceeds send buffer ({_sendCapacity} bytes)");
+        }
+        if (_sendEnd + size > _sendCapacity)
+        {
+            throw new RedisException("pipelined send buffer full");
+        }
+        int written = RespProtocol.WriteCommand(new Span<byte>((void*)(_send + _sendEnd), _sendCapacity - _sendEnd), name, args);
+        _sendEnd += written;
     }
 
-    private unsafe int WriteCommandAt(int offset, byte[] name, RedisArg[] args) =>
-        RespProtocol.WriteCommand(new Span<byte>((void*)(_send + offset), _sendCapacity - offset), name, args);
-
-    private unsafe void EnsureSendCapacity(int needed)
+    private async Task SenderLoopAsync()
     {
-        if (needed <= _sendCapacity)
+        try
         {
-            return;
-        }
-        int cap = _sendCapacity;
-        while (cap < needed)
-        {
-            cap *= 2;
-        }
-        _send = (nint)NativeMemory.Realloc((void*)_send, (nuint)cap);
-        _sendCapacity = cap;
-    }
-
-    private async ValueTask SendAllAsync(int length)
-    {
-        int sent = 0;
-        while (sent < length)
-        {
-            int n = await _socket.SendAsync(_send + sent, length - sent);
-            if (n <= 0)
+            while (_sendOffset < _sendEnd)
             {
-                IsBroken = true;
-                throw RedisException.Transport("send", n);
+                int n = await _socket.SendAsync(_send + _sendOffset, _sendEnd - _sendOffset);
+                if (n <= 0)
+                {
+                    IsBroken = true;
+                    throw RedisException.Transport("send", n);
+                }
+                _sendOffset += n;
             }
-            sent += n;
+            _sendOffset = 0;   // all staged bytes sent; reuse the buffer from the front
+            _sendEnd = 0;
+            _sending = false;
         }
+        catch (Exception ex)
+        {
+            IsBroken = true;
+            _sending = false;
+            FailAll(ex);
+        }
+    }
+
+    private async Task ReaderLoopAsync()
+    {
+        try
+        {
+            while (_inflight.Count > 0)
+            {
+                RespValue reply = await ReceiveReplyAsync();
+                _inflight.Dequeue().Complete(reply);
+            }
+            _reading = false;
+        }
+        catch (Exception ex)
+        {
+            IsBroken = true;
+            _reading = false;
+            FailAll(ex);
+        }
+    }
+
+    private void FailAll(Exception ex)
+    {
+        RedisException re = ex as RedisException ?? new RedisException(ex.Message);
+        while (_inflight.TryDequeue(out Pending? p))
+        {
+            p.Fail(re);
+        }
+    }
+
+    // One pipelined command: completes its waiter with the RESP reply (inline on the reactor).
+    private sealed class Pending : IValueTaskSource<RespValue>
+    {
+        private ManualResetValueTaskSourceCore<RespValue> _core = new() { RunContinuationsAsynchronously = false };
+
+        public short Version => _core.Version;
+        public void Complete(RespValue reply) => _core.SetResult(reply);
+        public void Fail(RedisException ex) => _core.SetException(ex);
+
+        public RespValue GetResult(short token) => _core.GetResult(token);
+        public ValueTaskSourceStatus GetStatus(short token) => _core.GetStatus(token);
+        public void OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
+            => _core.OnCompleted(continuation, state, token, flags);
     }
 
     private async ValueTask<RespValue> ReceiveReplyAsync()

--- a/ioxide.redis/RedisPool.cs
+++ b/ioxide.redis/RedisPool.cs
@@ -1,15 +1,18 @@
 namespace ioxide.redis;
 
 /// <summary>
-/// N Redis connections on one reactor's ring. Handlers rent, run commands, return; when all are
-/// busy, renters queue and resume inline as connections come back. Broken connections are replaced
-/// on return. One pool per reactor - create from <c>Reactor.OnStart</c>.
+/// N Redis connections on one reactor's ring, with pipelining. Commands round-robin across the
+/// connections and each connection multiplexes many in flight, so the connections stay busy under
+/// load instead of one round trip at a time. Broken connections are evicted and replaced. One pool
+/// per reactor - create from <c>Reactor.OnStart</c>.
 /// </summary>
 public sealed class RedisPool
 {
-    private readonly RingPool<RedisConnection> _pool = new();
+    private readonly List<RedisConnection> _connections = new();
     private readonly IRingHost _host;
     private readonly RedisOptions _options;
+    private int _next;
+    private TaskCompletionSource<bool>? _opened;
 
     private RedisPool(IRingHost host, RedisOptions options)
     {
@@ -34,7 +37,8 @@ public sealed class RedisPool
         try
         {
             RedisConnection connection = await RedisConnection.ConnectAsync(_host, _options);
-            _pool.Return(connection);
+            _connections.Add(connection);
+            _opened?.TrySetResult(true);
         }
         catch (Exception e)
         {
@@ -42,75 +46,76 @@ public sealed class RedisPool
         }
     }
 
-    public int IdleCount => _pool.IdleCount;
+    /// <summary>Live connections (for diagnostics).</summary>
+    public int ConnectionCount => _connections.Count;
 
-    /// <summary>Rent a connection for several commands (e.g. MULTI/EXEC or a pipeline); return in a finally.</summary>
-    public ValueTask<RedisConnection> RentAsync() => _pool.RentAsync();
-
-    public void Return(RedisConnection connection)
+    /// <summary>Run any command on the next connection (pipelined).</summary>
+    public ValueTask<RespValue> ExecuteAsync(string command, params RedisArg[] args)
     {
-        if (connection.IsBroken)
+        RedisConnection? c = Pick();
+        return c != null ? c.ExecuteAsync(command, args) : ExecuteSlowAsync(command, args);
+    }
+
+    /// <summary>GET (the cache-aside read path).</summary>
+    public ValueTask<string?> GetAsync(string key)
+    {
+        RedisConnection? c = Pick();
+        return c != null ? c.GetAsync(key) : GetSlowAsync(key);
+    }
+
+    /// <summary>SET key value EX seconds (the cache-aside populate path).</summary>
+    public ValueTask SetExAsync(string key, RedisArg value, int seconds)
+    {
+        RedisConnection? c = Pick();
+        return c != null ? c.SetExAsync(key, value, seconds) : SetExSlowAsync(key, value, seconds);
+    }
+
+    /// <summary>DEL (cache invalidation).</summary>
+    public ValueTask<long> DelAsync(params string[] keys)
+    {
+        RedisConnection? c = Pick();
+        return c != null ? c.DelAsync(keys) : DelSlowAsync(keys);
+    }
+
+    private async ValueTask<RespValue> ExecuteSlowAsync(string command, RedisArg[] args)
+        => await (await WaitForConnectionAsync()).ExecuteAsync(command, args);
+    private async ValueTask<string?> GetSlowAsync(string key)
+        => await (await WaitForConnectionAsync()).GetAsync(key);
+    private async ValueTask SetExSlowAsync(string key, RedisArg value, int seconds)
+        => await (await WaitForConnectionAsync()).SetExAsync(key, value, seconds);
+    private async ValueTask<long> DelSlowAsync(string[] keys)
+        => await (await WaitForConnectionAsync()).DelAsync(keys);
+
+    // Round-robin over healthy connections; evict and replace any found broken.
+    private RedisConnection? Pick()
+    {
+        while (_connections.Count > 0)
         {
-            connection.Dispose();
+            int index = (_next++ & 0x7fffffff) % _connections.Count;
+            RedisConnection c = _connections[index];
+            if (!c.IsBroken)
+            {
+                return c;
+            }
+            _connections.RemoveAt(index);
+            c.Dispose();
             _ = OpenOneAsync();
-            return;
         }
-        _pool.Return(connection);
+        return null;
     }
 
-    /// <summary>Rent → run one command → return.</summary>
-    public async ValueTask<RespValue> ExecuteAsync(string command, params RedisArg[] args)
+    private async ValueTask<RedisConnection> WaitForConnectionAsync()
     {
-        RedisConnection connection = await RentAsync();
-        try
+        while (true)
         {
-            return await connection.ExecuteAsync(command, args);
-        }
-        finally
-        {
-            Return(connection);
-        }
-    }
-
-    /// <summary>Rent → GET → return (the cache-aside read path).</summary>
-    public async ValueTask<string?> GetAsync(string key)
-    {
-        RedisConnection connection = await RentAsync();
-        try
-        {
-            return await connection.GetAsync(key);
-        }
-        finally
-        {
-            Return(connection);
-        }
-    }
-
-    /// <summary>Rent → SET key value EX seconds → return (the cache-aside populate path).</summary>
-    public async ValueTask SetExAsync(string key, RedisArg value, int seconds)
-    {
-        RedisConnection connection = await RentAsync();
-        try
-        {
-            await connection.SetExAsync(key, value, seconds);
-        }
-        finally
-        {
-            Return(connection);
-        }
-    }
-
-    /// <summary>Rent → DEL → return (cache invalidation).</summary>
-    public async ValueTask<long> DelAsync(params string[] keys)
-    {
-        RedisConnection connection = await RentAsync();
-        try
-        {
-            return await connection.DelAsync(keys);
-        }
-        finally
-        {
-            Return(connection);
+            RedisConnection? c = Pick();
+            if (c != null)
+            {
+                return c;
+            }
+            _opened ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            await _opened.Task;
+            _opened = null;
         }
     }
 }

--- a/ioxide.redis/ioxide.redis.csproj
+++ b/ioxide.redis/ioxide.redis.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.redis</RootNamespace>
 
     <PackageId>ioxide.redis</PackageId>
-    <Version>0.0.2</Version>
+    <Version>0.0.3</Version>
     <Authors>MDA2AV</Authors>
     <Description>Redis client for the ioxide io_uring runtime: pooled ring-native connections per reactor, full RESP2 protocol, a generic command API plus typed helpers (strings, keys, hashes, lists, sets, sorted sets, pub/sub, transactions, scripting), and pipelining. Inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.tls/ioxide.tls.csproj
+++ b/ioxide.tls/ioxide.tls.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.tls</RootNamespace>
 
     <PackageId>ioxide.tls</PackageId>
-    <Version>0.0.2</Version>
+    <Version>0.0.3</Version>
     <Authors>MDA2AV</Authors>
     <Description>TLS for the ioxide io_uring runtime: OpenSSL handshake driven over the ring, then kernel TLS (kTLS) transmit offload - handlers keep writing plaintext through the same connection API. Requires Linux kTLS (tls module) and OpenSSL 3.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide/IoxideRuntime.cs
+++ b/ioxide/IoxideRuntime.cs
@@ -7,7 +7,7 @@ namespace ioxide;
 /// </summary>
 public static class IoxideRuntime
 {
-    public const string Version = "0.0.2";
+    public const string Version = "0.0.3";
 
     // Wiring (a builder API will eventually wrap this):
     //   var reactor = new Reactor(id, config);               // implements IRingHost

--- a/ioxide/ioxide.csproj
+++ b/ioxide/ioxide.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide</RootNamespace>
 
     <PackageId>ioxide</PackageId>
-    <Version>0.0.2</Version>
+    <Version>0.0.3</Version>
     <Authors>MDA2AV</Authors>
     <Description>A shared-nothing io_uring runtime for .NET: one ring per reactor thread, inline completions, zero native dependencies. The engine - reactor, connection, and the IRingHost client seam.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Multiplex commands on each Postgres/Redis connection: many in flight, sent back to back, replies routed FIFO, so a connection stays busy under load instead of one round trip at a time. Pools round-robin across connections and evict broken ones.

**Measured locally (gcannon, vs the prior rent/return model):**
- Redis cache-hit path: ~3x throughput (307K -> 920K req/s)
- async-db: +8% throughput at -34% server CPU

All five packages bumped to 0.0.3 for cohesion (only ioxide.pg and ioxide.redis changed; the rest are republished at the same content).
