### PR TITLE
v0.0.4 - prepared statements in ioxide.pg

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 One ring per reactor thread - run one per core. HTTP, Postgres, and file I/O submit on that
 ring and resume inline on the same thread. No thread pool on the hot path. No native dependencies - raw syscalls, nothing else.
 
-> Linux 6.1+ · .NET 10 · status `0.0.3` - experimental
+> Linux 6.1+ · .NET 10 · status `0.0.4` - experimental
 
 **[Documentation](https://mda2av.github.io/ioxide/)** - architecture, guides, the full picture
 

--- a/ioxide.file/ioxide.file.csproj
+++ b/ioxide.file/ioxide.file.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.file</RootNamespace>
 
     <PackageId>ioxide.file</PackageId>
-    <Version>0.0.3</Version>
+    <Version>0.0.4</Version>
     <Authors>MDA2AV</Authors>
     <Description>File serving for the ioxide io_uring runtime: immutable asset snapshots with baked responses, pooled positional ring reads, atomic reloads.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.pg/PgConnection.cs
+++ b/ioxide.pg/PgConnection.cs
@@ -38,6 +38,11 @@ public sealed class PgConnection : IDisposable
     private int _sendOffset;
     private int _sendEnd;
 
+    // Auto-prepared statements: SQL text -> server statement name. Parse once per connection, then
+    // Bind/Execute on every reuse. Single-threaded per reactor, so no lock is needed.
+    private readonly Dictionary<string, string> _prepared = new();
+    private int _statementCounter;
+
     /// <summary>Transport-level failure happened; the connection must be discarded, not reused.</summary>
     public bool IsBroken { get; private set; }
 
@@ -150,6 +155,55 @@ public sealed class PgConnection : IDisposable
     /// <summary>Run one simple query, pipelined onto this connection. Resumes inline on the reactor.</summary>
     public ValueTask<PgResult> QueryAsync(string sql) => SubmitAsync(sql, null);
 
+    /// <summary>
+    /// Run a parameterized query as a prepared statement - auto-Parse on first use of this SQL on
+    /// this connection, then Bind/Execute on every reuse, so the server plans it once. Pipelined and
+    /// resumes inline on the reactor, same as <see cref="QueryAsync(string)"/>.
+    /// </summary>
+    public ValueTask<PgResult> QueryAsync(string sql, ReadOnlySpan<PgParam> args) => SubmitParamAsync(sql, args, null);
+
+    /// <summary>
+    /// Prepared parameterized query, streaming each DataRow to <paramref name="onRow"/> (inline). Read
+    /// the row count from <see cref="PgResult.Rows"/> on the awaited result.
+    /// </summary>
+    public ValueTask<PgResult> QueryAsync(string sql, ReadOnlySpan<PgParam> args, PgRowHandler onRow) => SubmitParamAsync(sql, args, onRow);
+
+    // Stage an extended-protocol command (Parse on first use + Bind + Execute + Sync), enqueue its
+    // waiter, and make sure the loops run. Synchronous: args is consumed into _send before returning,
+    // so the span never crosses an await.
+    private ValueTask<PgResult> SubmitParamAsync(string sql, ReadOnlySpan<PgParam> args, PgRowHandler? onRow)
+    {
+        if (IsBroken)
+        {
+            return ValueTask.FromException<PgResult>(new PgException("connection is broken"));
+        }
+
+        bool parse = !_prepared.TryGetValue(sql, out string? name);
+        name ??= "s" + _statementCounter++;
+
+        try
+        {
+            WriteExtendedAt(parse, name, sql, args);   // append to _send; throws on overflow before any state changes
+        }
+        catch (PgException ex)
+        {
+            return ValueTask.FromException<PgResult>(ex);
+        }
+
+        if (parse)
+        {
+            _prepared[sql] = name;
+        }
+
+        var pending = new Pending(onRow) { PreparedSql = parse ? sql : null };
+        _inflight.Enqueue(pending);
+
+        if (!_sending) { _sending = true; _ = SenderLoopAsync(); }
+        if (!_reading) { _reading = true; _ = ReaderLoopAsync(); }
+
+        return new ValueTask<PgResult>(pending, pending.Version);
+    }
+
     // Stage the command, enqueue its waiter, and make sure the sender and reader are running.
     private ValueTask<PgResult> SubmitAsync(string sql, PgRowHandler? onRow)
     {
@@ -176,23 +230,38 @@ public sealed class PgConnection : IDisposable
         return new ValueTask<PgResult>(pending, pending.Version);
     }
 
-    // Drains the staged send buffer; picks up commands appended while a send was in flight.
+    // Drains the staged send buffer; picks up commands appended while a send was in flight, and
+    // reclaims the sent prefix every cycle so the buffer doesn't march to capacity under a sustained
+    // submit rate (it is append-only, and resetting only on a full drain rarely happens under load).
     private async Task SenderLoopAsync()
     {
         try
         {
             while (_sendOffset < _sendEnd)
             {
-                int n = await _socket.SendAsync(_send + _sendOffset, _sendEnd - _sendOffset);
-                if (n <= 0)
+                int end = _sendEnd;   // snapshot; more may be appended (at _sendEnd) while we send
+                while (_sendOffset < end)
                 {
-                    IsBroken = true;
-                    throw PgException.Transport("send", n);
+                    int n = await _socket.SendAsync(_send + _sendOffset, end - _sendOffset);
+                    if (n <= 0)
+                    {
+                        IsBroken = true;
+                        throw PgException.Transport("send", n);
+                    }
+                    _sendOffset += n;
                 }
-                _sendOffset += n;
+
+                // The snapshot is fully sent and nothing is in flight, so the consumed prefix is free:
+                // slide any bytes appended during the send to the front and continue from there. The
+                // reactor is single-threaded, so no append interleaves with this move.
+                int tail = _sendEnd - end;
+                if (tail > 0)
+                {
+                    CompactSend(end, tail);
+                }
+                _sendOffset = 0;
+                _sendEnd = tail;
             }
-            _sendOffset = 0;   // all staged bytes sent; reuse the buffer from the front
-            _sendEnd = 0;
             _sending = false;
         }
         catch (Exception ex)
@@ -201,6 +270,13 @@ public sealed class PgConnection : IDisposable
             _sending = false;
             FailAll(ex);
         }
+    }
+
+    // Move [from, from+length) to the front of the send buffer. CopyTo is memmove-safe for the
+    // (rare) case where the appended tail overlaps the front.
+    private unsafe void CompactSend(int from, int length)
+    {
+        new Span<byte>((void*)(_send + from), length).CopyTo(new Span<byte>((void*)_send, length));
     }
 
     // Reads replies and routes each to the front in-flight command; completes it at ReadyForQuery.
@@ -232,9 +308,19 @@ public sealed class PgConnection : IDisposable
                         front.CommandTag = ReadBodyCString(message);
                         break;
 
+                    case PgProtocol.ParseComplete:
+                    case PgProtocol.BindComplete:
+                        break;   // extended-protocol acks; nothing to collect
+
                     case PgProtocol.ErrorResponse:
-                        // Per-query in the simple protocol: the next pipelined query still runs.
+                        // Per-command: the stream resyncs at the next ReadyForQuery, so siblings still run.
                         front.Error = ReadServerError(message);
+                        if (front.PreparedSql != null)
+                        {
+                            // The Parse failed - the statement was never created, so drop it and a retry re-parses.
+                            _prepared.Remove(front.PreparedSql);
+                            front.PreparedSql = null;
+                        }
                         break;
 
                     case PgProtocol.ReadyForQuery:
@@ -273,6 +359,7 @@ public sealed class PgConnection : IDisposable
         public int Rows;
         public string CommandTag = "";
         public PgException? Error;
+        public string? PreparedSql;   // set when this command included a Parse, so it can be evicted on error
 
         public Pending(PgRowHandler? onRow) => OnRow = onRow;
         public short Version => _core.Version;
@@ -449,6 +536,25 @@ public sealed class PgConnection : IDisposable
             throw new PgException("pipelined send buffer full");
         }
         int written = PgProtocol.WriteQuery(new Span<byte>((void*)(_send + _sendEnd), _sendCapacity - _sendEnd), sql);
+        _sendEnd += written;
+    }
+
+    // Append an extended-protocol command (Parse? + Bind + Execute + Sync) to the pipelined send
+    // buffer. Fixed buffer like WriteQueryAt: throws on overflow rather than realloc'ing, since an
+    // in-flight send holds the buffer's address.
+    private unsafe void WriteExtendedAt(bool parse, string statementName, string sql, ReadOnlySpan<PgParam> args)
+    {
+        int needed = PgProtocol.ExtendedLength(parse, statementName, sql, args);
+        if (needed > _sendCapacity)
+        {
+            throw new PgException($"query exceeds send buffer ({_sendCapacity} bytes)");
+        }
+        if (_sendEnd + needed > _sendCapacity)
+        {
+            throw new PgException("pipelined send buffer full");
+        }
+        int written = PgProtocol.WriteExtended(
+            new Span<byte>((void*)(_send + _sendEnd), _sendCapacity - _sendEnd), parse, statementName, sql, args);
         _sendEnd += written;
     }
 

--- a/ioxide.pg/PgParam.cs
+++ b/ioxide.pg/PgParam.cs
@@ -1,0 +1,54 @@
+using System.Buffers.Text;
+using System.Text;
+
+namespace ioxide.pg;
+
+/// <summary>
+/// A query parameter for the extended (prepared-statement) protocol. Values are sent in text
+/// format - the server parses them against the parameter types it infers for the statement - so
+/// the same plan is reused across calls while the wire encoding stays trivial. Build with
+/// <see cref="Int"/>, <see cref="Text"/>, or <see cref="Null"/>.
+/// </summary>
+public readonly struct PgParam
+{
+    private readonly long _num;
+    private readonly string? _str;
+    private readonly byte _kind;   // 0 = null, 1 = integer, 2 = text
+
+    private PgParam(byte kind, long num, string? str)
+    {
+        _kind = kind;
+        _num = num;
+        _str = str;
+    }
+
+    /// <summary>An integer parameter (int2/int4/int8, per the statement's inferred type).</summary>
+    public static PgParam Int(long value) => new(1, value, null);
+
+    /// <summary>A text parameter (text/varchar, or any type with a text input - dates, numerics, ...).</summary>
+    public static PgParam Text(string value) => new(2, 0, value);
+
+    /// <summary>A SQL NULL.</summary>
+    public static readonly PgParam Null = new(0, 0, null);
+
+    internal bool IsNull => _kind == 0;
+
+    /// <summary>Upper bound on the text encoding's byte length, for sizing the send buffer.</summary>
+    internal int MaxBytes => _kind switch
+    {
+        0 => 0,
+        1 => 20,                                 // long: at most 19 digits plus a sign
+        _ => Encoding.UTF8.GetByteCount(_str!),
+    };
+
+    /// <summary>Write the text encoding into <paramref name="destination"/>; returns bytes written. Not called for NULL.</summary>
+    internal int WriteText(Span<byte> destination)
+    {
+        if (_kind == 1)
+        {
+            Utf8Formatter.TryFormat(_num, destination, out int written);
+            return written;
+        }
+        return Encoding.UTF8.GetBytes(_str!, destination);
+    }
+}

--- a/ioxide.pg/PgPool.cs
+++ b/ioxide.pg/PgPool.cs
@@ -63,11 +63,33 @@ public sealed class PgPool
         return c != null ? c.QueryRowsAsync(sql, onRow) : QueryRowsSlowAsync(sql, onRow);
     }
 
+    /// <summary>Run a prepared parameterized query on the next connection (pipelined).</summary>
+    public ValueTask<PgResult> QueryAsync(string sql, ReadOnlySpan<PgParam> args)
+    {
+        PgConnection? c = Pick();
+        // Slow path is startup-only (no connection open yet); copying the params to the heap there is
+        // fine, and keeps the span off the async state machine.
+        return c != null ? c.QueryAsync(sql, args) : QuerySlowAsync(sql, args.ToArray());
+    }
+
+    /// <summary>Run a prepared parameterized query, streaming rows through <paramref name="onRow"/>. Read the count from the result.</summary>
+    public ValueTask<PgResult> QueryAsync(string sql, ReadOnlySpan<PgParam> args, PgRowHandler onRow)
+    {
+        PgConnection? c = Pick();
+        return c != null ? c.QueryAsync(sql, args, onRow) : QueryRowsSlowAsync(sql, args.ToArray(), onRow);
+    }
+
     private async ValueTask<PgResult> QuerySlowAsync(string sql)
         => await (await WaitForConnectionAsync()).QueryAsync(sql);
 
     private async ValueTask<int> QueryRowsSlowAsync(string sql, PgRowHandler onRow)
         => await (await WaitForConnectionAsync()).QueryRowsAsync(sql, onRow);
+
+    private async ValueTask<PgResult> QuerySlowAsync(string sql, PgParam[] args)
+        => await (await WaitForConnectionAsync()).QueryAsync(sql, args);
+
+    private async ValueTask<PgResult> QueryRowsSlowAsync(string sql, PgParam[] args, PgRowHandler onRow)
+        => await (await WaitForConnectionAsync()).QueryAsync(sql, args, onRow);
 
     // Round-robin over healthy connections; evict and replace any found broken.
     private PgConnection? Pick()

--- a/ioxide.pg/PgProtocol.cs
+++ b/ioxide.pg/PgProtocol.cs
@@ -21,6 +21,8 @@ internal static class PgProtocol
     public const byte RowDescription  = (byte)'T';
     public const byte DataRow         = (byte)'D';
     public const byte CommandComplete = (byte)'C';
+    public const byte ParseComplete   = (byte)'1';   // extended protocol: Parse acknowledged
+    public const byte BindComplete    = (byte)'2';   // extended protocol: Bind acknowledged
 
     /// <summary>
     /// Write a StartupMessage carrying the user and database parameters, returning its total
@@ -104,6 +106,108 @@ internal static class PgProtocol
     public static int QueryLength(string sql)
     {
         return 5 + Encoding.UTF8.GetByteCount(sql) + 1;
+    }
+
+    /// <summary>
+    /// Write one extended-protocol command: an optional Parse (when the statement is new), then
+    /// Bind (text-format params, text-format results), Execute (all rows), and Sync. The Sync makes
+    /// the server answer with one ReadyForQuery, so the command routes like a simple query.
+    /// </summary>
+    public static int WriteExtended(Span<byte> buffer, bool parse, string statementName, string sql, ReadOnlySpan<PgParam> args)
+    {
+        int position = 0;
+        if (parse)
+        {
+            position += WriteParse(buffer, statementName, sql);
+        }
+        position += WriteBind(buffer[position..], statementName, args);
+        position += WriteExecute(buffer[position..]);
+        position += WriteSync(buffer[position..]);
+        return position;
+    }
+
+    /// <summary>An upper bound on the bytes <see cref="WriteExtended"/> needs (params sized to their max text length).</summary>
+    public static int ExtendedLength(bool parse, string statementName, string sql, ReadOnlySpan<PgParam> args)
+    {
+        int nameLen = Encoding.UTF8.GetByteCount(statementName) + 1;
+        int total = 0;
+        if (parse)
+        {
+            total += 5 + nameLen + Encoding.UTF8.GetByteCount(sql) + 1 + 2;   // Parse: name, sql, int16 param-type count
+        }
+        int paramBytes = 0;
+        foreach (PgParam a in args)
+        {
+            paramBytes += 4 + a.MaxBytes;        // int32 length prefix + value
+        }
+        total += 5 + 1 + nameLen + 2 + 2 + paramBytes + 2;   // Bind: portal, stmt, fmt-count, param-count, params, result-fmt-count
+        total += 5 + 1 + 4;                                  // Execute: portal, max-rows
+        total += 5;                                          // Sync
+        return total;
+    }
+
+    // Parse ('P'): statement name, the SQL with $n placeholders, and an int16 0 = infer parameter types.
+    private static int WriteParse(Span<byte> buffer, string statementName, string sql)
+    {
+        buffer[0] = (byte)'P';
+        int position = 5;
+        position += WriteCString(buffer, position, statementName);
+        position += WriteCString(buffer, position, sql);
+        BinaryPrimitives.WriteInt16BigEndian(buffer[position..], 0);
+        position += 2;
+        BinaryPrimitives.WriteInt32BigEndian(buffer[1..], position - 1);
+        return position;
+    }
+
+    // Bind ('B'): unnamed portal, the statement, all-text params, then all-text results.
+    private static int WriteBind(Span<byte> buffer, string statementName, ReadOnlySpan<PgParam> args)
+    {
+        buffer[0] = (byte)'B';
+        int position = 5;
+        buffer[position++] = 0;                              // portal "" (NUL only)
+        position += WriteCString(buffer, position, statementName);
+        BinaryPrimitives.WriteInt16BigEndian(buffer[position..], 0);   // 0 param format codes = all text
+        position += 2;
+        BinaryPrimitives.WriteInt16BigEndian(buffer[position..], (short)args.Length);
+        position += 2;
+        foreach (PgParam a in args)
+        {
+            if (a.IsNull)
+            {
+                BinaryPrimitives.WriteInt32BigEndian(buffer[position..], -1);
+                position += 4;
+            }
+            else
+            {
+                int written = a.WriteText(buffer[(position + 4)..]);
+                BinaryPrimitives.WriteInt32BigEndian(buffer[position..], written);
+                position += 4 + written;
+            }
+        }
+        BinaryPrimitives.WriteInt16BigEndian(buffer[position..], 0);   // 0 result format codes = all text
+        position += 2;
+        BinaryPrimitives.WriteInt32BigEndian(buffer[1..], position - 1);
+        return position;
+    }
+
+    // Execute ('E'): unnamed portal, max-rows 0 = return every row.
+    private static int WriteExecute(Span<byte> buffer)
+    {
+        buffer[0] = (byte)'E';
+        int position = 5;
+        buffer[position++] = 0;                              // portal ""
+        BinaryPrimitives.WriteInt32BigEndian(buffer[position..], 0);
+        position += 4;
+        BinaryPrimitives.WriteInt32BigEndian(buffer[1..], position - 1);
+        return position;
+    }
+
+    // Sync ('S'): a bare 4-byte length.
+    private static int WriteSync(Span<byte> buffer)
+    {
+        buffer[0] = (byte)'S';
+        BinaryPrimitives.WriteInt32BigEndian(buffer[1..], 4);
+        return 5;
     }
 
     private static int WriteCString(Span<byte> buffer, int position, string text)

--- a/ioxide.pg/ioxide.pg.csproj
+++ b/ioxide.pg/ioxide.pg.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.pg</RootNamespace>
 
     <PackageId>ioxide.pg</PackageId>
-    <Version>0.0.3</Version>
+    <Version>0.0.4</Version>
     <Authors>MDA2AV</Authors>
     <Description>Postgres driver for the ioxide io_uring runtime: pooled ring-native connections per reactor, ring-native connect and handshake, inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.redis/ioxide.redis.csproj
+++ b/ioxide.redis/ioxide.redis.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.redis</RootNamespace>
 
     <PackageId>ioxide.redis</PackageId>
-    <Version>0.0.3</Version>
+    <Version>0.0.4</Version>
     <Authors>MDA2AV</Authors>
     <Description>Redis client for the ioxide io_uring runtime: pooled ring-native connections per reactor, full RESP2 protocol, a generic command API plus typed helpers (strings, keys, hashes, lists, sets, sorted sets, pub/sub, transactions, scripting), and pipelining. Inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.tls/ioxide.tls.csproj
+++ b/ioxide.tls/ioxide.tls.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.tls</RootNamespace>
 
     <PackageId>ioxide.tls</PackageId>
-    <Version>0.0.3</Version>
+    <Version>0.0.4</Version>
     <Authors>MDA2AV</Authors>
     <Description>TLS for the ioxide io_uring runtime: OpenSSL handshake driven over the ring, then kernel TLS (kTLS) transmit offload - handlers keep writing plaintext through the same connection API. Requires Linux kTLS (tls module) and OpenSSL 3.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide/IoxideRuntime.cs
+++ b/ioxide/IoxideRuntime.cs
@@ -7,7 +7,7 @@ namespace ioxide;
 /// </summary>
 public static class IoxideRuntime
 {
-    public const string Version = "0.0.3";
+    public const string Version = "0.0.4";
 
     // Wiring (a builder API will eventually wrap this):
     //   var reactor = new Reactor(id, config);               // implements IRingHost

--- a/ioxide/ioxide.csproj
+++ b/ioxide/ioxide.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide</RootNamespace>
 
     <PackageId>ioxide</PackageId>
-    <Version>0.0.3</Version>
+    <Version>0.0.4</Version>
     <Authors>MDA2AV</Authors>
     <Description>A shared-nothing io_uring runtime for .NET: one ring per reactor thread, inline completions, zero native dependencies. The engine - reactor, connection, and the IRingHost client seam.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Add the Postgres extended query protocol (Parse/Bind/Execute/Sync) with a per-connection statement cache, so repeated parameterized queries skip the re-parse and re-plan the simple-query protocol pays every call. New PgParam type and QueryAsync(sql, args[, onRow]) overloads on PgConnection/PgPool; statements auto-prepare on first use and Bind/Execute on reuse. The simple QueryAsync(sql) path is unchanged.

Also reclaim the pipelined send buffer every send cycle: it was append-only and reset only on a full drain, so under a sustained submit rate it marched to capacity and overflowed. It now compacts the sent prefix each cycle.

Bump all packages to 0.0.4 for cohesion.