### PR TITLE
Run the ioxide.e2e suite in the build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,31 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    # pg + redis sidecars so the e2e suite's pg/redis tests run (they skip cleanly if absent).
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: bench
+          POSTGRES_DB: bench
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -30,6 +55,25 @@ jobs:
 
       - name: Build
         run: dotnet build ioxide.slnx --configuration Release --no-restore
+
+      # io_uring is needed by the reactor; the tls module by the kTLS test. Best-effort — io_uring is
+      # enabled by default on the runners, and the suite skips the kTLS test if the module is absent.
+      - name: Enable io_uring + load kTLS module
+        run: |
+          sudo sysctl -w kernel.io_uring_disabled=0 2>/dev/null || true
+          sudo modprobe tls 2>/dev/null || true
+
+      # E2E suite (already compiled as part of ioxide.slnx). Drives real reactors over real sockets;
+      # pg/redis tests use the sidecars above. Non-zero exit fails the job before any pack/publish.
+      - name: Run E2E tests
+        env:
+          EXAMPLES_PG_HOST: localhost
+          EXAMPLES_PG_PORT: 5432
+          EXAMPLES_PG_USER: bench
+          EXAMPLES_PG_DB: bench
+          EXAMPLES_REDIS_HOST: localhost
+          EXAMPLES_REDIS_PORT: 6379
+        run: dotnet run --project Tests/ioxide.e2e.csproj --configuration Release --no-build
 
       - name: Pack ioxide
         run: dotnet pack ioxide/ioxide.csproj --configuration Release --no-build --output ./artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,34 +68,31 @@ jobs:
 
       # Diagnostic: io_uring_setup errno on the host, and whether a seccomp-unconfined / privileged
       # container can bypass the block (so the e2e could run inside one instead of needing self-hosted).
-      - name: Probe io_uring (flags + entries)
+      - name: Probe io_uring (memlock accumulation at 8192 entries)
         run: |
-          echo "memlock (ulimit -l): $(ulimit -l) KB"
+          echo "memlock soft/hard: $(ulimit -Sl) / $(ulimit -Hl) KB"
           cat > /tmp/p.c <<'PROBE'
           #include <stdio.h>
           #include <errno.h>
           #include <string.h>
-          #include <unistd.h>
+          #include <stdlib.h>
           #include <sys/syscall.h>
-          static void t(const char* n, unsigned int flags, unsigned int entries){
-          unsigned char p[256]={0};
-          *(unsigned int*)(p+8)=flags;
+          int main(int argc, char** argv){
+          unsigned flags=(1u<<12)|(1u<<13)|(1u<<16);
+          unsigned entries=argc>1?(unsigned)atoi(argv[1]):8192;
+          int n=0;
+          for(;;){
+          unsigned char p[256]={0}; *(unsigned*)(p+8)=flags;
           long fd=syscall(425,entries,p);
-          if(fd<0) printf("%-34s FAIL errno=%d (%s)\n",n,errno,strerror(errno));
-          else { printf("%-34s OK fd=%ld\n",n,fd); close(fd); }
+          if(fd<0){printf("entries=%u: FAILED at ring #%d errno=%d (%s)\n",entries,n,errno,strerror(errno));return 0;}
+          if(++n>=80){printf("entries=%u: created 80 rings OK\n",entries);return 0;}
           }
-          int main(void){
-          unsigned SI=1u<<12, DTR=1u<<13, NSA=1u<<16;
-          t("flags=0 e=8",0,8);
-          t("SINGLE_ISSUER e=8",SI,8);
-          t("SI|DEFER_TASKRUN e=8",SI|DTR,8);
-          t("SI|DTR|NO_SQARRAY e=8",SI|DTR|NSA,8);
-          t("SI|DTR|NO_SQARRAY e=256",SI|DTR|NSA,256);
-          t("SI|DTR|NO_SQARRAY e=4096",SI|DTR|NSA,4096);
-          return 0;}
+          }
           PROBE
           gcc -O2 -o /tmp/p /tmp/p.c
-          /tmp/p
+          echo "--- accumulate 8192-entry rings @ default memlock ---"; /tmp/p 8192
+          sudo prlimit --pid $$ --memlock=-1:-1 2>/dev/null || ulimit -l unlimited 2>/dev/null || true
+          echo "--- after raising memlock to $(ulimit -Sl) ---"; /tmp/p 8192
 
       # E2E suite (already compiled as part of ioxide.slnx). Drives real reactors over real sockets;
       # pg/redis tests use the sidecars above. Non-zero exit fails the job before any pack/publish.
@@ -107,7 +104,12 @@ jobs:
           EXAMPLES_PG_DB: bench
           EXAMPLES_REDIS_HOST: 127.0.0.1
           EXAMPLES_REDIS_PORT: 6379
-        run: dotnet run --project Tests/ioxide.e2e.csproj --configuration Release --no-build
+        run: |
+          # ioxide rings (RingEntries=8192) pin memory; the e2e starts many reactors, so the
+          # default 8 MB RLIMIT_MEMLOCK is exhausted. Raise it before the run.
+          sudo prlimit --pid $$ --memlock=-1:-1 2>/dev/null || ulimit -l unlimited 2>/dev/null || true
+          echo "memlock for e2e: $(ulimit -Sl) KB"
+          dotnet run --project Tests/ioxide.e2e.csproj --configuration Release --no-build
 
       - name: Pack ioxide
         run: dotnet pack ioxide/ioxide.csproj --configuration Release --no-build --output ./artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,18 +60,21 @@ jobs:
       # enabled by default on the runners, and the suite skips the kTLS test if the module is absent.
       - name: Enable io_uring + load kTLS module
         run: |
-          sudo sysctl -w kernel.io_uring_disabled=0 2>/dev/null || true
-          sudo modprobe tls 2>/dev/null || true
+          echo "kernel: $(uname -r)"
+          echo "io_uring_disabled (before): $(cat /proc/sys/kernel/io_uring_disabled 2>/dev/null || echo n/a)"
+          sudo sysctl -w kernel.io_uring_disabled=0 || echo "WARN: could not set kernel.io_uring_disabled"
+          echo "io_uring_disabled (after):  $(cat /proc/sys/kernel/io_uring_disabled 2>/dev/null || echo n/a)"
+          sudo modprobe tls 2>/dev/null && echo "tls module loaded" || echo "tls module unavailable (kTLS test will skip)"
 
       # E2E suite (already compiled as part of ioxide.slnx). Drives real reactors over real sockets;
       # pg/redis tests use the sidecars above. Non-zero exit fails the job before any pack/publish.
       - name: Run E2E tests
         env:
-          EXAMPLES_PG_HOST: localhost
+          EXAMPLES_PG_HOST: 127.0.0.1
           EXAMPLES_PG_PORT: 5432
           EXAMPLES_PG_USER: bench
           EXAMPLES_PG_DB: bench
-          EXAMPLES_REDIS_HOST: localhost
+          EXAMPLES_REDIS_HOST: 127.0.0.1
           EXAMPLES_REDIS_PORT: 6379
         run: dotnet run --project Tests/ioxide.e2e.csproj --configuration Release --no-build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,24 +68,34 @@ jobs:
 
       # Diagnostic: io_uring_setup errno on the host, and whether a seccomp-unconfined / privileged
       # container can bypass the block (so the e2e could run inside one instead of needing self-hosted).
-      - name: Probe io_uring (host vs container)
+      - name: Probe io_uring (flags + entries)
         run: |
+          echo "memlock (ulimit -l): $(ulimit -l) KB"
           cat > /tmp/p.c <<'PROBE'
           #include <stdio.h>
           #include <errno.h>
           #include <string.h>
+          #include <unistd.h>
           #include <sys/syscall.h>
-          int main(void){
+          static void t(const char* n, unsigned int flags, unsigned int entries){
           unsigned char p[256]={0};
-          long fd=syscall(425,8,p);
-          if(fd<0){printf("FAIL errno=%d (%s)\n",errno,strerror(errno));return 1;}
-          printf("OK fd=%ld\n",fd);return 0;}
+          *(unsigned int*)(p+8)=flags;
+          long fd=syscall(425,entries,p);
+          if(fd<0) printf("%-34s FAIL errno=%d (%s)\n",n,errno,strerror(errno));
+          else { printf("%-34s OK fd=%ld\n",n,fd); close(fd); }
+          }
+          int main(void){
+          unsigned SI=1u<<12, DTR=1u<<13, NSA=1u<<16;
+          t("flags=0 e=8",0,8);
+          t("SINGLE_ISSUER e=8",SI,8);
+          t("SI|DEFER_TASKRUN e=8",SI|DTR,8);
+          t("SI|DTR|NO_SQARRAY e=8",SI|DTR|NSA,8);
+          t("SI|DTR|NO_SQARRAY e=256",SI|DTR|NSA,256);
+          t("SI|DTR|NO_SQARRAY e=4096",SI|DTR|NSA,4096);
+          return 0;}
           PROBE
           gcc -O2 -o /tmp/p /tmp/p.c
-          echo "=== host ==="; /tmp/p || true
-          echo "=== docker default seccomp ==="; docker run --rm -v /tmp/p:/p:ro ubuntu:24.04 /p || true
-          echo "=== docker seccomp=unconfined ==="; docker run --rm --security-opt seccomp=unconfined -v /tmp/p:/p:ro ubuntu:24.04 /p || true
-          echo "=== docker privileged ==="; docker run --rm --privileged -v /tmp/p:/p:ro ubuntu:24.04 /p || true
+          /tmp/p
 
       # E2E suite (already compiled as part of ioxide.slnx). Drives real reactors over real sockets;
       # pg/redis tests use the sidecars above. Non-zero exit fails the job before any pack/publish.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,27 @@ jobs:
           echo "io_uring_disabled (after):  $(cat /proc/sys/kernel/io_uring_disabled 2>/dev/null || echo n/a)"
           sudo modprobe tls 2>/dev/null && echo "tls module loaded" || echo "tls module unavailable (kTLS test will skip)"
 
+      # Diagnostic: io_uring_setup errno on the host, and whether a seccomp-unconfined / privileged
+      # container can bypass the block (so the e2e could run inside one instead of needing self-hosted).
+      - name: Probe io_uring (host vs container)
+        run: |
+          cat > /tmp/p.c <<'PROBE'
+          #include <stdio.h>
+          #include <errno.h>
+          #include <string.h>
+          #include <sys/syscall.h>
+          int main(void){
+          unsigned char p[256]={0};
+          long fd=syscall(425,8,p);
+          if(fd<0){printf("FAIL errno=%d (%s)\n",errno,strerror(errno));return 1;}
+          printf("OK fd=%ld\n",fd);return 0;}
+          PROBE
+          gcc -O2 -o /tmp/p /tmp/p.c
+          echo "=== host ==="; /tmp/p || true
+          echo "=== docker default seccomp ==="; docker run --rm -v /tmp/p:/p:ro ubuntu:24.04 /p || true
+          echo "=== docker seccomp=unconfined ==="; docker run --rm --security-opt seccomp=unconfined -v /tmp/p:/p:ro ubuntu:24.04 /p || true
+          echo "=== docker privileged ==="; docker run --rm --privileged -v /tmp/p:/p:ro ubuntu:24.04 /p || true
+
       # E2E suite (already compiled as part of ioxide.slnx). Drives real reactors over real sockets;
       # pg/redis tests use the sidecars above. Non-zero exit fails the job before any pack/publish.
       - name: Run E2E tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,43 +56,11 @@ jobs:
       - name: Build
         run: dotnet build ioxide.slnx --configuration Release --no-restore
 
-      # io_uring is needed by the reactor; the tls module by the kTLS test. Best-effort — io_uring is
-      # enabled by default on the runners, and the suite skips the kTLS test if the module is absent.
-      - name: Enable io_uring + load kTLS module
+      # kTLS module for the TLS e2e test; io_uring enable in case a runner disables it (both best-effort).
+      - name: Prepare runtime (kTLS + io_uring)
         run: |
-          echo "kernel: $(uname -r)"
-          echo "io_uring_disabled (before): $(cat /proc/sys/kernel/io_uring_disabled 2>/dev/null || echo n/a)"
-          sudo sysctl -w kernel.io_uring_disabled=0 || echo "WARN: could not set kernel.io_uring_disabled"
-          echo "io_uring_disabled (after):  $(cat /proc/sys/kernel/io_uring_disabled 2>/dev/null || echo n/a)"
-          sudo modprobe tls 2>/dev/null && echo "tls module loaded" || echo "tls module unavailable (kTLS test will skip)"
-
-      # Diagnostic: io_uring_setup errno on the host, and whether a seccomp-unconfined / privileged
-      # container can bypass the block (so the e2e could run inside one instead of needing self-hosted).
-      - name: Probe io_uring (memlock accumulation at 8192 entries)
-        run: |
-          echo "memlock soft/hard: $(ulimit -Sl) / $(ulimit -Hl) KB"
-          cat > /tmp/p.c <<'PROBE'
-          #include <stdio.h>
-          #include <errno.h>
-          #include <string.h>
-          #include <stdlib.h>
-          #include <sys/syscall.h>
-          int main(int argc, char** argv){
-          unsigned flags=(1u<<12)|(1u<<13)|(1u<<16);
-          unsigned entries=argc>1?(unsigned)atoi(argv[1]):8192;
-          int n=0;
-          for(;;){
-          unsigned char p[256]={0}; *(unsigned*)(p+8)=flags;
-          long fd=syscall(425,entries,p);
-          if(fd<0){printf("entries=%u: FAILED at ring #%d errno=%d (%s)\n",entries,n,errno,strerror(errno));return 0;}
-          if(++n>=80){printf("entries=%u: created 80 rings OK\n",entries);return 0;}
-          }
-          }
-          PROBE
-          gcc -O2 -o /tmp/p /tmp/p.c
-          echo "--- accumulate 8192-entry rings @ default memlock ---"; /tmp/p 8192
-          sudo prlimit --pid $$ --memlock=-1:-1 2>/dev/null || ulimit -l unlimited 2>/dev/null || true
-          echo "--- after raising memlock to $(ulimit -Sl) ---"; /tmp/p 8192
+          sudo modprobe tls 2>/dev/null || true
+          sudo sysctl -w kernel.io_uring_disabled=0 2>/dev/null || true
 
       # E2E suite (already compiled as part of ioxide.slnx). Drives real reactors over real sockets;
       # pg/redis tests use the sidecars above. Non-zero exit fails the job before any pack/publish.


### PR DESCRIPTION
Runs the e2e suite (`Tests/ioxide.e2e`) as part of CI.

- `postgres:18` (bench/bench, trust) + `redis:7-alpine` service containers
- best-effort `sysctl kernel.io_uring_disabled=0` + `modprobe tls` before the run
- `dotnet run --project Tests/ioxide.e2e.csproj` after Build, before pack/publish — a non-zero exit blocks the release
- pg/redis/kTLS tests skip cleanly if a dependency is unreachable

Verified locally with the sidecars + tls module: **15 passed, 0 failed, 0 skipped**.
