### PR TITLE
Fix reactor crash on Connection: close with fragmented headers

### DIFF
--- a/ioxide.Kestrel/HopDuplexPipe.cs
+++ b/ioxide.Kestrel/HopDuplexPipe.cs
@@ -23,6 +23,10 @@ internal sealed class HopDuplexPipe : IDuplexPipe, IAsyncDisposable
     private Task _sendPump = Task.CompletedTask;
     private int _started;
 
+    [System.Runtime.InteropServices.DllImport("libc", EntryPoint = "shutdown")]
+    private static extern int Shutdown(int sockfd, int how);
+    private const int ShutWr = 1;   // SHUT_WR
+
     public PipeReader Input => _inbound.Reader;
     public PipeWriter Output => _outbound.Writer;
 
@@ -139,14 +143,21 @@ internal sealed class HopDuplexPipe : IDuplexPipe, IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        // Kestrel has completed its ends; wake the pumps and unwind. MarkClosed wakes a recv parked in
-        // conn.ReadAsync — schedule it ON the reactor so the recv continuation (which touches reactor-owned
-        // recv state) runs there, not on Kestrel's dispose thread. The pipe cancels resume via the pipes'
-        // reactor reader/writer schedulers, so they're reactor-safe too.
+        // Quiesce the send side BEFORE closing. Wake the send pump if it's parked on the output reader and
+        // await it, so any in-flight SEND completes normally and the full response is flushed. Draining here
+        // — rather than concurrently with MarkClosed — is what makes the response reliably reach the client
+        // and avoids completing a live flush twice (MarkClosed racing the SEND CQE's CompleteFlush).
+        _outbound.Reader.CancelPendingRead();
+        try { await _sendPump.ConfigureAwait(false); } catch { }
+
+        // Half-close the write side so EOF-delimited clients (Connection: close / upgrade) see the end of
+        // the response — ioxide's refcounted teardown does not FIN a server-initiated close on its own.
+        Shutdown(_conn.ClientFd, ShutWr);
+
+        // Now wake and unwind the recv side. MarkClosed wakes a recv parked in conn.ReadAsync — schedule it
+        // on the reactor so the recv continuation (reactor-owned state) runs there, not the dispose thread.
         _reactor.ScheduleOnReactor(static c => ((Connection)c!).MarkClosed(), _conn);
         _inbound.Writer.CancelPendingFlush();
-        _outbound.Reader.CancelPendingRead();
-        try { await _recvPump; } catch { }
-        try { await _sendPump; } catch { }
+        try { await _recvPump.ConfigureAwait(false); } catch { }
     }
 }

--- a/ioxide.Kestrel/ioxide.Kestrel.csproj
+++ b/ioxide.Kestrel/ioxide.Kestrel.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.Kestrel</RootNamespace>
 
     <PackageId>ioxide.Kestrel</PackageId>
-    <Version>0.0.13</Version>
+    <Version>0.0.14</Version>
     <Authors>MDA2AV</Authors>
     <Description>ASP.NET Core Kestrel transport backed by the ioxide io_uring runtime: one reactor (ring) per core, SO_REUSEPORT load-balanced, with Kestrel's HTTP request loop pinned to the reactor thread. Drop-in via UseIoxide().</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.file/ioxide.file.csproj
+++ b/ioxide.file/ioxide.file.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.file</RootNamespace>
 
     <PackageId>ioxide.file</PackageId>
-    <Version>0.0.13</Version>
+    <Version>0.0.14</Version>
     <Authors>MDA2AV</Authors>
     <Description>File serving for the ioxide io_uring runtime: immutable asset snapshots with baked responses, pooled positional ring reads, atomic reloads.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.pg/ioxide.pg.csproj
+++ b/ioxide.pg/ioxide.pg.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.pg</RootNamespace>
 
     <PackageId>ioxide.pg</PackageId>
-    <Version>0.0.13</Version>
+    <Version>0.0.14</Version>
     <Authors>MDA2AV</Authors>
     <Description>Postgres driver for the ioxide io_uring runtime: pooled ring-native connections per reactor, ring-native connect and handshake, inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.redis/ioxide.redis.csproj
+++ b/ioxide.redis/ioxide.redis.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.redis</RootNamespace>
 
     <PackageId>ioxide.redis</PackageId>
-    <Version>0.0.13</Version>
+    <Version>0.0.14</Version>
     <Authors>MDA2AV</Authors>
     <Description>Redis client for the ioxide io_uring runtime: pooled ring-native connections per reactor, full RESP2 protocol, a generic command API plus typed helpers (strings, keys, hashes, lists, sets, sorted sets, pub/sub, transactions, scripting), and pipelining. Inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide.tls/ioxide.tls.csproj
+++ b/ioxide.tls/ioxide.tls.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.tls</RootNamespace>
 
     <PackageId>ioxide.tls</PackageId>
-    <Version>0.0.13</Version>
+    <Version>0.0.14</Version>
     <Authors>MDA2AV</Authors>
     <Description>TLS for the ioxide io_uring runtime: OpenSSL handshake driven over the ring, then kernel TLS (kTLS) transmit offload - handlers keep writing plaintext through the same connection API. Requires Linux kTLS (tls module) and OpenSSL 3.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ioxide/Connection/Connection.Write.Flush.cs
+++ b/ioxide/Connection/Connection.Write.Flush.cs
@@ -89,9 +89,16 @@ public sealed unsafe partial class Connection : IValueTaskSource
         WriteInFlight = 0;
         ZcNotifPending = 0;
         Volatile.Write(ref _flushInProgress, 0);
-        Interlocked.Exchange(ref _flushArmed, 0);
 
-        _flushSignal.SetResult(true);
+        // Guard against a double completion. During teardown MarkClosed() may have already disarmed and
+        // completed this flush (e.g. a Connection: close response whose SEND CQE lands after the close),
+        // which Resets/invalidates the value-task source. Only the call that actually disarms the flush
+        // signals — mirroring MarkClosed and the recv path's _armed check. Without this, the late CQE's
+        // SetResult throws InvalidOperationException on the reactor thread and crashes the process.
+        if (Interlocked.Exchange(ref _flushArmed, 0) == 1)
+        {
+            _flushSignal.SetResult(true);
+        }
     }
 
 #region IValueTaskSource

--- a/ioxide/ioxide.csproj
+++ b/ioxide/ioxide.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide</RootNamespace>
 
     <PackageId>ioxide</PackageId>
-    <Version>0.0.13</Version>
+    <Version>0.0.14</Version>
     <Authors>MDA2AV</Authors>
     <Description>A shared-nothing io_uring runtime for .NET: one ring per reactor thread, inline completions, zero native dependencies. The engine - reactor, connection, and the IRingHost client seam.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Bug

A request whose **headers span multiple recvs** followed by a **server-initiated close** (`Connection: close`) crashes the whole reactor process:

```
Unhandled exception. System.InvalidOperationException: Operation is not valid due to the current state of the object.
   at ...ManualResetValueTaskSourceCore`1.SignalCompletion()
   at ioxide.Connection.CompleteFlush()
   at ioxide.Reactor.OnSendCompletion(...)
   at ioxide.Reactor.LoopShared()
```

Teardown races the send: `MarkClosed()` disarms and completes `_flushSignal`, then the in-flight SEND's CQE calls `CompleteFlush()` which completes the value-task source **a second time** → throws on the reactor thread → process abort. `MarkClosed` guards with `if (Interlocked.Exchange(ref _flushArmed,0)==1)`; `CompleteFlush` didn't.

## Fix

- **ioxide core** (`CompleteFlush`): only signal when this call is the one that disarms the flush — mirrors `MarkClosed` and the recv path. Prevents the double completion.
- **ioxide.Kestrel** (`HopDuplexPipe.DisposeAsync`): drain the send pump *before* `MarkClosed` (so the response is fully flushed and no live flush is completed twice), then half-close (FIN) the write side so EOF-delimited `Connection: close` responses terminate for the client (ioxide's refcounted teardown doesn't FIN a server-initiated close on its own).
- Bump packages to 0.0.14.

## Verified

Reproduced with the exact HttpArena `split before headers` probe (per-header TCP fragments + `Connection: close`): before, the server aborts after one such request; after, **20/20 return correct responses and the server stays up** with connections closing cleanly. Found via the `aspnet-minimal-ioxide` HttpArena entry's validation.