### PR TITLE
tests: per-process port windows, and fix a unit test that could not fail

### DIFF
--- a/bench/run.sh
+++ b/bench/run.sh
@@ -34,7 +34,9 @@ play() { # $1 subdir, rest env; starts a playground binary detached
   sleep 3
 }
 
-stop_play() { pkill -f 'Playground[.]' 2>/dev/null; sleep 1; }
+# Scoped to this run's own children, not every Playground process on the machine - a developer
+# with a sample running should not have it killed by a bench.
+stop_play() { pkill -P $$ -f 'Playground[.]' 2>/dev/null; pkill -f "$BIN/" 2>/dev/null; sleep 1; }
 
 wait_http() { # $1 url: poll until it answers (up to ~8s) so a slow start reads as fail-with-log
   for _ in $(seq 16); do

--- a/tests/Ioxide.Tests.E2E/Core/CoreTests.cs
+++ b/tests/Ioxide.Tests.E2E/Core/CoreTests.cs
@@ -174,6 +174,7 @@ internal static class CoreTests
         runner.Test("core: recv-queue overflow closes that connection, server survives", () =>
         {
             var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var parked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             int parkerClaimed = 0;
 
             (int port, _, _) = TestServer.StartConfigured(
@@ -199,6 +200,7 @@ internal static class CoreTests
 
                             if (drained > 0 && Interlocked.Exchange(ref parkerClaimed, 1) == 0)
                             {
+                                parked.SetResult();   // the flood may start now, not 200 ms from now
                                 await gate.Task;
                             }
                             else if (drained > 0 && !snap.IsClosed)
@@ -234,8 +236,13 @@ internal static class CoreTests
             NetworkStream stream = flood.GetStream();
 
             stream.Write(new byte[64]);     // consumed; the handler parks
-            Thread.Sleep(200);
-            stream.Write(new byte[4096]);   // 64-byte buffers → 64 CQEs → the 8-slot queue overflows
+
+            // Wait for the park to actually happen. Sleeping a fixed 200 ms instead makes the test
+            // fail on a loaded machine: the flood is drained by a handler that never parked, the
+            // queue never overflows, and the read below waits out its timeout.
+            Assert.True(parked.Task.Wait(TimeSpan.FromSeconds(10)), "handler never parked");
+
+            stream.Write(new byte[4096]);   // 64-byte buffers -> 64 CQEs -> the 8-slot queue overflows
 
             bool closed;
             try

--- a/tests/Ioxide.Tests.E2E/Core/HardeningTests.cs
+++ b/tests/Ioxide.Tests.E2E/Core/HardeningTests.cs
@@ -97,17 +97,14 @@ internal static class HardeningTests
                     },
                 });
 
-            Thread.Sleep(250);   // WaitForListen's probe connection must recycle and free its gid
-
-            // Fill the reactor to its gid cap with live keep-alive connections.
+            // Fill the reactor to its gid cap with live keep-alive connections. WaitForListen's
+            // probe connection still holds a gid until the reactor recycles it, so the fourth slot
+            // may not be free yet: retry rather than sleep a fixed 250 ms and hope. A loaded
+            // machine misses that deadline and the fill below fails on a server that is fine.
             var held = new List<TcpClient>();
             for (int i = 0; i < 4; i++)
             {
-                var c = new TcpClient();
-                c.Connect("127.0.0.1", port);
-                c.ReceiveTimeout = 4000;
-                held.Add(c);
-                GetOk(c);
+                held.Add(ConnectServing(port, TimeSpan.FromSeconds(10)));
             }
 
             // Beyond the cap: the unfixed core threw in AllocGid and the reactor died here.
@@ -132,12 +129,10 @@ internal static class HardeningTests
             // ...and accept fresh ones once capacity frees.
             held[3].Close();
             held.RemoveAt(3);
-            Thread.Sleep(300);   // recycle returns the gid
 
-            using var fresh = new TcpClient();
-            fresh.Connect("127.0.0.1", port);
-            fresh.ReceiveTimeout = 4000;
-            GetOk(fresh);
+            // The gid returns when the reactor recycles that connection, which is its own event,
+            // not a fixed interval - so retry until the capacity is actually back.
+            using TcpClient fresh = ConnectServing(port, TimeSpan.FromSeconds(10));
 
             foreach (TcpClient c in held)
             {
@@ -147,6 +142,38 @@ internal static class HardeningTests
     }
 
     private static int Fds() => Directory.EnumerateFileSystemEntries("/proc/self/fd").Count();
+
+    /// <summary>
+    /// Connect and keep trying until the server answers, up to a deadline. Capacity in these tests
+    /// frees on the reactor's own schedule (a recycle, a sweep), so waiting for the observable
+    /// outcome is the only synchronization that holds on a slow machine.
+    /// </summary>
+    private static TcpClient ConnectServing(int port, TimeSpan timeout)
+    {
+        long deadline = Environment.TickCount64 + (long)timeout.TotalMilliseconds;
+        Exception? last = null;
+
+        while (Environment.TickCount64 < deadline)
+        {
+            var candidate = new TcpClient();
+            try
+            {
+                candidate.Connect("127.0.0.1", port);
+                candidate.ReceiveTimeout = 1000;
+                GetOk(candidate);
+                candidate.ReceiveTimeout = 4000;
+                return candidate;
+            }
+            catch (Exception e)
+            {
+                last = e;
+                candidate.Dispose();
+                Thread.Sleep(50);
+            }
+        }
+
+        throw new Exception($"no connection served within {timeout.TotalSeconds}s: {last?.Message}");
+    }
 
     private static void GetOk(TcpClient c)
     {

--- a/tests/Ioxide.Tests.Harness/TestServer.cs
+++ b/tests/Ioxide.Tests.Harness/TestServer.cs
@@ -15,7 +15,42 @@ namespace Ioxide.Tests;
 /// </summary>
 public static class TestServer
 {
-    private static int _nextPort = 18080;
+    /// <summary>
+    /// Every test process needs its own port range, and the failure mode when it does not have one
+    /// is silent rather than loud: ioxide listeners set SO_REUSEPORT, so two processes binding the
+    /// same port BOTH succeed and the kernel load-balances connections between them. WaitForListen
+    /// connects happily and a test is then answered by the other process's server, which shows up
+    /// as an unrelated assertion failing somewhere far away.
+    ///
+    /// The window therefore mixes the entry assembly name (so different suites never overlap) with
+    /// the process id (so two runs of the SAME suite - a developer and CI, or two terminals - do
+    /// not either). No registration, no coordination, and new suites need no changes.
+    /// </summary>
+    private static int _nextPort = PortBaseForThisProcess();
+
+    // 20000 to 32700, which stops short of ip_local_port_range (32768 on Linux by default): a
+    // listener bound above that line races the machine's own ephemeral allocations, including the
+    // client sockets these very tests open.
+    private const int WindowSize = 100;
+    private const int WindowCount = 127;
+
+    private static int PortBaseForThisProcess()
+    {
+        string name = System.Reflection.Assembly.GetEntryAssembly()?.GetName().Name ?? "unknown";
+
+        // Hashed by hand: string.GetHashCode is randomized per process, so the suite half of the
+        // key would move between runs and stop being a property of the suite at all.
+        int hash = 17;
+        foreach (char c in name)
+        {
+            hash = (hash * 31) + c;
+        }
+
+        int window = Math.Abs(hash ^ Environment.ProcessId) % WindowCount;
+
+        // 20000 upward, clear of bench/run.sh (18080-18464) and the playground defaults.
+        return 20000 + (window * WindowSize);
+    }
 
     /// <summary>Reserve a unique port (e.g. for TcpOptions.ExtraPorts).</summary>
     public static int NextPort() => Interlocked.Increment(ref _nextPort);

--- a/tests/Ioxide.Tests.Http/HttpClientTests.cs
+++ b/tests/Ioxide.Tests.Http/HttpClientTests.cs
@@ -8,7 +8,7 @@ namespace Ioxide.Tests;
 /// <summary>
 /// The ring-native HTTP/1.1 client, exercised the way it is meant to be used: a PROXY. One ioxide
 /// server is the origin, a second one handles inbound requests by calling the origin through
-/// ioxide.http11 from inside its handler, and the test drives the proxy with a plain socket.
+/// ioxide.httpclient from inside its handler, and the test drives the proxy with a plain socket.
 /// That covers the whole chain - pool on the reactor, connect/send/recv on the ring, response
 /// parsing - and proves the client is usable from where handlers actually live.
 ///

--- a/tests/Ioxide.Tests.Unit/MessageTests.cs
+++ b/tests/Ioxide.Tests.Unit/MessageTests.cs
@@ -82,8 +82,10 @@ internal static class MessageTests
             Assert.Equal("content-type", Text(response.Headers[0].Key));
         });
 
-        runner.Test("response: header lookup is case-insensitive on the wire name", () =>
+        runner.Test("response: LowercaseArena makes a wire name matchable", () =>
         {
+            // TryGetHeader compares exactly. Wire names arrive in any case, so the h1 parser
+            // lowercases them in the arena first - this is that step, not a lenient lookup.
             using var response = new HttpClientResponse();
 
             (int Offset, int Length) name = response.Append("Content-Type"u8);
@@ -102,8 +104,8 @@ internal static class MessageTests
 
         runner.Test("response: ResetForInterim drops a 1xx and reuses the arena", () =>
         {
-            // 103 Early Hints arrives, then the real response. Everything from the interim
-            // section has to go, or its headers would be returned as the final body.
+            // 103 Early Hints arrives, then the real response on the same connection. Everything
+            // from the interim section has to go, or its headers are returned as the final body.
             using var response = new HttpClientResponse();
 
             (int Offset, int Length) hint = response.Append("link"u8);
@@ -112,9 +114,22 @@ internal static class MessageTests
 
             response.ResetForInterim();
 
-            Assert.Equal(0, response.Headers.Count);
             Assert.Equal(0, response.ArenaLength);
             Assert.Equal(0, response.Status);
+
+            // Write the real response into the reused arena and materialize. Freeze is what turns
+            // recorded ranges into Headers, so asserting the count BEFORE it would pass even if
+            // ResetForInterim had kept every interim range - the test could not fail.
+            (int Offset, int Length) name = response.Append("content-type"u8);
+            (int Offset, int Length) value = response.Append("text/plain"u8);
+            response.AddHeaderRange(name, value);
+            response.SetBodyRange((0, 0));
+            response.Status = 200;
+            response.Freeze();
+
+            Assert.Equal(1, response.Headers.Count);
+            Assert.Equal("content-type", Text(response.Headers[0].Key));
+            Assert.Equal("text/plain", Text(response.Headers[0].Value));
         });
     }
 


### PR DESCRIPTION
The #128 squash landed everything except its final commit, so main currently has the brittle version of both fixes below. Six files, no overlap with what already merged.

## Port collisions (confirmed by execution)

Each suite is its own process now, and every one started its port counter at 18080. This fails **silently**: ioxide listeners set `SO_REUSEPORT`, so two processes bind the same port with no error and the kernel load-balances between them. `WaitForListen` connects happily and a test is then answered by another suite's server — reproduced with Http asserting `hello from origin` and receiving `ok` from E2E's echo handler.

Ports now derive from the entry assembly name **and** the process id, so different suites and repeat runs of the same suite all separate. Capped at 32700, because the first version reached into `ip_local_port_range` (32768+) and raced the machine's own ephemeral allocations — including the client sockets these tests open.

Verified: 3 E2E instances concurrently 40/40 each, 4 different suites concurrently green, E2E 6/6 sequential.

## A unit test that could not fail

`MessageTests` asserted `Headers.Count == 0` right after `ResetForInterim`, but ranges only become `Headers` at `Freeze()` — so it passed whether or not the reset cleared anything. It now writes the real response into the reused arena and freezes.

**Proved by mutation**: deleting `_ranges.Clear()` from `ResetForInterim` fails it (`expected [1], got [2]`), where the old assertion stayed green.

## Also

- Two `Thread.Sleep` synchronizations that flaked ~10% of runs: the recv-queue overflow test waits for the handler to actually park; the `MaxConnections` shedding test polls for capacity instead of assuming a 250 ms recycle.
- A test named for case-insensitive lookup renamed to what it tests (`TryGetHeader` compares exactly; `LowercaseArena` is the parser step).
- A doc comment still naming `ioxide.http11`.
- `bench/run.sh`'s `stop_play` no longer pkills every Playground process on the machine.

82 passing across all seven suites on top of current main.