### PR TITLE
Fix ConnectionPipeReader.AdvanceTo offset underflow (hang on chunked/pipelined reads)

### DIFF
--- a/ioxide/Connection/ConnectionPipeReader.cs
+++ b/ioxide/Connection/ConnectionPipeReader.cs
@@ -221,8 +221,18 @@ public sealed unsafe class ConnectionPipeReader : PipeReader, IValueTaskSource<R
             return;
         }
 
-        long consumedBytes = _lastSequence.GetOffset(consumed);
-        long examinedBytes = _lastSequence.GetOffset(examined);
+        // GetOffset measures from the start *segment*, not the sequence's logical
+        // start. When the held sequence begins mid-segment (the head recv slice is
+        // partially consumed — e.g. a request whose header and body arrive in one
+        // recv: the body read advances after the header was already skipped),
+        // GetOffset over-counts by _headConsumed. Rebase by the sequence start so
+        // consumed/examined stay consistent with the relative _heldBytes/_examined
+        // counters below. Without this, _heldBytes underflows negative and the next
+        // ReadAsync parks forever waiting for bytes that already arrived (the hang
+        // seen on chunked request bodies, which read again for the terminating chunk).
+        long startOffset = _lastSequence.GetOffset(_lastSequence.Start);
+        long consumedBytes = _lastSequence.GetOffset(consumed) - startOffset;
+        long examinedBytes = _lastSequence.GetOffset(examined) - startOffset;
         if (examinedBytes < consumedBytes)
         {
             examinedBytes = consumedBytes;


### PR DESCRIPTION
## Summary

`ConnectionPipeReader.AdvanceTo` measured `consumed`/`examined` with
`ReadOnlySequence.GetOffset(position)`, which returns the offset from the start
**segment**, not from the sequence's logical start. When the held sequence begins
mid-segment — i.e. the head recv slice is partially consumed — those offsets are
too large by the consumed prefix (`_headConsumed`). Since `_heldBytes` is a
buffer-relative counter, `_heldBytes -= consumedBytes` then underflows **negative**,
and the next `ReadAsync` sees `_heldBytes <= _examined` with the socket still open,
so it parks and waits forever for bytes that already arrived.

## How it shows up

A consumer that reads from a buffer starting mid-segment and then advances:

- **Chunked request bodies** — the decoder reads the first chunk, advances, then
  must read again for the terminating `0\r\n\r\n`; that second read hangs. (This is
  what surfaced it: a GenHTTP server on the ioxide engine hung on every
  `Transfer-Encoding: chunked` POST while Content-Length POSTs worked — CL needs
  only one body read, so the corrupted counter never causes a re-park.)
- **Pipelined requests** sharing a recv buffer — same partial-head-slice shape; latent.

The trigger is "header + body (or the next pipelined request) arrive in one recv":
the header is consumed first (`_headConsumed > 0`), so the body view starts mid-slice.
The raw recv/send API is unaffected — only `PipeReader` / `ConnectionDualPipe`
consumers hit this.

## Fix

Rebase the offsets by the sequence start so they're relative to the buffer the
caller was handed, consistent with the `_heldBytes` / `_examined` counters:

```csharp
long startOffset   = _lastSequence.GetOffset(_lastSequence.Start);
long consumedBytes = _lastSequence.GetOffset(consumed) - startOffset;
long examinedBytes = _lastSequence.GetOffset(examined) - startOffset;
```

## Verification

Replicated the exact `BuildResult` + `AdvanceTo` accounting against the real
`System.Buffers.ReadOnlySequence` API:

- header(89) + body(12) in one recv, consume 7 of the body →
  before: `_heldBytes = -84` (hang); after: `_heldBytes = 5` (the bytes left for the
  terminating chunk).
- multi-segment consume (start mid-segment, spanning into the next segment) → correct/unchanged.

## Follow-up

A regression test driving a chunked body through `ConnectionPipeReader` with
header+body in one recv would guard this; happy to add one.
