### PR TITLE
IPv6 dual-stack listeners; bump packages to 0.0.12

### DIFF
--- a/ioxide.file/ioxide.file.csproj
+++ b/ioxide.file/ioxide.file.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.file</RootNamespace>
 
     <PackageId>ioxide.file</PackageId>
-    <Version>0.0.11</Version>
+    <Version>0.0.12</Version>
     <Authors>MDA2AV</Authors>
     <Description>File serving for the ioxide io_uring runtime: immutable asset snapshots with baked responses, pooled positional ring reads, atomic reloads.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.pg/ioxide.pg.csproj
+++ b/ioxide.pg/ioxide.pg.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.pg</RootNamespace>
 
     <PackageId>ioxide.pg</PackageId>
-    <Version>0.0.11</Version>
+    <Version>0.0.12</Version>
     <Authors>MDA2AV</Authors>
     <Description>Postgres driver for the ioxide io_uring runtime: pooled ring-native connections per reactor, ring-native connect and handshake, inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.redis/ioxide.redis.csproj
+++ b/ioxide.redis/ioxide.redis.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.redis</RootNamespace>
 
     <PackageId>ioxide.redis</PackageId>
-    <Version>0.0.11</Version>
+    <Version>0.0.12</Version>
     <Authors>MDA2AV</Authors>
     <Description>Redis client for the ioxide io_uring runtime: pooled ring-native connections per reactor, full RESP2 protocol, a generic command API plus typed helpers (strings, keys, hashes, lists, sets, sorted sets, pub/sub, transactions, scripting), and pipelining. Inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.tls/ioxide.tls.csproj
+++ b/ioxide.tls/ioxide.tls.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.tls</RootNamespace>
 
     <PackageId>ioxide.tls</PackageId>
-    <Version>0.0.11</Version>
+    <Version>0.0.12</Version>
     <Authors>MDA2AV</Authors>
     <Description>TLS for the ioxide io_uring runtime: OpenSSL handshake driven over the ring, then kernel TLS (kTLS) transmit offload - handlers keep writing plaintext through the same connection API. Requires Linux kTLS (tls module) and OpenSSL 3.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide/Reactor/Reactor.cs
+++ b/ioxide/Reactor/Reactor.cs
@@ -355,7 +355,7 @@ public sealed unsafe partial class Reactor
         }
         for (int i = 0; i < _listenFds.Length; i++)
         {
-            _listenFds[i] = OpenReusePortListener(_listenPorts[i], _config.ListenBacklog);
+            _listenFds[i] = OpenReusePortListener(_listenPorts[i], _config.ListenBacklog, _config.DualStack);
         }
 
         if (_incremental)
@@ -837,9 +837,9 @@ public sealed unsafe partial class Reactor
         setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(int));
     }
 
-    private static int OpenReusePortListener(ushort port, int backlog)
+    private static int OpenReusePortListener(ushort port, int backlog, bool dualStack)
     {
-        int fd = socket(AF_INET, SOCK_STREAM, 0);
+        int fd = socket(dualStack ? AF_INET6 : AF_INET, SOCK_STREAM, 0);
         if (fd < 0)
         {
             throw new InvalidOperationException($"socket failed: {fd}");
@@ -849,14 +849,34 @@ public sealed unsafe partial class Reactor
         setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(int));
         setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(int));
 
-        sockaddr_in addr = default;
-        addr.sin_family      = AF_INET;
-        addr.sin_port        = Htons(port);
-        addr.sin_addr.s_addr = 0; // 0.0.0.0
-
-        if (bind(fd, &addr, (uint)sizeof(sockaddr_in)) < 0)
+        if (dualStack)
         {
-            throw new InvalidOperationException("bind failed");
+            // A single AF_INET6 listener bound to :: with IPV6_V6ONLY=0 accepts both IPv6 and
+            // IPv4-mapped clients - one socket serves both families.
+            int v6only = 0;
+            setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(int));
+
+            sockaddr_in6 addr6 = default;
+            addr6.sin6_family = AF_INET6;
+            addr6.sin6_port   = Htons(port);
+            // sin6_addr left zero == in6addr_any (::)
+
+            if (bind(fd, &addr6, (uint)sizeof(sockaddr_in6)) < 0)
+            {
+                throw new InvalidOperationException("bind failed");
+            }
+        }
+        else
+        {
+            sockaddr_in addr = default;
+            addr.sin_family      = AF_INET;
+            addr.sin_port        = Htons(port);
+            addr.sin_addr.s_addr = 0; // 0.0.0.0
+
+            if (bind(fd, &addr, (uint)sizeof(sockaddr_in)) < 0)
+            {
+                throw new InvalidOperationException("bind failed");
+            }
         }
 
         if (listen(fd, backlog) < 0)

--- a/ioxide/ServerConfig.cs
+++ b/ioxide/ServerConfig.cs
@@ -31,6 +31,12 @@ public sealed record ServerConfig
     /// <summary>listen() backlog per SO_REUSEPORT listener - the accept-queue depth for connection bursts.</summary>
     public int    ListenBacklog { get; init; } = 1024;
 
+    /// <summary>
+    /// Bind listeners as dual-stack IPv6 (AF_INET6 on :: with IPV6_V6ONLY=0) so one socket accepts both
+    /// IPv6 and IPv4-mapped clients. When false (default) listeners are IPv4-only (AF_INET on 0.0.0.0).
+    /// </summary>
+    public bool   DualStack { get; init; } = false;
+
     // Shared buffer ring (Incremental == false).
     public int    RecvBufferSize    { get; init; } = 32 * 1024;
     public int    BufferRingEntries { get; init; } = 4096;

--- a/ioxide/io_uring/Native.cs
+++ b/ioxide/io_uring/Native.cs
@@ -85,6 +85,10 @@ public static unsafe class Native {
     public const int IPPROTO_TCP  = 6;
     public const int TCP_NODELAY  = 1;
 
+    public const int AF_INET6     = 10;
+    public const int IPPROTO_IPV6 = 41;
+    public const int IPV6_V6ONLY  = 26;
+
     [DllImport("libc", EntryPoint = "syscall")]
     private static extern long syscall3(long nr, uint a1, IoUringParams* a2);
 
@@ -107,7 +111,7 @@ public static unsafe class Native {
     [DllImport("libc")] public static extern int   munmap(void* addr, nuint length);
     [DllImport("libc")] public static extern int   close(int fd);
     [DllImport("libc")] public static extern int   socket(int domain, int type, int proto);
-    [DllImport("libc")] public static extern int   bind(int fd, sockaddr_in* addr, uint len);
+    [DllImport("libc")] public static extern int   bind(int fd, void* addr, uint len);
     [DllImport("libc")] public static extern int   listen(int fd, int backlog);
     [DllImport("libc")] public static extern int   setsockopt(int fd, int level, int optname, void* optval, uint optlen);
     [DllImport("libc")] public static extern int   eventfd(uint initval, int flags);
@@ -205,6 +209,15 @@ public static unsafe class Native {
         public ushort  sin_port;
         public in_addr sin_addr;
         public fixed byte sin_zero[8];
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct sockaddr_in6 {
+        public ushort     sin6_family;
+        public ushort     sin6_port;
+        public uint       sin6_flowinfo;
+        public fixed byte sin6_addr[16];  // in6_addr - zeroed == in6addr_any (::)
+        public uint       sin6_scope_id;
     }
 
 #pragma warning disable CS8981 // lower-cased names deliberately mirror the kernel struct names (uapi)

--- a/ioxide/ioxide.csproj
+++ b/ioxide/ioxide.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide</RootNamespace>
 
     <PackageId>ioxide</PackageId>
-    <Version>0.0.11</Version>
+    <Version>0.0.12</Version>
     <Authors>MDA2AV</Authors>
     <Description>A shared-nothing io_uring runtime for .NET: one ring per reactor thread, inline completions, zero native dependencies. The engine - reactor, connection, and the IRingHost client seam.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## What

Adds opt-in **dual-stack** binding via `ServerConfig.DualStack`. When set, each `SO_REUSEPORT` listener is opened as an `AF_INET6` socket bound to `::` with `IPV6_V6ONLY=0`, so a single socket accepts both IPv6 and IPv4-mapped clients. Default stays IPv4-only (`AF_INET` on `0.0.0.0`), so existing behaviour is unchanged.

## Changes

- **`Native`**: add `AF_INET6` / `IPPROTO_IPV6` / `IPV6_V6ONLY`, a `sockaddr_in6` struct, and relax `bind()` to `void*` (its only caller is the listener).
- **`Reactor.OpenReusePortListener`**: branch on `dualStack`. The accept/recv/send hot path is fd-based, so it is untouched — no perf impact.
- **`ServerConfig`**: new `DualStack` flag (default `false`).
- Bumps `ioxide`, `ioxide.tls`, `ioxide.file`, `ioxide.pg`, `ioxide.redis` to **0.0.12**.

## Motivation

GenHTTP's acceptance suite has two dual-stack binding tests (`TestAnyIPv4WithDualStack`, `TestAnyIPv6WithDualStack`) that the Ioxide engine couldn't satisfy because listeners were IPv4-only. This adds the missing capability.

## Verification

- `ioxide` builds clean (0 warnings / 0 errors).
- `sockaddr_in6` is the standard 28-byte Linux ABI layout; `IPV6_V6ONLY` is cleared before `bind`.
- End-to-end IPv6 connectivity is validated by GenHTTP's acceptance tests once 0.0.12 is consumed.
