### PR TITLE
Publish ioxide.Kestrel: add missing pack step + README badge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Pack ioxide.redis
         run: dotnet pack ioxide.redis/ioxide.redis.csproj --configuration Release --no-build --output ./artifacts
 
+      - name: Pack ioxide.Kestrel
+        run: dotnet pack ioxide.Kestrel/ioxide.Kestrel.csproj --configuration Release --no-build --output ./artifacts
+
       - name: Publish to NuGet
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![ioxide.file](https://img.shields.io/nuget/v/ioxide.file?label=ioxide.file)](https://www.nuget.org/packages/ioxide.file/)
 [![ioxide.tls](https://img.shields.io/nuget/v/ioxide.tls?label=ioxide.tls)](https://www.nuget.org/packages/ioxide.tls/)
 [![ioxide.redis](https://img.shields.io/nuget/v/ioxide.redis?label=ioxide.redis)](https://www.nuget.org/packages/ioxide.redis/)
+[![ioxide.Kestrel](https://img.shields.io/nuget/v/ioxide.Kestrel?label=ioxide.Kestrel)](https://www.nuget.org/packages/ioxide.Kestrel/)
 
 **A shared-nothing io_uring runtime for .NET.**
 


### PR DESCRIPTION
Follow-up to #84. That PR was squash-merged at the version-bump commit, before the publish-wiring commit landed — so `main` got the `ioxide.Kestrel` project but **not** the workflow step that packs/publishes it (nor the README badge). As a result the post-merge run packed the other five packages but not `ioxide.Kestrel`, so it never reached nuget.org.

This adds:
- `Pack ioxide.Kestrel` step in `.github/workflows/build.yml` (the `artifacts/*.nupkg` push then includes it).
- `ioxide.Kestrel` nuget badge in the README.

On merge to `main`, the Build and Publish workflow will pack and push `ioxide.Kestrel` 0.0.13 to nuget.org + GitHub Packages (the already-published 0.0.13 packages no-op via `--skip-duplicate`).