### PR TITLE
docs: kTLS under tcp, and a proxy section with all nine h1/h2/h3 combinations

### DIFF
--- a/Playground/Proxy/H1ToH1/Playground.Proxy.H1ToH1.csproj
+++ b/Playground/Proxy/H1ToH1/Playground.Proxy.H1ToH1.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net11.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace>Playground.Proxy.H1ToH1</RootNamespace>
+    <AssemblyName>Playground.Proxy.H1ToH1</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Shared/Playground.Shared.csproj" />
+    <ProjectReference Include="../../../src/ioxide/ioxide.csproj" />
+    <ProjectReference Include="../../../src/clients/ioxide.httpclient/ioxide.httpclient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Playground/Proxy/H1ToH1/Program.cs
+++ b/Playground/Proxy/H1ToH1/Program.cs
@@ -5,7 +5,7 @@ using ioxide.utils;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  proxy - a reverse proxy, whole. Every inbound request is forwarded to an upstream origin
+//  proxy h1->h1 - a reverse proxy, whole. Every inbound request is forwarded to an upstream origin
 //  through the ring-native HTTP client and the response is relayed back. BOTH hops - the inbound
 //  connection and the outbound call - run on this reactor's ring and resume inline, so a proxied
 //  request never leaves the thread it arrived on. No thread pool, no cross-core handoff.
@@ -13,7 +13,7 @@ using Playground.Shared;
 //      # terminal 1: an origin to forward to
 //      PLAYGROUND_PORT=8081 dotnet run -c Release --project Playground/Tcp/Raw
 //      # terminal 2: the proxy
-//      dotnet run -c Release --project Playground/Proxy/H1
+//      dotnet run -c Release --project Playground/Proxy/H1ToH1
 //      curl http://127.0.0.1:8080/
 //
 //  Needs: ioxide.httpclient
@@ -103,7 +103,7 @@ for (int i = 0; i < threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($"[proxy] {config.ReactorCount} reactors on :{config.Tcp.Port} "
+Console.WriteLine($"[proxy h1->h1] {config.ReactorCount} reactors on :{config.Tcp.Port} "
                 + $"-> {upstream.Host}:{upstream.Port}, {upstream.PoolSize} connections each");
 
 foreach (Thread thread in threads)

--- a/Playground/Proxy/H1ToH2/Playground.Proxy.H1ToH2.csproj
+++ b/Playground/Proxy/H1ToH2/Playground.Proxy.H1ToH2.csproj
@@ -6,8 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <RootNamespace>Playground.Proxy.H1</RootNamespace>
-    <AssemblyName>Playground.Proxy.H1</AssemblyName>
+    <RootNamespace>Playground.Proxy.H1ToH2</RootNamespace>
+    <AssemblyName>Playground.Proxy.H1ToH2</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Playground/Proxy/H1ToH2/Program.cs
+++ b/Playground/Proxy/H1ToH2/Program.cs
@@ -1,0 +1,132 @@
+using System.Text;
+using ioxide;
+using ioxide.httpclient;
+using ioxide.utils;
+using Playground.Shared;
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+//  proxy h1->h2 - a plain HTTP/1.1 server whose upstream calls ride HTTP/2 (h2c). The frontend is
+//  Proxy.H1ToH1's, byte for byte; only the pool changed. That is the point of the matrix: the
+//  protocol on each hop is a pool type, not a rewrite.
+//
+//  What the swap buys is fan-in. h1 needs one upstream connection per in-flight request, so the
+//  pool sizes for concurrency; h2 multiplexes, so PoolSize 1 carries every concurrent request on
+//  a single socket. A proxy in front of a few origins can hold one connection to each.
+//
+//      # the h2c upstream, moved off 8080 so the proxy can have it
+//      PLAYGROUND_PORT=8081 dotnet run -c Release --project Playground/Http2/Nghttp2
+//      dotnet run -c Release --project Playground/Proxy/H1ToH2
+//      curl http://127.0.0.1:8080/anything
+//
+//  Needs: ioxide.httpclient
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+var config = new ServerConfig
+{
+    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    Tcp = new TcpOptions
+    {
+        Port = Env.Port("PLAYGROUND_PORT", 8080),
+    },
+};
+
+var upstream = new Http2ClientOptions
+{
+    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
+    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8081),
+    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1),         // h2 multiplexes: one connection carries all
+};
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i < threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    // Opened on the reactor thread, so the upstream socket rides this reactor's ring too.
+    reactor.OnStart = r => Http2ClientPool.Start(r, upstream);
+
+    reactor.TcpHandle = async (r, conn) =>
+    {
+        Http2ClientPool client = r.GetService<Http2ClientPool>();
+
+        try
+        {
+            while (true)
+            {
+                RecvSnapshot snapshot = await conn.ReadAsync();
+
+                string path = "/";
+                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                {
+                    if (item.HasBuffer)
+                    {
+                        if (TryReadTarget(item.AsSpan(), out ReadOnlySpan<byte> target))
+                        {
+                            path = Encoding.ASCII.GetString(target);
+                        }
+                        conn.ReturnBuffer(in item);
+                    }
+                }
+
+                try
+                {
+                    // h1 request in, h2 stream out - same ring, same thread, inline resume.
+                    using HttpClientResponse response = await client.GetAsync(path);
+
+                    conn.Write(Encoding.ASCII.GetBytes(
+                        $"HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n"));
+                    conn.Write(response.Body.Span);   // bytes straight through, no decode
+                }
+                catch (Exception e)
+                {
+                    byte[] message = Encoding.ASCII.GetBytes($"upstream: {e.Message}");
+                    conn.Write(Encoding.ASCII.GetBytes(
+                        $"HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n"));
+                    conn.Write(message);
+                }
+
+                await conn.FlushAsync();
+
+                if (snapshot.IsClosed) return;
+                conn.ResetRead();
+            }
+        }
+        finally
+        {
+            conn.DecRef();
+        }
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $"reactor-{i}" };
+    threads[i].Start();
+}
+
+Console.WriteLine($"[proxy h1->h2] {config.ReactorCount} reactors on :{config.Tcp!.Port} "
+                + $"-> h2c {upstream.Host}:{upstream.Port}, {upstream.PoolSize} connection(s) each");
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}
+
+// "GET /sleep?x=1 HTTP/1.1" -> "/sleep". Your framework of choice would do this for you; ioxide
+// deliberately doesn't, so here it is in full.
+static bool TryReadTarget(ReadOnlySpan<byte> request, out ReadOnlySpan<byte> target)
+{
+    target = default;
+
+    int firstSpace = request.IndexOf((byte)' ');
+    if (firstSpace < 0) return false;
+
+    ReadOnlySpan<byte> afterMethod = request[(firstSpace + 1)..];
+    int secondSpace = afterMethod.IndexOf((byte)' ');
+    if (secondSpace < 0) return false;
+
+    target = afterMethod[..secondSpace];
+
+    int query = target.IndexOf((byte)'?');
+    if (query >= 0) target = target[..query];
+
+    return true;
+}

--- a/Playground/Proxy/H2ToH1/Playground.Proxy.H2ToH1.csproj
+++ b/Playground/Proxy/H2ToH1/Playground.Proxy.H2ToH1.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net11.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace>Playground.Proxy.H2ToH1</RootNamespace>
+    <AssemblyName>Playground.Proxy.H2ToH1</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Shared/Playground.Shared.csproj" />
+    <ProjectReference Include="../../../src/ioxide/ioxide.csproj" />
+    <ProjectReference Include="../../../src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj" />
+    <ProjectReference Include="../../../src/clients/ioxide.httpclient/ioxide.httpclient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Playground/Proxy/H2ToH1/Program.cs
+++ b/Playground/Proxy/H2ToH1/Program.cs
@@ -1,0 +1,112 @@
+using System.Text;
+using ioxide;
+using ioxide.httpclient;
+using ioxide.nghttp2;
+using Playground.Shared;
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+//  proxy h2->h1 - an HTTP/2 front door for an HTTP/1.1 upstream. This is the classic edge shape:
+//  clients get multiplexing and header compression, the origin keeps speaking the protocol it
+//  already speaks.
+//
+//  Note the asymmetry it creates. One h2 connection can have a hundred streams in flight, and
+//  each one needs its own h1 upstream connection for the duration - h1 has no multiplexing to
+//  borrow. So the pool sizes for concurrency here, unlike every h2/h3 upstream in this folder.
+//  Run out and the request queues behind a waiter rather than the pool opening unbounded, with
+//  the whole acquire bounded by HttpClientOptions.AcquireTimeoutMs - a saturated origin surfaces
+//  as a 502 on that stream, not as an fd leak.
+//
+//      PLAYGROUND_PORT=8081 dotnet run -c Release --project Playground/Tcp/Raw
+//      dotnet run -c Release --project Playground/Proxy/H2ToH1
+//      curl --http2-prior-knowledge http://127.0.0.1:8080/anything
+//
+//  Needs: ioxide.nghttp2, ioxide.httpclient
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+var config = new ServerConfig
+{
+    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    Tcp = new TcpOptions
+    {
+        Port = Env.Port("PLAYGROUND_PORT", 8080),
+    },
+};
+
+var upstream = new HttpClientOptions
+{
+    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
+    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8081),
+    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 32),        // h1 has no multiplexing: size for concurrency
+};
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i < threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    // The pool's connections belong to THIS reactor's ring - one pool per reactor, no locks.
+    reactor.OnStart = r => HttpClientPool.Start(r, upstream);
+
+    reactor.TcpHandle = async (r, conn) =>
+    {
+        HttpClientPool client = r.GetService<HttpClientPool>();
+
+        try
+        {
+            // Buffered + async: each stream dispatches with its body assembled, and the handler
+            // may await - the upstream round trip resumes inline on this reactor. Concurrent
+            // streams interleave here, which is exactly why the h1 pool has to be deep.
+            await new Nghttp2Connection(conn).RunBufferedAsync(async request =>
+            {
+                try
+                {
+                    // Method, path and body forward as the bytes they already are: h2 decoded
+                    // them out of HPACK, and the h1 client writes them back out as a request line.
+                    using HttpClientResponse response = await client.SendAsync(new HttpClientRequest(
+                        request.Method, request.Path) { Body = request.Body });
+
+                    // Copy before Dispose: the response arena is freed then, and nghttp2 copies
+                    // the h2 response only AFTER this handler returns. A real proxy would also
+                    // drop hop-by-hop headers - Connection, Keep-Alive, Transfer-Encoding are all
+                    // illegal in h2 and would be a protocol error to forward.
+                    var proxied = new Nghttp2Response
+                    {
+                        Status = response.Status,
+                        Body = response.Body.ToArray(),
+                    };
+                    if (response.TryGetHeader("content-type"u8, out ReadOnlyMemory<byte> contentType))
+                    {
+                        proxied.Headers.Add("content-type"u8.ToArray(), contentType.ToArray());
+                    }
+                    return proxied;
+                }
+                catch (Exception e)
+                {
+                    // Upstream down is a gateway error on this stream, not a dead h2 connection:
+                    // every other stream on it keeps working.
+                    return new Nghttp2Response
+                    {
+                        Status = 502,
+                        Body = Encoding.ASCII.GetBytes($"upstream failed: {e.Message}\n"),
+                    };
+                }
+            });
+        }
+        finally
+        {
+            conn.DecRef();
+        }
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $"reactor-{i}" };
+    threads[i].Start();
+}
+
+Console.WriteLine($"[proxy h2->h1] {config.ReactorCount} reactors, h2c on :{config.Tcp!.Port} "
+                + $"-> http/1.1 {upstream.Host}:{upstream.Port}, {upstream.PoolSize} connections each");
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}

--- a/Playground/Proxy/H2ToH2/Playground.Proxy.H2ToH2.csproj
+++ b/Playground/Proxy/H2ToH2/Playground.Proxy.H2ToH2.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net11.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace>Playground.Proxy.H2ToH2</RootNamespace>
+    <AssemblyName>Playground.Proxy.H2ToH2</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Shared/Playground.Shared.csproj" />
+    <ProjectReference Include="../../../src/ioxide/ioxide.csproj" />
+    <ProjectReference Include="../../../src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj" />
+    <ProjectReference Include="../../../src/clients/ioxide.httpclient/ioxide.httpclient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Playground/Proxy/H2ToH2/Program.cs
+++ b/Playground/Proxy/H2ToH2/Program.cs
@@ -1,0 +1,103 @@
+using System.Text;
+using ioxide;
+using ioxide.httpclient;
+using ioxide.nghttp2;
+using Playground.Shared;
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+//  proxy h2->h2 - HTTP/2 on both sides. The narrowest proxy in this folder: n client streams on
+//  one inbound connection fan out to n streams on ONE outbound connection, so the whole thing
+//  runs on two sockets per reactor no matter how many requests are in flight.
+//
+//  Two different nghttp2 sessions are involved and they share nothing. The inbound one decodes
+//  HPACK against the client's dynamic table; the outbound one re-encodes against the origin's.
+//  Header state is per-connection in HTTP/2 and cannot be forwarded - a proxy always re-encodes,
+//  which is why "just splice the frames" is not a shortcut that exists.
+//
+//      # the h2c upstream, moved off 8080 so the proxy can have it
+//      PLAYGROUND_PORT=8081 dotnet run -c Release --project Playground/Http2/Nghttp2
+//      dotnet run -c Release --project Playground/Proxy/H2ToH2
+//      curl --http2-prior-knowledge http://127.0.0.1:8080/anything
+//
+//  Needs: ioxide.nghttp2, ioxide.httpclient
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+var config = new ServerConfig
+{
+    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    Tcp = new TcpOptions
+    {
+        Port = Env.Port("PLAYGROUND_PORT", 8080),
+    },
+};
+
+var upstream = new Http2ClientOptions
+{
+    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
+    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8081),
+    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1),         // h2 multiplexes: one connection carries all
+};
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i < threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    reactor.OnStart = r => Http2ClientPool.Start(r, upstream);
+
+    reactor.TcpHandle = async (r, conn) =>
+    {
+        Http2ClientPool client = r.GetService<Http2ClientPool>();
+
+        try
+        {
+            await new Nghttp2Connection(conn).RunBufferedAsync(async request =>
+            {
+                try
+                {
+                    // Both hops are h2 streams on this reactor's ring, and this await resumes
+                    // inline - the request never leaves the thread it arrived on.
+                    using HttpClientResponse response = await client.SendAsync(new HttpClientRequest(
+                        request.Method, request.Path) { Body = request.Body });
+
+                    // Copy before Dispose: the response arena is freed then, and nghttp2 copies
+                    // the h2 response only AFTER this handler returns.
+                    var proxied = new Nghttp2Response
+                    {
+                        Status = response.Status,
+                        Body = response.Body.ToArray(),
+                    };
+                    if (response.TryGetHeader("content-type"u8, out ReadOnlyMemory<byte> contentType))
+                    {
+                        proxied.Headers.Add("content-type"u8.ToArray(), contentType.ToArray());
+                    }
+                    return proxied;
+                }
+                catch (Exception e)
+                {
+                    return new Nghttp2Response
+                    {
+                        Status = 502,
+                        Body = Encoding.ASCII.GetBytes($"upstream failed: {e.Message}\n"),
+                    };
+                }
+            });
+        }
+        finally
+        {
+            conn.DecRef();
+        }
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $"reactor-{i}" };
+    threads[i].Start();
+}
+
+Console.WriteLine($"[proxy h2->h2] {config.ReactorCount} reactors, h2c on :{config.Tcp!.Port} "
+                + $"-> h2c {upstream.Host}:{upstream.Port}");
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}

--- a/Playground/Proxy/H2ToH3/Playground.Proxy.H2ToH3.csproj
+++ b/Playground/Proxy/H2ToH3/Playground.Proxy.H2ToH3.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net11.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace>Playground.Proxy.H2ToH3</RootNamespace>
+    <AssemblyName>Playground.Proxy.H2ToH3</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Shared/Playground.Shared.csproj" />
+    <ProjectReference Include="../../../src/ioxide/ioxide.csproj" />
+    <ProjectReference Include="../../../src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj" />
+    <ProjectReference Include="../../../src/clients/ioxide.httpclient/ioxide.httpclient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Playground/Proxy/H2ToH3/Program.cs
+++ b/Playground/Proxy/H2ToH3/Program.cs
@@ -1,0 +1,105 @@
+using System.Text;
+using ioxide;
+using ioxide.httpclient;
+using ioxide.nghttp2;
+using Playground.Shared;
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+//  proxy h2->h3 - HTTP/2 in over TCP, HTTP/3 out over QUIC. The protocol-translating edge: the
+//  client half of a migration where the origin has moved to h3 and the clients have not.
+//
+//  Look at what the config does NOT contain: no ServerConfig.Quic, no UDP ports, no certificate.
+//  Dialing h3 out needs none of it - the first connect makes the reactor open a UDP socket on an
+//  EPHEMERAL port, and replies route back by connection ID. Being an h3 client requires no h3
+//  server, exactly as in Proxy.H1ToH3; the frontend changing from h1 to h2 changes nothing about
+//  that half.
+//
+//      dotnet run -c Release --project Playground/Http3/Nghttp3      # the h3 upstream on udp :8443
+//      dotnet run -c Release --project Playground/Proxy/H2ToH3
+//      curl --http2-prior-knowledge http://127.0.0.1:8080/anything
+//
+//  Needs: ioxide.nghttp2, ioxide.httpclient
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+var config = new ServerConfig
+{
+    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    Tcp = new TcpOptions
+    {
+        Port = Env.Port("PLAYGROUND_PORT", 8080),
+    },
+};
+
+var upstream = new Http3ClientOptions
+{
+    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
+    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8443),         // the upstream's QUIC (UDP) port
+    ServerName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost"),
+    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1),         // h3 multiplexes: one connection carries all
+};
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i < threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    // Opening the pool here is what makes the reactor grow its client-side QUIC transport: an
+    // ephemeral UDP socket, armed on this ring, shared by every upstream connection.
+    reactor.OnStart = r => Http3ClientPool.Start(r, upstream);
+
+    reactor.TcpHandle = async (r, conn) =>
+    {
+        Http3ClientPool client = r.GetService<Http3ClientPool>();
+
+        try
+        {
+            await new Nghttp2Connection(conn).RunBufferedAsync(async request =>
+            {
+                try
+                {
+                    // An h2 stream in, a QUIC stream out. Both are completions on this reactor's
+                    // ring - one from a TCP recv, one from a UDP recv - and both resume inline.
+                    using HttpClientResponse response = await client.SendAsync(new HttpClientRequest(
+                        request.Method, request.Path) { Body = request.Body });
+
+                    // Copy before Dispose: the response arena is freed then, and nghttp2 copies
+                    // the h2 response only AFTER this handler returns.
+                    var proxied = new Nghttp2Response
+                    {
+                        Status = response.Status,
+                        Body = response.Body.ToArray(),
+                    };
+                    if (response.TryGetHeader("content-type"u8, out ReadOnlyMemory<byte> contentType))
+                    {
+                        proxied.Headers.Add("content-type"u8.ToArray(), contentType.ToArray());
+                    }
+                    return proxied;
+                }
+                catch (Exception e)
+                {
+                    return new Nghttp2Response
+                    {
+                        Status = 502,
+                        Body = Encoding.ASCII.GetBytes($"upstream failed: {e.Message}\n"),
+                    };
+                }
+            });
+        }
+        finally
+        {
+            conn.DecRef();
+        }
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $"reactor-{i}" };
+    threads[i].Start();
+}
+
+Console.WriteLine($"[proxy h2->h3] {config.ReactorCount} reactors, h2c on :{config.Tcp!.Port} "
+                + $"-> h3 {upstream.Host}:{upstream.Port} (client-only QUIC, ephemeral port)");
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}

--- a/Playground/README.md
+++ b/Playground/README.md
@@ -26,11 +26,15 @@ Run any of them with `dotnet run -c Release --project Playground/<Group>/<Name>`
 | [`Http3.Nghttp3`](Http3/Nghttp3/Program.cs) | 169 | HTTP/3 with **streamed** dispatch, and a `SIGTERM` GOAWAY drain. | `ioxide.ngtcp2`, `ioxide.nghttp3` |
 | [`Http3.Buffered`](Http3/Buffered/Program.cs) | 146 | The same server with **buffered** dispatch - one method call is the whole difference. | `ioxide.ngtcp2`, `ioxide.nghttp3` |
 | [`Quic.Alpn`](Quic/Alpn/Program.cs) | 111 | One QUIC listener, two protocols by ALPN: h3, or raw stream echo over the dual pipe. QUIC-only - `Tcp = null`. | `ioxide.ngtcp2`, `ioxide.nghttp3` |
-| [`Proxy.H1`](Proxy/H1/Program.cs) | 131 | A reverse proxy where both hops stay on one reactor thread. | `ioxide.httpclient` |
+| [`Proxy.H1ToH1`](Proxy/H1ToH1/Program.cs) | 131 | A reverse proxy, whole - both hops on one reactor thread. Read this one first. | `ioxide.httpclient` |
+| [`Proxy.H1ToH2`](Proxy/H1ToH2/Program.cs) | 132 | The same frontend, h2 upstream: `PoolSize` 1 carries every concurrent request. | `ioxide.httpclient` |
+| [`Proxy.H1ToH3`](Proxy/H1ToH3/Program.cs) | 131 | h1 in, h3 out - with no `Quic` config at all: the first connect opens an ephemeral client socket. | `ioxide.httpclient` |
+| [`Proxy.H2ToH1`](Proxy/H2ToH1/Program.cs) | 112 | The classic edge: clients get multiplexing, the origin keeps h1. The one combination whose pool must size for concurrency. | `ioxide.nghttp2`, `ioxide.httpclient` |
+| [`Proxy.H2ToH2`](Proxy/H2ToH2/Program.cs) | 103 | h2 both sides - two sockets per reactor whatever the load. Two HPACK tables that cannot be spliced. | `ioxide.nghttp2`, `ioxide.httpclient` |
+| [`Proxy.H2ToH3`](Proxy/H2ToH3/Program.cs) | 105 | The protocol-translating edge: TCP in, QUIC out, no server-side QUIC config. | `ioxide.nghttp2`, `ioxide.httpclient` |
 | [`Proxy.H3ToH1`](Proxy/H3ToH1/Program.cs) | 106 | HTTP/3 front door, HTTP/1.1 upstream - QUIC-only frontend, keep-alive h1 pool behind. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
-| [`Proxy.H3ToH2`](Proxy/H3ToH2/Program.cs) | 104 | The same proxy with the pool swapped: requests multiplex onto one h2c upstream connection. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
-| [`Proxy.H3ToH3`](Proxy/H3ToH3/Program.cs) | 107 | h3 on both sides: the upstream QUIC connections share the serving socket - one fd, both directions. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
-| [`Proxy.H1ToH3`](Proxy/H1ToH3/Program.cs) | 129 | h1 in, h3 out - with no `Quic` config at all: the first connect opens an ephemeral client socket. | `ioxide.httpclient` |
+| [`Proxy.H3ToH2`](Proxy/H3ToH2/Program.cs) | 103 | The same proxy with the pool swapped: requests multiplex onto one h2c upstream connection. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
+| [`Proxy.H3ToH3`](Proxy/H3ToH3/Program.cs) | 105 | h3 on both sides: the upstream QUIC connections share the serving socket - one fd, both directions. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
 | [`Clients.Pg`](Clients/Pg/Program.cs) | 181 | A `PgPool` per reactor: scalar queries, prepared params (`/add`, `/upper`), row streaming (`/rows`), errors and timeouts. | `ioxide.pg` |
 | [`Clients.Redis`](Clients/Redis/Program.cs) | 194 | A `RedisPool` per reactor: GET hot path, cache-aside, RESP types, explicit pipelining. | `ioxide.redis` |
 | [`Clients.File`](Clients/File/Program.cs) | 253 | Static files: baked responses, ring reads, disk revalidation, `SIGHUP` reload. | `ioxide.file` |
@@ -125,10 +129,15 @@ answers `500`, which is the error path working.
 | --- | --- |
 | `PLAYGROUND_UPSTREAM_HOST` | `127.0.0.1` |
 | `PLAYGROUND_UPSTREAM_PORT` | `8081` |
-| `PLAYGROUND_UPSTREAM_POOL` | `8` (per reactor) |
+| `PLAYGROUND_UPSTREAM_POOL` | `8` h1 upstream, `32` for `H2ToH1`, `1` for any h2/h3 upstream |
 
-Needs an origin to forward to: run `Tcp.Raw` with `PLAYGROUND_PORT=8081` in one terminal and the
-proxy in another. With nothing listening it answers `502` once the acquire timeout elapses.
+Nine samples, one per frontend x upstream combination: the frontend protocol is the server type
+(`Nghttp2Connection`, `Nghttp3Connection`, or a raw TCP loop) and the upstream protocol is the
+pool type (`HttpClientPool`, `Http2ClientPool`, `Http3ClientPool`). Nothing else differs, which
+is the point.
+
+Each needs an origin to forward to - run one of the servers above on `PLAYGROUND_UPSTREAM_PORT`
+in another terminal. With nothing listening they answer `502` once the acquire timeout elapses.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,6 @@ Nothing here is pseudocode. Every pattern above exists as something you can run:
 
 | | What you get |
 | --- | --- |
-| **[Documentation](https://mda2av.github.io/ioxide/)** | The examples browser - TCP with and without kTLS, HTTP/2, QUIC, HTTP/3 and every client, side by side. |
+| **[Documentation](https://mda2av.github.io/ioxide/)** | The examples browser - TCP with and without kTLS, HTTP/2, QUIC, HTTP/3, every client, and all nine proxy combinations, side by side. |
 | **[Playground](Playground/)** | One project per workload, grouped by topic. Each `Program.cs` is a **complete** server - config, reactors, threads, handler - so you can copy the file out and run it. |
 | **[Examples.AspNet](Examples.AspNet/)** | `UseIoxide()` measured against a stock Kestrel baseline. |

--- a/README.md
+++ b/README.md
@@ -64,6 +64,6 @@ Nothing here is pseudocode. Every pattern above exists as something you can run:
 
 | | What you get |
 | --- | --- |
-| **[Documentation](https://mda2av.github.io/ioxide/)** | The examples browser - TCP, QUIC, HTTP/2, HTTP/3, every client, and the ASP.NET drop-in, side by side. |
+| **[Documentation](https://mda2av.github.io/ioxide/)** | The examples browser - TCP with and without kTLS, HTTP/2, QUIC, HTTP/3 and every client, side by side. |
 | **[Playground](Playground/)** | One project per workload, grouped by topic. Each `Program.cs` is a **complete** server - config, reactors, threads, handler - so you can copy the file out and run it. |
 | **[Examples.AspNet](Examples.AspNet/)** | `UseIoxide()` measured against a stock Kestrel baseline. |

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -213,6 +213,16 @@ nav.top .links a.gh svg { display: block; }
 #tab-h2:checked ~ .ex-menu label[for="tab-h2"],
 #tab-h2cs:checked ~ .ex-menu label[for="tab-h2cs"],
 #tab-h2tls:checked ~ .ex-menu label[for="tab-h2tls"],
+#tab-pxmatrix:checked ~ .ex-menu label[for="tab-pxmatrix"],
+#tab-pxh1toh1:checked ~ .ex-menu label[for="tab-pxh1toh1"],
+#tab-pxh1toh2:checked ~ .ex-menu label[for="tab-pxh1toh2"],
+#tab-pxh1toh3:checked ~ .ex-menu label[for="tab-pxh1toh3"],
+#tab-pxh2toh1:checked ~ .ex-menu label[for="tab-pxh2toh1"],
+#tab-pxh2toh2:checked ~ .ex-menu label[for="tab-pxh2toh2"],
+#tab-pxh2toh3:checked ~ .ex-menu label[for="tab-pxh2toh3"],
+#tab-pxh3toh1:checked ~ .ex-menu label[for="tab-pxh3toh1"],
+#tab-pxh3toh2:checked ~ .ex-menu label[for="tab-pxh3toh2"],
+#tab-pxh3toh3:checked ~ .ex-menu label[for="tab-pxh3toh3"],
 #tab-qpipe:checked ~ .ex-menu label[for="tab-qpipe"],
 #tab-qraw:checked ~ .ex-menu label[for="tab-qraw"],
 #tab-h3:checked ~ .ex-menu label[for="tab-h3"],
@@ -301,6 +311,16 @@ nav.top .links a.gh svg { display: block; }
 #tab-h2:checked ~ .pane-h2 { display: block; }
 #tab-h2cs:checked ~ .pane-h2cs { display: block; }
 #tab-h2tls:checked ~ .pane-h2tls { display: block; }
+#tab-pxmatrix:checked ~ .pane-pxmatrix { display: block; }
+#tab-pxh1toh1:checked ~ .pane-pxh1toh1 { display: block; }
+#tab-pxh1toh2:checked ~ .pane-pxh1toh2 { display: block; }
+#tab-pxh1toh3:checked ~ .pane-pxh1toh3 { display: block; }
+#tab-pxh2toh1:checked ~ .pane-pxh2toh1 { display: block; }
+#tab-pxh2toh2:checked ~ .pane-pxh2toh2 { display: block; }
+#tab-pxh2toh3:checked ~ .pane-pxh2toh3 { display: block; }
+#tab-pxh3toh1:checked ~ .pane-pxh3toh1 { display: block; }
+#tab-pxh3toh2:checked ~ .pane-pxh3toh2 { display: block; }
+#tab-pxh3toh3:checked ~ .pane-pxh3toh3 { display: block; }
 #tab-qpipe:checked ~ .pane-qpipe { display: block; }
 #tab-qraw:checked ~ .pane-qraw { display: block; }
 #tab-h3:checked ~ .pane-h3 { display: block; }
@@ -356,6 +376,11 @@ nav.top .links a.gh svg { display: block; }
 }
 .pane .ex-foot b { color: var(--text); }
 
+/* The combination matrix: the row header names the frontend, each cell jumps to that sample. */
+.mx-t { color: var(--text-dim); font-size: 0.82em; }
+.vs td .ex-jump { display: inline-block; padding: 0.1rem 0; }
+.mx-pool { color: var(--text-dim); font-size: 0.88em; }
+
 /* A cross-reference that switches tabs, styled as a link because that is what it behaves like. */
 .ex-jump {
   color: var(--accent-soft);
@@ -404,6 +429,16 @@ nav.top .links a.gh svg { display: block; }
   #tab-h2:checked ~ .ex-menu label[for="tab-h2"],
   #tab-h2cs:checked ~ .ex-menu label[for="tab-h2cs"],
   #tab-h2tls:checked ~ .ex-menu label[for="tab-h2tls"],
+  #tab-pxmatrix:checked ~ .ex-menu label[for="tab-pxmatrix"],
+  #tab-pxh1toh1:checked ~ .ex-menu label[for="tab-pxh1toh1"],
+  #tab-pxh1toh2:checked ~ .ex-menu label[for="tab-pxh1toh2"],
+  #tab-pxh1toh3:checked ~ .ex-menu label[for="tab-pxh1toh3"],
+  #tab-pxh2toh1:checked ~ .ex-menu label[for="tab-pxh2toh1"],
+  #tab-pxh2toh2:checked ~ .ex-menu label[for="tab-pxh2toh2"],
+  #tab-pxh2toh3:checked ~ .ex-menu label[for="tab-pxh2toh3"],
+  #tab-pxh3toh1:checked ~ .ex-menu label[for="tab-pxh3toh1"],
+  #tab-pxh3toh2:checked ~ .ex-menu label[for="tab-pxh3toh2"],
+  #tab-pxh3toh3:checked ~ .ex-menu label[for="tab-pxh3toh3"],
   #tab-qpipe:checked ~ .ex-menu label[for="tab-qpipe"],
   #tab-qraw:checked ~ .ex-menu label[for="tab-qraw"],
   #tab-h3:checked ~ .ex-menu label[for="tab-h3"],

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -221,8 +221,7 @@ nav.top .links a.gh svg { display: block; }
 #tab-redis:checked ~ .ex-menu label[for="tab-redis"],
 #tab-files:checked ~ .ex-menu label[for="tab-files"],
 #tab-tls:checked ~ .ex-menu label[for="tab-tls"],
-#tab-tlspipe:checked ~ .ex-menu label[for="tab-tlspipe"],
-#tab-kestrel:checked ~ .ex-menu label[for="tab-kestrel"] {
+#tab-tlspipe:checked ~ .ex-menu label[for="tab-tlspipe"] {
   color: var(--accent-soft);
   border-left-color: var(--accent-soft);
   background: var(--code-bg);
@@ -311,7 +310,6 @@ nav.top .links a.gh svg { display: block; }
 #tab-files:checked ~ .pane-files { display: block; }
 #tab-tls:checked ~ .pane-tls { display: block; }
 #tab-tlspipe:checked ~ .pane-tlspipe { display: block; }
-#tab-kestrel:checked ~ .pane-kestrel { display: block; }
 .pane pre {
   margin: 0;
   font-size: 0.82rem;   /* smaller than body code: these are whole programs, not fragments */
@@ -414,8 +412,7 @@ nav.top .links a.gh svg { display: block; }
   #tab-redis:checked ~ .ex-menu label[for="tab-redis"],
   #tab-files:checked ~ .ex-menu label[for="tab-files"],
   #tab-tls:checked ~ .ex-menu label[for="tab-tls"],
-  #tab-tlspipe:checked ~ .ex-menu label[for="tab-tlspipe"],
-  #tab-kestrel:checked ~ .ex-menu label[for="tab-kestrel"] {
+  #tab-tlspipe:checked ~ .ex-menu label[for="tab-tlspipe"] {
     border-bottom-color: var(--accent-soft);
   }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,6 +26,8 @@
   <input type="radio" name="mode-tabs" id="tab-shared">
   <input type="radio" name="mode-tabs" id="tab-inc">
   <input type="radio" name="mode-tabs" id="tab-vs">
+  <input type="radio" name="mode-tabs" id="tab-tls">
+  <input type="radio" name="mode-tabs" id="tab-tlspipe">
   <input type="radio" name="mode-tabs" id="tab-h2">
   <input type="radio" name="mode-tabs" id="tab-h2cs">
   <input type="radio" name="mode-tabs" id="tab-h2tls">
@@ -36,9 +38,6 @@
   <input type="radio" name="mode-tabs" id="tab-pg">
   <input type="radio" name="mode-tabs" id="tab-redis">
   <input type="radio" name="mode-tabs" id="tab-files">
-  <input type="radio" name="mode-tabs" id="tab-tls">
-  <input type="radio" name="mode-tabs" id="tab-tlspipe">
-  <input type="radio" name="mode-tabs" id="tab-kestrel">
   <nav class="ex-menu" aria-label="Examples">
     <label class="ex-home" for="tab-none">overview</label>
 
@@ -48,6 +47,8 @@
       <label for="tab-shared">raw &middot; shared ring</label>
       <label for="tab-inc">raw &middot; incremental</label>
       <label for="tab-vs">shared vs incremental</label>
+      <label for="tab-tls">ktls &middot; raw</label>
+      <label for="tab-tlspipe">ktls &middot; pipes</label>
     </details>
 
     <details class="ex-sect">
@@ -74,13 +75,6 @@
       <label for="tab-pg">postgres</label>
       <label for="tab-redis">redis</label>
       <label for="tab-files">files</label>
-    </details>
-
-    <details class="ex-sect">
-      <summary>serving</summary>
-      <label for="tab-tls">ktls &middot; raw</label>
-      <label for="tab-tlspipe">ktls &middot; pipes</label>
-      <label for="tab-kestrel">asp.net</label>
     </details>
   </nav>
 
@@ -118,9 +112,7 @@
 
     <p class="ex-links">
       All of it runs: <a href="https://github.com/MDA2AV/ioxide/tree/main/Playground">Playground</a>
-      is a complete server per file, and
-      <a href="https://github.com/MDA2AV/ioxide/tree/main/Examples.AspNet">Examples.AspNet</a>
-      measures <code>UseIoxide()</code> against stock Kestrel.
+      is a complete server per file, grouped by topic.
     </p>
 
     <p class="ex-hint">Pick an example to see the code</p>
@@ -413,6 +405,232 @@ foreach (Thread t in threads) t.Join();</code></pre>
       routes the right return path internally.
       The pipes tab is API sugar over either mode: the reader owns the carry for you.</p>
     </div>
+  </div>
+  <div class="pane pane-tls">
+    <div class="pane-head">
+      <h3>kTLS</h3>
+      <span class="pane-pkg">ioxide</span>
+    </div>
+<pre><code class="language-csharp">// dotnet add package ioxide      -- TLS ships in the core package
+// Needs the Linux &#x27;tls&#x27; module (sudo modprobe tls), OpenSSL 3, and cert.pem / key.pem.
+using ioxide;
+using ioxide.tls;
+using ioxide.utils;
+
+var config = new ServerConfig
+{
+    ReactorCount = Environment.ProcessorCount,   // one ring per reactor, one reactor per core
+    RingEntries  = 8192,                         // io_uring SQ/CQ depth
+    DualStack    = false,                        // true = one AF_INET6 socket takes v6 + v4-mapped
+
+    // Shared recv ring - the default mode, used while Incremental is null.
+    RecvBufferSize = 32 * 1024,
+    RecvSlots      = 4096,
+
+    Tcp = new TcpOptions
+    {
+        Port             = 8443,
+        ExtraPorts       = [],                   // more listeners; conn.ListenerPort says which
+        ListenBacklog    = 1024,                 // accept queue per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,            // per-connection write buffer
+        PoolMax          = 1024,                 // connection objects recycled per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,   // Segmented = chained slabs, one SENDMSG
+        ZeroCopySend     = false,                // SEND_ZC; only pays off on large responses
+        RecvQueueEntries = 64,                   // per-connection SPSC queue, power of two
+    },
+
+};
+
+ReadOnlyMemory&lt;byte&gt; ok = &quot;HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok&quot;u8.ToArray();
+var threads = new Thread[config.ReactorCount];
+
+for (int id = 0; id &lt; threads.Length; id++)
+{
+    var reactor = new Reactor(id, config);
+
+    reactor.OnStart = r =&gt; TlsService.Start(r, new TlsOptions
+    {
+        CertificatePath = &quot;cert.pem&quot;,
+        KeyPath         = &quot;key.pem&quot;,
+        Alpn            = [&quot;http/1.1&quot;],   // ordered, most preferred first
+    });
+
+    reactor.TcpHandle = async (r, conn) =&gt;
+    {
+        TlsSession? tls = null;
+
+        try
+        {
+            // The OpenSSL handshake is driven over the ring, so it awaits like everything else.
+            // After it, kernel TLS owns transmit: everything below is written as PLAINTEXT.
+            tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
+
+            // A request can ride in with the handshake&#x27;s final flight - answer it first.
+            if (tls.DrainPlaintext().Length &gt; 0)
+            {
+                conn.Write(ok.Span);
+                await conn.FlushAsync();
+            }
+
+            while (true)
+            {
+                RecvSnapshot snapshot = await conn.ReadAsync();
+
+                int got = 0;
+                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                {
+                    if (item.HasBuffer)
+                    {
+                        got += Decrypt(tls, in item);   // only transmit is offloaded
+                        conn.ReturnBuffer(in item);
+                    }
+                }
+
+                if (got &gt; 0)
+                {
+                    conn.Write(ok.Span);   // plaintext in; the kernel produces the records
+                    await conn.FlushAsync();
+                }
+
+                if (snapshot.IsClosed || tls.Closed) return;
+                conn.ResetRead();
+            }
+        }
+        catch (Exception e)
+        {
+            // Handlers run fire-and-forget, so a missing &#x27;tls&#x27; module would vanish silently.
+            Console.Error.WriteLine($&quot;tls: {e.Message}&quot;);
+        }
+        finally
+        {
+            tls?.Dispose();
+            conn.DecRef();
+        }
+    };
+
+    threads[id] = new Thread(reactor.Run) { Name = $&quot;reactor-{id}&quot; };
+    threads[id].Start();
+}
+
+Console.WriteLine($&quot;TLS on :{config.Tcp.Port} (kTLS transmit offload)&quot;);
+foreach (Thread t in threads) t.Join();
+
+static unsafe int Decrypt(TlsSession tls, in SpscRecvRing.Item item)
+{
+    fixed (byte* cipher = item.AsSpan())
+    {
+        return tls.Decrypt(cipher, item.AsSpan().Length).Length;
+    }
+}</code></pre>
+  </div>
+
+  <div class="pane pane-tlspipe">
+    <div class="pane-head">
+      <h3>kTLS &middot; pipes</h3>
+      <span class="pane-pkg">ioxide</span>
+    </div>
+<pre><code class="language-csharp">// dotnet add package ioxide      -- TLS ships in the core package
+// Needs the Linux &#x27;tls&#x27; module (sudo modprobe tls), OpenSSL 3, and cert.pem / key.pem.
+using System.IO.Pipelines;
+using ioxide;
+using ioxide.tls;
+
+var config = new ServerConfig
+{
+    ReactorCount = Environment.ProcessorCount,
+    RecvBufferSize = 32 * 1024,
+    RecvSlots      = 4096,
+    Tcp = new TcpOptions { Port = 8443 },
+};
+
+ReadOnlyMemory&lt;byte&gt; ok = &quot;HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok&quot;u8.ToArray();
+var threads = new Thread[config.ReactorCount];
+
+for (int id = 0; id &lt; threads.Length; id++)
+{
+    var reactor = new Reactor(id, config);
+
+    reactor.OnStart = r =&gt; TlsService.Start(r, new TlsOptions
+    {
+        CertificatePath = &quot;cert.pem&quot;,
+        KeyPath         = &quot;key.pem&quot;,
+        Alpn            = [&quot;http/1.1&quot;],   // ordered, most preferred first
+    });
+
+    reactor.TcpHandle = async (r, conn) =&gt;
+    {
+        TlsSession? tls = null;
+
+        try
+        {
+            // The handshake first - it drives the connection directly, before the pipes attach.
+            tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
+
+            // Pipes attach AFTER the handshake. From here the connection is just bytes again:
+            // ciphertext arriving, plaintext leaving (kernel TLS produces the records on send).
+            var reader = new TcpConnectionPipeReader(conn);
+            var writer = new TcpConnectionPipeWriter(conn);
+
+            // A request can ride in with the handshake&#x27;s final flight - answer it first.
+            if (tls.DrainPlaintext().Length &gt; 0)
+            {
+                ok.Span.CopyTo(writer.GetSpan(ok.Length));
+                writer.Advance(ok.Length);
+                await writer.FlushAsync();
+            }
+
+            while (true)
+            {
+                ReadResult result = await reader.ReadAsync();
+
+                // The pipe hands CIPHERTEXT - only transmit is offloaded - so decrypt each
+                // segment as it is consumed.
+                int got = 0;
+                foreach (ReadOnlyMemory&lt;byte&gt; segment in result.Buffer)
+                {
+                    got += Decrypt(tls, segment.Span);
+                }
+                reader.AdvanceTo(result.Buffer.End);
+
+                if (got &gt; 0)
+                {
+                    // The write side is the plain pipes path, untouched: plaintext into the
+                    // slab, one flush - the kernel encrypts on send.
+                    ok.Span.CopyTo(writer.GetSpan(ok.Length));
+                    writer.Advance(ok.Length);
+                    await writer.FlushAsync();
+                }
+
+                if (result.IsCompleted || tls.Closed) return;
+            }
+        }
+        catch (Exception e)
+        {
+            // Handlers run fire-and-forget, so a missing &#x27;tls&#x27; module would vanish silently.
+            Console.Error.WriteLine($&quot;tls: {e.Message}&quot;);
+        }
+        finally
+        {
+            tls?.Dispose();
+            conn.DecRef();
+        }
+    };
+
+    threads[id] = new Thread(reactor.Run) { Name = $&quot;reactor-{id}&quot; };
+    threads[id].Start();
+}
+
+Console.WriteLine($&quot;TLS on :{config.Tcp.Port} (kTLS transmit offload, pipes surface)&quot;);
+foreach (Thread t in threads) t.Join();
+
+static unsafe int Decrypt(TlsSession tls, ReadOnlySpan&lt;byte&gt; ciphertext)
+{
+    fixed (byte* cipher = ciphertext)
+    {
+        return tls.Decrypt(cipher, ciphertext.Length).Length;
+    }
+}
+</code></pre>
   </div>
   <div class="pane pane-h2">
     <div class="pane-head">
@@ -1373,254 +1591,6 @@ static bool TryReadTarget(ReadOnlySpan&lt;byte&gt; request, out ReadOnlySpan&lt;
 
     return true;
 }</code></pre>
-  </div>
-  <div class="pane pane-tls">
-    <div class="pane-head">
-      <h3>kTLS</h3>
-      <span class="pane-pkg">ioxide</span>
-    </div>
-<pre><code class="language-csharp">// dotnet add package ioxide      -- TLS ships in the core package
-// Needs the Linux &#x27;tls&#x27; module (sudo modprobe tls), OpenSSL 3, and cert.pem / key.pem.
-using ioxide;
-using ioxide.tls;
-using ioxide.utils;
-
-var config = new ServerConfig
-{
-    ReactorCount = Environment.ProcessorCount,   // one ring per reactor, one reactor per core
-    RingEntries  = 8192,                         // io_uring SQ/CQ depth
-    DualStack    = false,                        // true = one AF_INET6 socket takes v6 + v4-mapped
-
-    // Shared recv ring - the default mode, used while Incremental is null.
-    RecvBufferSize = 32 * 1024,
-    RecvSlots      = 4096,
-
-    Tcp = new TcpOptions
-    {
-        Port             = 8443,
-        ExtraPorts       = [],                   // more listeners; conn.ListenerPort says which
-        ListenBacklog    = 1024,                 // accept queue per SO_REUSEPORT listener
-        WriteSlabSize    = 16 * 1024,            // per-connection write buffer
-        PoolMax          = 1024,                 // connection objects recycled per reactor
-        WriteOverflow    = WriteOverflowStrategy.Grow,   // Segmented = chained slabs, one SENDMSG
-        ZeroCopySend     = false,                // SEND_ZC; only pays off on large responses
-        RecvQueueEntries = 64,                   // per-connection SPSC queue, power of two
-    },
-
-};
-
-ReadOnlyMemory&lt;byte&gt; ok = &quot;HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok&quot;u8.ToArray();
-var threads = new Thread[config.ReactorCount];
-
-for (int id = 0; id &lt; threads.Length; id++)
-{
-    var reactor = new Reactor(id, config);
-
-    reactor.OnStart = r =&gt; TlsService.Start(r, new TlsOptions
-    {
-        CertificatePath = &quot;cert.pem&quot;,
-        KeyPath         = &quot;key.pem&quot;,
-        Alpn            = [&quot;http/1.1&quot;],   // ordered, most preferred first
-    });
-
-    reactor.TcpHandle = async (r, conn) =&gt;
-    {
-        TlsSession? tls = null;
-
-        try
-        {
-            // The OpenSSL handshake is driven over the ring, so it awaits like everything else.
-            // After it, kernel TLS owns transmit: everything below is written as PLAINTEXT.
-            tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
-
-            // A request can ride in with the handshake&#x27;s final flight - answer it first.
-            if (tls.DrainPlaintext().Length &gt; 0)
-            {
-                conn.Write(ok.Span);
-                await conn.FlushAsync();
-            }
-
-            while (true)
-            {
-                RecvSnapshot snapshot = await conn.ReadAsync();
-
-                int got = 0;
-                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
-                {
-                    if (item.HasBuffer)
-                    {
-                        got += Decrypt(tls, in item);   // only transmit is offloaded
-                        conn.ReturnBuffer(in item);
-                    }
-                }
-
-                if (got &gt; 0)
-                {
-                    conn.Write(ok.Span);   // plaintext in; the kernel produces the records
-                    await conn.FlushAsync();
-                }
-
-                if (snapshot.IsClosed || tls.Closed) return;
-                conn.ResetRead();
-            }
-        }
-        catch (Exception e)
-        {
-            // Handlers run fire-and-forget, so a missing &#x27;tls&#x27; module would vanish silently.
-            Console.Error.WriteLine($&quot;tls: {e.Message}&quot;);
-        }
-        finally
-        {
-            tls?.Dispose();
-            conn.DecRef();
-        }
-    };
-
-    threads[id] = new Thread(reactor.Run) { Name = $&quot;reactor-{id}&quot; };
-    threads[id].Start();
-}
-
-Console.WriteLine($&quot;TLS on :{config.Tcp.Port} (kTLS transmit offload)&quot;);
-foreach (Thread t in threads) t.Join();
-
-static unsafe int Decrypt(TlsSession tls, in SpscRecvRing.Item item)
-{
-    fixed (byte* cipher = item.AsSpan())
-    {
-        return tls.Decrypt(cipher, item.AsSpan().Length).Length;
-    }
-}</code></pre>
-  </div>
-
-  <div class="pane pane-tlspipe">
-    <div class="pane-head">
-      <h3>kTLS &middot; pipes</h3>
-      <span class="pane-pkg">ioxide</span>
-    </div>
-<pre><code class="language-csharp">// dotnet add package ioxide      -- TLS ships in the core package
-// Needs the Linux &#x27;tls&#x27; module (sudo modprobe tls), OpenSSL 3, and cert.pem / key.pem.
-using System.IO.Pipelines;
-using ioxide;
-using ioxide.tls;
-
-var config = new ServerConfig
-{
-    ReactorCount = Environment.ProcessorCount,
-    RecvBufferSize = 32 * 1024,
-    RecvSlots      = 4096,
-    Tcp = new TcpOptions { Port = 8443 },
-};
-
-ReadOnlyMemory&lt;byte&gt; ok = &quot;HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok&quot;u8.ToArray();
-var threads = new Thread[config.ReactorCount];
-
-for (int id = 0; id &lt; threads.Length; id++)
-{
-    var reactor = new Reactor(id, config);
-
-    reactor.OnStart = r =&gt; TlsService.Start(r, new TlsOptions
-    {
-        CertificatePath = &quot;cert.pem&quot;,
-        KeyPath         = &quot;key.pem&quot;,
-        Alpn            = [&quot;http/1.1&quot;],   // ordered, most preferred first
-    });
-
-    reactor.TcpHandle = async (r, conn) =&gt;
-    {
-        TlsSession? tls = null;
-
-        try
-        {
-            // The handshake first - it drives the connection directly, before the pipes attach.
-            tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
-
-            // Pipes attach AFTER the handshake. From here the connection is just bytes again:
-            // ciphertext arriving, plaintext leaving (kernel TLS produces the records on send).
-            var reader = new TcpConnectionPipeReader(conn);
-            var writer = new TcpConnectionPipeWriter(conn);
-
-            // A request can ride in with the handshake&#x27;s final flight - answer it first.
-            if (tls.DrainPlaintext().Length &gt; 0)
-            {
-                ok.Span.CopyTo(writer.GetSpan(ok.Length));
-                writer.Advance(ok.Length);
-                await writer.FlushAsync();
-            }
-
-            while (true)
-            {
-                ReadResult result = await reader.ReadAsync();
-
-                // The pipe hands CIPHERTEXT - only transmit is offloaded - so decrypt each
-                // segment as it is consumed.
-                int got = 0;
-                foreach (ReadOnlyMemory&lt;byte&gt; segment in result.Buffer)
-                {
-                    got += Decrypt(tls, segment.Span);
-                }
-                reader.AdvanceTo(result.Buffer.End);
-
-                if (got &gt; 0)
-                {
-                    // The write side is the plain pipes path, untouched: plaintext into the
-                    // slab, one flush - the kernel encrypts on send.
-                    ok.Span.CopyTo(writer.GetSpan(ok.Length));
-                    writer.Advance(ok.Length);
-                    await writer.FlushAsync();
-                }
-
-                if (result.IsCompleted || tls.Closed) return;
-            }
-        }
-        catch (Exception e)
-        {
-            // Handlers run fire-and-forget, so a missing &#x27;tls&#x27; module would vanish silently.
-            Console.Error.WriteLine($&quot;tls: {e.Message}&quot;);
-        }
-        finally
-        {
-            tls?.Dispose();
-            conn.DecRef();
-        }
-    };
-
-    threads[id] = new Thread(reactor.Run) { Name = $&quot;reactor-{id}&quot; };
-    threads[id].Start();
-}
-
-Console.WriteLine($&quot;TLS on :{config.Tcp.Port} (kTLS transmit offload, pipes surface)&quot;);
-foreach (Thread t in threads) t.Join();
-
-static unsafe int Decrypt(TlsSession tls, ReadOnlySpan&lt;byte&gt; ciphertext)
-{
-    fixed (byte* cipher = ciphertext)
-    {
-        return tls.Decrypt(cipher, ciphertext.Length).Length;
-    }
-}
-</code></pre>
-  </div>
-  <div class="pane pane-kestrel">
-    <div class="pane-head">
-      <h3>ASP.NET Core</h3>
-      <span class="pane-pkg">ioxide.Kestrel</span>
-    </div>
-<pre><code class="language-csharp">// dotnet new web &amp;&amp; dotnet add package ioxide.Kestrel
-using ioxide.Kestrel;
-
-var builder = WebApplication.CreateBuilder(args);
-
-// The whole change: one ring per core, SO_REUSEPORT load-balanced, with Kestrel&#x27;s request loop
-// pinned to the reactor thread. Endpoints, middleware and DI are untouched.
-builder.WebHost.UseIoxide(o =&gt; o.ReactorCount = Environment.ProcessorCount);
-builder.WebHost.ConfigureKestrel(o =&gt; o.ListenAnyIP(8080));
-
-var app = builder.Build();
-
-app.MapGet(&quot;/&quot;, () =&gt; &quot;hello from io_uring&quot;);
-app.MapGet(&quot;/plaintext&quot;, () =&gt; Results.Text(&quot;Hello, World!&quot;));
-
-app.Run();</code></pre>
   </div>
 </div>
 </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,10 +31,20 @@
   <input type="radio" name="mode-tabs" id="tab-h2">
   <input type="radio" name="mode-tabs" id="tab-h2cs">
   <input type="radio" name="mode-tabs" id="tab-h2tls">
+  <input type="radio" name="mode-tabs" id="tab-pxmatrix">
+  <input type="radio" name="mode-tabs" id="tab-pxh1toh1">
+  <input type="radio" name="mode-tabs" id="tab-pxh1toh2">
+  <input type="radio" name="mode-tabs" id="tab-pxh1toh3">
+  <input type="radio" name="mode-tabs" id="tab-pxh2toh1">
+  <input type="radio" name="mode-tabs" id="tab-pxh2toh2">
+  <input type="radio" name="mode-tabs" id="tab-pxh2toh3">
+  <input type="radio" name="mode-tabs" id="tab-pxh3toh1">
+  <input type="radio" name="mode-tabs" id="tab-pxh3toh2">
+  <input type="radio" name="mode-tabs" id="tab-pxh3toh3">
+  <input type="radio" name="mode-tabs" id="tab-http">
   <input type="radio" name="mode-tabs" id="tab-qpipe">
   <input type="radio" name="mode-tabs" id="tab-qraw">
   <input type="radio" name="mode-tabs" id="tab-h3">
-  <input type="radio" name="mode-tabs" id="tab-http">
   <input type="radio" name="mode-tabs" id="tab-pg">
   <input type="radio" name="mode-tabs" id="tab-redis">
   <input type="radio" name="mode-tabs" id="tab-files">
@@ -59,6 +69,21 @@
     </details>
 
     <details class="ex-sect">
+      <summary>proxy</summary>
+      <label for="tab-pxmatrix">the nine combinations</label>
+      <label for="tab-pxh1toh1">h1 &rarr; h1</label>
+      <label for="tab-pxh1toh2">h1 &rarr; h2</label>
+      <label for="tab-pxh1toh3">h1 &rarr; h3</label>
+      <label for="tab-pxh2toh1">h2 &rarr; h1</label>
+      <label for="tab-pxh2toh2">h2 &rarr; h2</label>
+      <label for="tab-pxh2toh3">h2 &rarr; h3</label>
+      <label for="tab-pxh3toh1">h3 &rarr; h1</label>
+      <label for="tab-pxh3toh2">h3 &rarr; h2</label>
+      <label for="tab-pxh3toh3">h3 &rarr; h3</label>
+      <label for="tab-http">auto &middot; alt-svc</label>
+    </details>
+
+    <details class="ex-sect">
       <summary>quic</summary>
       <label for="tab-qpipe">pipes</label>
       <label for="tab-qraw">raw</label>
@@ -71,7 +96,6 @@
 
     <details class="ex-sect">
       <summary>clients</summary>
-      <label for="tab-http">http</label>
       <label for="tab-pg">postgres</label>
       <label for="tab-redis">redis</label>
       <label for="tab-files">files</label>
@@ -1102,6 +1126,1023 @@ Console.WriteLine($&quot;HTTP/3 on udp :8443 (ngtcp2 {QuicEngine.NativeVersion()
 foreach (Thread t in threads) t.Join();</code></pre>
   </div>
   
+  <div class="pane pane-pxmatrix">
+    <div class="pane-head">
+      <h3>The nine combinations</h3>
+      <span class="pane-pkg">ioxide + ioxide.httpclient</span>
+    </div>
+    <div class="vs">
+      <p>A reverse proxy is two hops, and in ioxide each one is a <em>type</em>. The frontend
+      protocol is the server you hand the connection to; the upstream protocol is the pool you
+      call. Nothing else changes between the nine samples below - not the reactor, not the
+      config, not the handler's shape.</p>
+      <table>
+        <tr><th></th><th>upstream h1</th><th>upstream h2</th><th>upstream h3</th></tr>
+        <tr><td><b>frontend h1</b><br><span class="mx-t">a raw TCP loop</span></td>
+            <td><label for="tab-pxh1toh1" class="ex-jump">h1 &rarr; h1</label></td>
+            <td><label for="tab-pxh1toh2" class="ex-jump">h1 &rarr; h2</label></td>
+            <td><label for="tab-pxh1toh3" class="ex-jump">h1 &rarr; h3</label></td></tr>
+        <tr><td><b>frontend h2</b><br><span class="mx-t"><code>Nghttp2Connection</code></span></td>
+            <td><label for="tab-pxh2toh1" class="ex-jump">h2 &rarr; h1</label></td>
+            <td><label for="tab-pxh2toh2" class="ex-jump">h2 &rarr; h2</label></td>
+            <td><label for="tab-pxh2toh3" class="ex-jump">h2 &rarr; h3</label></td></tr>
+        <tr><td><b>frontend h3</b><br><span class="mx-t"><code>Nghttp3Connection</code></span></td>
+            <td><label for="tab-pxh3toh1" class="ex-jump">h3 &rarr; h1</label></td>
+            <td><label for="tab-pxh3toh2" class="ex-jump">h3 &rarr; h2</label></td>
+            <td><label for="tab-pxh3toh3" class="ex-jump">h3 &rarr; h3</label></td></tr>
+        <tr><td colspan="4" class="mx-pool"><code>HttpClientPool</code> &middot;
+            <code>Http2ClientPool</code> &middot; <code>Http3ClientPool</code> - all three expose the
+            same <code>SendAsync(HttpClientRequest)</code>, so swapping the upstream is swapping a
+            declaration.</td></tr>
+      </table>
+      <p><b>Both hops ride one ring.</b> The inbound connection and the outbound call are
+      completions on the same reactor, and each <code>await</code> resumes inline on the thread
+      that owns them - a proxied request never leaves the core it arrived on, and the pool needs no
+      lock because only one thread can ever touch it.</p>
+      <p><b>The pool sizes differ, and only for one reason.</b> h2 and h3 multiplex, so
+      <code>PoolSize = 1</code> carries every concurrent request on a single connection. h1 does
+      not, so an h1 upstream needs a connection per in-flight request - which is why
+      <b>h2 &rarr; h1</b> is the one sample here that sizes its pool for concurrency.</p>
+      <p>Every pane is the corresponding
+      <a href="https://github.com/MDA2AV/ioxide/tree/main/Playground/Proxy">Playground/Proxy</a>
+      program, whole, with the sample's environment-variable defaults inlined. None of them filter
+      hop-by-hop headers; a production proxy must, and <code>Connection</code>,
+      <code>Keep-Alive</code> and <code>Transfer-Encoding</code> are protocol errors to forward
+      into h2 or h3 at all.</p>
+    </div>
+  </div>
+  <div class="pane pane-pxh1toh1">
+    <div class="pane-head">
+      <h3>HTTP/1.1 in &middot; HTTP/1.1 out</h3>
+      <span class="pane-pkg">ioxide + ioxide.httpclient</span>
+    </div>
+<pre><code class="language-csharp">// dotnet add package ioxide ioxide.httpclient
+//   PLAYGROUND_PORT=8081 dotnet run --project Playground/Tcp/Raw   # the origin
+//   curl http://127.0.0.1:8080/
+
+using System.Text;
+using ioxide;
+using ioxide.httpclient;
+using ioxide.utils;
+
+var config = new ServerConfig
+{
+    ReactorCount = Environment.ProcessorCount,
+    Tcp = new TcpOptions
+    {
+        Port = 8080,
+    },
+};
+
+var upstream = new HttpClientOptions
+{
+    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
+    Port = 8081,
+    PoolSize = 8,         // keep-alive connections per reactor
+};
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i &lt; threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    // Opened on the reactor thread, so the outbound sockets ride this reactor&#x27;s ring too.
+    reactor.OnStart = r =&gt; HttpClientPool.Start(r, upstream);
+
+    reactor.TcpHandle = async (r, conn) =&gt;
+    {
+        HttpClientPool client = r.GetService&lt;HttpClientPool&gt;();
+
+        try
+        {
+            while (true)
+            {
+                RecvSnapshot snapshot = await conn.ReadAsync();
+
+                string path = &quot;/&quot;;
+                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                {
+                    if (item.HasBuffer)
+                    {
+                        if (TryReadTarget(item.AsSpan(), out ReadOnlySpan&lt;byte&gt; target))
+                        {
+                            path = Encoding.ASCII.GetString(target);
+                        }
+                        conn.ReturnBuffer(in item);
+                    }
+                }
+
+                try
+                {
+                    // The outbound call. Same ring, same thread - this await resumes inline.
+                    // The response owns its bytes, so dispose it when you&#x27;re done with them.
+                    using HttpClientResponse response = await client.GetAsync(path);
+
+                    conn.Write(Encoding.ASCII.GetBytes(
+                        $&quot;HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n&quot;));
+                    conn.Write(response.Body.Span);   // bytes straight through, no decode
+                }
+                catch (HttpClientException e)
+                {
+                    // A dead origin surfaces here rather than hanging: the pool bounds the whole
+                    // acquire, so you get an exception and can answer with a 502.
+                    byte[] message = Encoding.ASCII.GetBytes($&quot;upstream: {e.Message}&quot;);
+                    conn.Write(Encoding.ASCII.GetBytes(
+                        $&quot;HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n&quot;));
+                    conn.Write(message);
+                }
+
+                await conn.FlushAsync();
+
+                if (snapshot.IsClosed) return;
+                conn.ResetRead();
+            }
+        }
+        finally
+        {
+            conn.DecRef();
+        }
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $&quot;reactor-{i}&quot; };
+    threads[i].Start();
+}
+
+Console.WriteLine($&quot;[proxy h1-&gt;h1] {config.ReactorCount} reactors on :{config.Tcp.Port} &quot;
+                + $&quot;-&gt; {upstream.Host}:{upstream.Port}, {upstream.PoolSize} connections each&quot;);
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}
+
+static bool TryReadTarget(ReadOnlySpan&lt;byte&gt; request, out ReadOnlySpan&lt;byte&gt; target)
+{
+    target = default;
+
+    int firstSpace = request.IndexOf((byte)&#x27; &#x27;);
+    if (firstSpace &lt; 0) return false;
+
+    ReadOnlySpan&lt;byte&gt; afterMethod = request[(firstSpace + 1)..];
+    int secondSpace = afterMethod.IndexOf((byte)&#x27; &#x27;);
+    if (secondSpace &lt; 0) return false;
+
+    target = afterMethod[..secondSpace];
+
+    int query = target.IndexOf((byte)&#x27;?&#x27;);
+    if (query &gt;= 0) target = target[..query];
+
+    return true;
+}</code></pre>
+    <p class="ex-foot">The baseline, and the one to read first. Everything else in this section is this program with one type changed.</p>
+  </div>
+  <div class="pane pane-pxh1toh2">
+    <div class="pane-head">
+      <h3>HTTP/1.1 in &middot; HTTP/2 out</h3>
+      <span class="pane-pkg">ioxide + ioxide.httpclient</span>
+    </div>
+<pre><code class="language-csharp">// dotnet add package ioxide ioxide.httpclient
+//   PLAYGROUND_PORT=8081 dotnet run --project Playground/Http2/Nghttp2
+//   curl http://127.0.0.1:8080/
+
+using System.Text;
+using ioxide;
+using ioxide.httpclient;
+using ioxide.utils;
+
+var config = new ServerConfig
+{
+    ReactorCount = Environment.ProcessorCount,
+    Tcp = new TcpOptions
+    {
+        Port = 8080,
+    },
+};
+
+var upstream = new Http2ClientOptions
+{
+    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
+    Port = 8081,
+    PoolSize = 1,         // h2 multiplexes: one connection carries all
+};
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i &lt; threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    // Opened on the reactor thread, so the upstream socket rides this reactor&#x27;s ring too.
+    reactor.OnStart = r =&gt; Http2ClientPool.Start(r, upstream);
+
+    reactor.TcpHandle = async (r, conn) =&gt;
+    {
+        Http2ClientPool client = r.GetService&lt;Http2ClientPool&gt;();
+
+        try
+        {
+            while (true)
+            {
+                RecvSnapshot snapshot = await conn.ReadAsync();
+
+                string path = &quot;/&quot;;
+                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                {
+                    if (item.HasBuffer)
+                    {
+                        if (TryReadTarget(item.AsSpan(), out ReadOnlySpan&lt;byte&gt; target))
+                        {
+                            path = Encoding.ASCII.GetString(target);
+                        }
+                        conn.ReturnBuffer(in item);
+                    }
+                }
+
+                try
+                {
+                    // h1 request in, h2 stream out - same ring, same thread, inline resume.
+                    using HttpClientResponse response = await client.GetAsync(path);
+
+                    conn.Write(Encoding.ASCII.GetBytes(
+                        $&quot;HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n&quot;));
+                    conn.Write(response.Body.Span);   // bytes straight through, no decode
+                }
+                catch (Exception e)
+                {
+                    byte[] message = Encoding.ASCII.GetBytes($&quot;upstream: {e.Message}&quot;);
+                    conn.Write(Encoding.ASCII.GetBytes(
+                        $&quot;HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n&quot;));
+                    conn.Write(message);
+                }
+
+                await conn.FlushAsync();
+
+                if (snapshot.IsClosed) return;
+                conn.ResetRead();
+            }
+        }
+        finally
+        {
+            conn.DecRef();
+        }
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $&quot;reactor-{i}&quot; };
+    threads[i].Start();
+}
+
+Console.WriteLine($&quot;[proxy h1-&gt;h2] {config.ReactorCount} reactors on :{config.Tcp!.Port} &quot;
+                + $&quot;-&gt; h2c {upstream.Host}:{upstream.Port}, {upstream.PoolSize} connection(s) each&quot;);
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}
+
+// &quot;GET /sleep?x=1 HTTP/1.1&quot; -&gt; &quot;/sleep&quot;. Your framework of choice would do this for you; ioxide
+// deliberately doesn&#x27;t, so here it is in full.
+static bool TryReadTarget(ReadOnlySpan&lt;byte&gt; request, out ReadOnlySpan&lt;byte&gt; target)
+{
+    target = default;
+
+    int firstSpace = request.IndexOf((byte)&#x27; &#x27;);
+    if (firstSpace &lt; 0) return false;
+
+    ReadOnlySpan&lt;byte&gt; afterMethod = request[(firstSpace + 1)..];
+    int secondSpace = afterMethod.IndexOf((byte)&#x27; &#x27;);
+    if (secondSpace &lt; 0) return false;
+
+    target = afterMethod[..secondSpace];
+
+    int query = target.IndexOf((byte)&#x27;?&#x27;);
+    if (query &gt;= 0) target = target[..query];
+
+    return true;
+}</code></pre>
+    <p class="ex-foot">Identical to <b>h1 &rarr; h1</b> above except for the pool type and its size. h1 needs an upstream connection per in-flight request; h2 multiplexes, so <code>PoolSize = 1</code> carries every concurrent request on one socket.</p>
+  </div>
+  <div class="pane pane-pxh1toh3">
+    <div class="pane-head">
+      <h3>HTTP/1.1 in &middot; HTTP/3 out</h3>
+      <span class="pane-pkg">ioxide + ioxide.httpclient</span>
+    </div>
+<pre><code class="language-csharp">// dotnet add package ioxide ioxide.httpclient
+//   dotnet run --project Playground/Http3/Nghttp3         # h3 origin on udp :8443
+//   curl http://127.0.0.1:8080/
+
+using System.Text;
+using ioxide;
+using ioxide.httpclient;
+using ioxide.utils;
+
+var config = new ServerConfig
+{
+    ReactorCount = Environment.ProcessorCount,
+    Tcp = new TcpOptions
+    {
+        Port = 8080,
+    },
+};
+
+var upstream = new Http3ClientOptions
+{
+    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
+    Port = 8443,         // the upstream&#x27;s QUIC (UDP) port
+    ServerName = &quot;localhost&quot;,
+    PoolSize = 1,         // h3 multiplexes: one connection carries all
+};
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i &lt; threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    // Opening the pool here is what makes the reactor grow its client-side QUIC transport: an
+    // ephemeral UDP socket, armed on this ring, shared by every upstream connection.
+    reactor.OnStart = r =&gt; Http3ClientPool.Start(r, upstream);
+
+    reactor.TcpHandle = async (r, conn) =&gt;
+    {
+        Http3ClientPool client = r.GetService&lt;Http3ClientPool&gt;();
+
+        try
+        {
+            while (true)
+            {
+                RecvSnapshot snapshot = await conn.ReadAsync();
+
+                string path = &quot;/&quot;;
+                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                {
+                    if (item.HasBuffer)
+                    {
+                        if (TryReadTarget(item.AsSpan(), out ReadOnlySpan&lt;byte&gt; target))
+                        {
+                            path = Encoding.ASCII.GetString(target);
+                        }
+                        conn.ReturnBuffer(in item);
+                    }
+                }
+
+                try
+                {
+                    // h1 request in, h3 request out - same ring, same thread, inline resume.
+                    using HttpClientResponse response = await client.GetAsync(path);
+
+                    conn.Write(Encoding.ASCII.GetBytes(
+                        $&quot;HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n&quot;));
+                    conn.Write(response.Body.Span);   // bytes straight through, no decode
+                }
+                catch (Exception e)
+                {
+                    byte[] message = Encoding.ASCII.GetBytes($&quot;upstream: {e.Message}&quot;);
+                    conn.Write(Encoding.ASCII.GetBytes(
+                        $&quot;HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n&quot;));
+                    conn.Write(message);
+                }
+
+                await conn.FlushAsync();
+
+                if (snapshot.IsClosed) return;
+                conn.ResetRead();
+            }
+        }
+        finally
+        {
+            conn.DecRef();
+        }
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $&quot;reactor-{i}&quot; };
+    threads[i].Start();
+}
+
+Console.WriteLine($&quot;[proxy h1-&gt;h3] {config.ReactorCount} reactors on :{config.Tcp!.Port} &quot;
+                + $&quot;-&gt; h3 {upstream.Host}:{upstream.Port} (client-only QUIC, ephemeral port)&quot;);
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}
+
+// &quot;GET /sleep?x=1 HTTP/1.1&quot; -&gt; &quot;/sleep&quot;. Your framework of choice would do this for you; ioxide
+// deliberately doesn&#x27;t, so here it is in full.
+static bool TryReadTarget(ReadOnlySpan&lt;byte&gt; request, out ReadOnlySpan&lt;byte&gt; target)
+{
+    target = default;
+
+    int firstSpace = request.IndexOf((byte)&#x27; &#x27;);
+    if (firstSpace &lt; 0) return false;
+
+    ReadOnlySpan&lt;byte&gt; afterMethod = request[(firstSpace + 1)..];
+    int secondSpace = afterMethod.IndexOf((byte)&#x27; &#x27;);
+    if (secondSpace &lt; 0) return false;
+
+    target = afterMethod[..secondSpace];
+
+    int query = target.IndexOf((byte)&#x27;?&#x27;);
+    if (query &gt;= 0) target = target[..query];
+
+    return true;
+}</code></pre>
+    <p class="ex-foot">Note what the config does <em>not</em> contain: no <code>Quic</code>, no UDP ports, no certificate. Being an HTTP/3 <em>client</em> requires no HTTP/3 server - the first connect opens an ephemeral UDP socket on this reactor's ring and replies route back by connection ID.</p>
+  </div>
+  <div class="pane pane-pxh2toh1">
+    <div class="pane-head">
+      <h3>HTTP/2 in &middot; HTTP/1.1 out</h3>
+      <span class="pane-pkg">ioxide + ioxide.nghttp2 + ioxide.httpclient</span>
+    </div>
+<pre><code class="language-csharp">// dotnet add package ioxide ioxide.nghttp2 ioxide.httpclient
+//   PLAYGROUND_PORT=8081 dotnet run --project Playground/Tcp/Raw   # the origin
+//   curl --http2-prior-knowledge http://127.0.0.1:8080/
+
+using System.Text;
+using ioxide;
+using ioxide.httpclient;
+using ioxide.nghttp2;
+
+var config = new ServerConfig
+{
+    ReactorCount = Environment.ProcessorCount,
+    Tcp = new TcpOptions
+    {
+        Port = 8080,
+    },
+};
+
+var upstream = new HttpClientOptions
+{
+    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
+    Port = 8081,
+    PoolSize = 32,        // h1 has no multiplexing: size for concurrency
+};
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i &lt; threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    // The pool&#x27;s connections belong to THIS reactor&#x27;s ring - one pool per reactor, no locks.
+    reactor.OnStart = r =&gt; HttpClientPool.Start(r, upstream);
+
+    reactor.TcpHandle = async (r, conn) =&gt;
+    {
+        HttpClientPool client = r.GetService&lt;HttpClientPool&gt;();
+
+        try
+        {
+            // Buffered + async: each stream dispatches with its body assembled, and the handler
+            // may await - the upstream round trip resumes inline on this reactor. Concurrent
+            // streams interleave here, which is exactly why the h1 pool has to be deep.
+            await new Nghttp2Connection(conn).RunBufferedAsync(async request =&gt;
+            {
+                try
+                {
+                    // Method, path and body forward as the bytes they already are: h2 decoded
+                    // them out of HPACK, and the h1 client writes them back out as a request line.
+                    using HttpClientResponse response = await client.SendAsync(new HttpClientRequest(
+                        request.Method, request.Path) { Body = request.Body });
+
+                    // Copy before Dispose: the response arena is freed then, and nghttp2 copies
+                    // the h2 response only AFTER this handler returns. A real proxy would also
+                    // drop hop-by-hop headers - Connection, Keep-Alive, Transfer-Encoding are all
+                    // illegal in h2 and would be a protocol error to forward.
+                    var proxied = new Nghttp2Response
+                    {
+                        Status = response.Status,
+                        Body = response.Body.ToArray(),
+                    };
+                    if (response.TryGetHeader(&quot;content-type&quot;u8, out ReadOnlyMemory&lt;byte&gt; contentType))
+                    {
+                        proxied.Headers.Add(&quot;content-type&quot;u8.ToArray(), contentType.ToArray());
+                    }
+                    return proxied;
+                }
+                catch (Exception e)
+                {
+                    // Upstream down is a gateway error on this stream, not a dead h2 connection:
+                    // every other stream on it keeps working.
+                    return new Nghttp2Response
+                    {
+                        Status = 502,
+                        Body = Encoding.ASCII.GetBytes($&quot;upstream failed: {e.Message}\n&quot;),
+                    };
+                }
+            });
+        }
+        finally
+        {
+            conn.DecRef();
+        }
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $&quot;reactor-{i}&quot; };
+    threads[i].Start();
+}
+
+Console.WriteLine($&quot;[proxy h2-&gt;h1] {config.ReactorCount} reactors, h2c on :{config.Tcp!.Port} &quot;
+                + $&quot;-&gt; http/1.1 {upstream.Host}:{upstream.Port}, {upstream.PoolSize} connections each&quot;);
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}</code></pre>
+    <p class="ex-foot">The classic edge: clients get multiplexing and header compression, the origin keeps speaking what it already speaks. The one combination here whose pool must size for concurrency - a hundred h2 streams need a hundred h1 connections, because h1 has no multiplexing to borrow.</p>
+  </div>
+  <div class="pane pane-pxh2toh2">
+    <div class="pane-head">
+      <h3>HTTP/2 in &middot; HTTP/2 out</h3>
+      <span class="pane-pkg">ioxide + ioxide.nghttp2 + ioxide.httpclient</span>
+    </div>
+<pre><code class="language-csharp">// dotnet add package ioxide ioxide.nghttp2 ioxide.httpclient
+//   PLAYGROUND_PORT=8081 dotnet run --project Playground/Http2/Nghttp2
+//   curl --http2-prior-knowledge http://127.0.0.1:8080/
+
+using System.Text;
+using ioxide;
+using ioxide.httpclient;
+using ioxide.nghttp2;
+
+var config = new ServerConfig
+{
+    ReactorCount = Environment.ProcessorCount,
+    Tcp = new TcpOptions
+    {
+        Port = 8080,
+    },
+};
+
+var upstream = new Http2ClientOptions
+{
+    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
+    Port = 8081,
+    PoolSize = 1,         // h2 multiplexes: one connection carries all
+};
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i &lt; threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    reactor.OnStart = r =&gt; Http2ClientPool.Start(r, upstream);
+
+    reactor.TcpHandle = async (r, conn) =&gt;
+    {
+        Http2ClientPool client = r.GetService&lt;Http2ClientPool&gt;();
+
+        try
+        {
+            await new Nghttp2Connection(conn).RunBufferedAsync(async request =&gt;
+            {
+                try
+                {
+                    // Both hops are h2 streams on this reactor&#x27;s ring, and this await resumes
+                    // inline - the request never leaves the thread it arrived on.
+                    using HttpClientResponse response = await client.SendAsync(new HttpClientRequest(
+                        request.Method, request.Path) { Body = request.Body });
+
+                    // Copy before Dispose: the response arena is freed then, and nghttp2 copies
+                    // the h2 response only AFTER this handler returns.
+                    var proxied = new Nghttp2Response
+                    {
+                        Status = response.Status,
+                        Body = response.Body.ToArray(),
+                    };
+                    if (response.TryGetHeader(&quot;content-type&quot;u8, out ReadOnlyMemory&lt;byte&gt; contentType))
+                    {
+                        proxied.Headers.Add(&quot;content-type&quot;u8.ToArray(), contentType.ToArray());
+                    }
+                    return proxied;
+                }
+                catch (Exception e)
+                {
+                    return new Nghttp2Response
+                    {
+                        Status = 502,
+                        Body = Encoding.ASCII.GetBytes($&quot;upstream failed: {e.Message}\n&quot;),
+                    };
+                }
+            });
+        }
+        finally
+        {
+            conn.DecRef();
+        }
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $&quot;reactor-{i}&quot; };
+    threads[i].Start();
+}
+
+Console.WriteLine($&quot;[proxy h2-&gt;h2] {config.ReactorCount} reactors, h2c on :{config.Tcp!.Port} &quot;
+                + $&quot;-&gt; h2c {upstream.Host}:{upstream.Port}&quot;);
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}</code></pre>
+    <p class="ex-foot">The narrowest proxy in this set: two sockets per reactor no matter how many requests are in flight. Two independent nghttp2 sessions are involved and they share nothing - HPACK state is per-connection, so a proxy always re-encodes. “Just splice the frames” is not a shortcut that exists.</p>
+  </div>
+  <div class="pane pane-pxh2toh3">
+    <div class="pane-head">
+      <h3>HTTP/2 in &middot; HTTP/3 out</h3>
+      <span class="pane-pkg">ioxide + ioxide.nghttp2 + ioxide.httpclient</span>
+    </div>
+<pre><code class="language-csharp">// dotnet add package ioxide ioxide.nghttp2 ioxide.httpclient
+//   dotnet run --project Playground/Http3/Nghttp3         # h3 origin on udp :8443
+//   curl --http2-prior-knowledge http://127.0.0.1:8080/
+
+using System.Text;
+using ioxide;
+using ioxide.httpclient;
+using ioxide.nghttp2;
+
+var config = new ServerConfig
+{
+    ReactorCount = Environment.ProcessorCount,
+    Tcp = new TcpOptions
+    {
+        Port = 8080,
+    },
+};
+
+var upstream = new Http3ClientOptions
+{
+    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
+    Port = 8443,         // the upstream&#x27;s QUIC (UDP) port
+    ServerName = &quot;localhost&quot;,
+    PoolSize = 1,         // h3 multiplexes: one connection carries all
+};
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i &lt; threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    // Opening the pool here is what makes the reactor grow its client-side QUIC transport: an
+    // ephemeral UDP socket, armed on this ring, shared by every upstream connection.
+    reactor.OnStart = r =&gt; Http3ClientPool.Start(r, upstream);
+
+    reactor.TcpHandle = async (r, conn) =&gt;
+    {
+        Http3ClientPool client = r.GetService&lt;Http3ClientPool&gt;();
+
+        try
+        {
+            await new Nghttp2Connection(conn).RunBufferedAsync(async request =&gt;
+            {
+                try
+                {
+                    // An h2 stream in, a QUIC stream out. Both are completions on this reactor&#x27;s
+                    // ring - one from a TCP recv, one from a UDP recv - and both resume inline.
+                    using HttpClientResponse response = await client.SendAsync(new HttpClientRequest(
+                        request.Method, request.Path) { Body = request.Body });
+
+                    // Copy before Dispose: the response arena is freed then, and nghttp2 copies
+                    // the h2 response only AFTER this handler returns.
+                    var proxied = new Nghttp2Response
+                    {
+                        Status = response.Status,
+                        Body = response.Body.ToArray(),
+                    };
+                    if (response.TryGetHeader(&quot;content-type&quot;u8, out ReadOnlyMemory&lt;byte&gt; contentType))
+                    {
+                        proxied.Headers.Add(&quot;content-type&quot;u8.ToArray(), contentType.ToArray());
+                    }
+                    return proxied;
+                }
+                catch (Exception e)
+                {
+                    return new Nghttp2Response
+                    {
+                        Status = 502,
+                        Body = Encoding.ASCII.GetBytes($&quot;upstream failed: {e.Message}\n&quot;),
+                    };
+                }
+            });
+        }
+        finally
+        {
+            conn.DecRef();
+        }
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $&quot;reactor-{i}&quot; };
+    threads[i].Start();
+}
+
+Console.WriteLine($&quot;[proxy h2-&gt;h3] {config.ReactorCount} reactors, h2c on :{config.Tcp!.Port} &quot;
+                + $&quot;-&gt; h3 {upstream.Host}:{upstream.Port} (client-only QUIC, ephemeral port)&quot;);
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}</code></pre>
+    <p class="ex-foot">TCP in, QUIC out - the client half of a migration where the origin moved to HTTP/3 and the clients did not. Both hops are completions on the same ring, one from a TCP recv and one from a UDP recv, and both resume inline.</p>
+  </div>
+  <div class="pane pane-pxh3toh1">
+    <div class="pane-head">
+      <h3>HTTP/3 in &middot; HTTP/1.1 out</h3>
+      <span class="pane-pkg">ioxide + ioxide.ngtcp2 + ioxide.nghttp3 + ioxide.httpclient</span>
+    </div>
+<pre><code class="language-csharp">// dotnet add package ioxide ioxide.ngtcp2 ioxide.nghttp3 ioxide.httpclient
+//   PLAYGROUND_PORT=8081 dotnet run --project Playground/Tcp/Raw   # the origin
+//   curl --http3-only -k https://127.0.0.1:8443/
+
+using ioxide;
+using ioxide.httpclient;
+using ioxide.nghttp3;
+using ioxide.ngtcp2;
+
+const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
+const string keyPath  = &quot;key.pem&quot;;
+
+using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: [&quot;h3&quot;]);
+
+var config = new ServerConfig
+{
+    ReactorCount = Environment.ProcessorCount,
+    Tcp = null,   // the proxy serves h3 only; its TCP sockets are all outbound
+    Udp = new UdpOptions { RecvSlots = 16 },
+    Quic = new QuicOptions
+    {
+        Port = 8443,
+        LocalCidLength = 8,
+        ConnectionFactory = engine.CreateFactory(),
+    },
+};
+
+var upstream = new HttpClientOptions
+{
+    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
+    Port = 8081,
+    PoolSize = 8,         // keep-alive connections per reactor
+};
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i &lt; threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    // The pool&#x27;s connections belong to THIS reactor&#x27;s ring - one pool per reactor, no locks.
+    reactor.OnStart = r =&gt; HttpClientPool.Start(r, upstream);
+
+    reactor.QuicHandle = (r, conn) =&gt;
+    {
+        HttpClientPool client = r.GetService&lt;HttpClientPool&gt;();
+
+        // Buffered + async: each request dispatches with its body assembled, and the handler may
+        // await - the upstream round trip resumes inline on this reactor.
+        return new Nghttp3Connection(conn).RunBufferedAsync(async request =&gt;
+        {
+            try
+            {
+                // Method, path and body forward as the bytes they already are. The request&#x27;s
+                // memories stay valid across the await - the handler owns them until it returns.
+                using HttpClientResponse response = await client.SendAsync(new HttpClientRequest(
+                    request.Method, request.Path) { Body = request.Body });
+
+                // The upstream response is arena-backed and freed at Dispose, but nghttp3 copies
+                // the h3 response only AFTER this handler returns - so take a copy now. A real
+                // proxy would also filter hop-by-hop headers here.
+                var proxied = new Nghttp3Response
+                {
+                    Status = response.Status,
+                    Body = response.Body.ToArray(),
+                };
+                if (response.TryGetHeader(&quot;content-type&quot;u8, out ReadOnlyMemory&lt;byte&gt; contentType))
+                {
+                    proxied.Headers.Add(&quot;content-type&quot;u8.ToArray(), contentType.ToArray());
+                }
+                return proxied;
+            }
+            catch (Exception e)
+            {
+                // Upstream down is a gateway error, not a dead h3 connection.
+                return new Nghttp3Response
+                {
+                    Status = 502,
+                    Body = System.Text.Encoding.ASCII.GetBytes($&quot;upstream failed: {e.Message}\n&quot;),
+                };
+            }
+        });
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $&quot;reactor-{i}&quot; };
+    threads[i].Start();
+}
+
+Console.WriteLine($&quot;[proxy h3-&gt;h1] {config.ReactorCount} reactors, h3 on udp :{config.Quic!.Port} &quot;
+                + $&quot;-&gt; http/1.1 {upstream.Host}:{upstream.Port}&quot;);
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}</code></pre>
+    <p class="ex-foot">QUIC-only frontend: <code>Tcp = null</code>, so every TCP socket this process owns is outbound. The h3 server and the h1 client share the reactor and nothing else.</p>
+  </div>
+  <div class="pane pane-pxh3toh2">
+    <div class="pane-head">
+      <h3>HTTP/3 in &middot; HTTP/2 out</h3>
+      <span class="pane-pkg">ioxide + ioxide.ngtcp2 + ioxide.nghttp3 + ioxide.httpclient</span>
+    </div>
+<pre><code class="language-csharp">// dotnet add package ioxide ioxide.ngtcp2 ioxide.nghttp3 ioxide.httpclient
+//   PLAYGROUND_PORT=8081 dotnet run --project Playground/Http2/Nghttp2
+//   curl --http3-only -k https://127.0.0.1:8443/
+
+using ioxide;
+using ioxide.httpclient;
+using ioxide.nghttp3;
+using ioxide.ngtcp2;
+
+const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
+const string keyPath  = &quot;key.pem&quot;;
+
+using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: [&quot;h3&quot;]);
+
+var config = new ServerConfig
+{
+    ReactorCount = Environment.ProcessorCount,
+    Tcp = null,   // the proxy serves h3 only; its TCP sockets are all outbound
+    Udp = new UdpOptions { RecvSlots = 16 },
+    Quic = new QuicOptions
+    {
+        Port = 8443,
+        LocalCidLength = 8,
+        ConnectionFactory = engine.CreateFactory(),
+    },
+};
+
+var upstream = new Http2ClientOptions
+{
+    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
+    Port = 8081,
+    PoolSize = 1,         // h2 multiplexes: one connection carries all
+};
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i &lt; threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    reactor.OnStart = r =&gt; Http2ClientPool.Start(r, upstream);
+
+    reactor.QuicHandle = (r, conn) =&gt;
+    {
+        Http2ClientPool client = r.GetService&lt;Http2ClientPool&gt;();
+
+        return new Nghttp3Connection(conn).RunBufferedAsync(async request =&gt;
+        {
+            try
+            {
+                // Same request type as the h1 client - the protocols share their message shapes,
+                // so swapping the upstream is swapping the pool.
+                using HttpClientResponse response = await client.SendAsync(new HttpClientRequest(
+                    request.Method, request.Path) { Body = request.Body });
+
+                // Copy before Dispose: the arena is freed then, and nghttp3 copies the h3
+                // response only after this handler returns.
+                var proxied = new Nghttp3Response
+                {
+                    Status = response.Status,
+                    Body = response.Body.ToArray(),
+                };
+                if (response.TryGetHeader(&quot;content-type&quot;u8, out ReadOnlyMemory&lt;byte&gt; contentType))
+                {
+                    proxied.Headers.Add(&quot;content-type&quot;u8.ToArray(), contentType.ToArray());
+                }
+                return proxied;
+            }
+            catch (Exception e)
+            {
+                return new Nghttp3Response
+                {
+                    Status = 502,
+                    Body = System.Text.Encoding.ASCII.GetBytes($&quot;upstream failed: {e.Message}\n&quot;),
+                };
+            }
+        });
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $&quot;reactor-{i}&quot; };
+    threads[i].Start();
+}
+
+Console.WriteLine($&quot;[proxy h3-&gt;h2] {config.ReactorCount} reactors, h3 on udp :{config.Quic!.Port} &quot;
+                + $&quot;-&gt; h2c {upstream.Host}:{upstream.Port}&quot;);
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}</code></pre>
+    <p class="ex-foot">The same program as <b>h3 &rarr; h1</b> with the pool swapped - which is the whole point of the matrix. Concurrent h3 requests fan into one h2c upstream connection instead of taking a keep-alive connection each.</p>
+  </div>
+  <div class="pane pane-pxh3toh3">
+    <div class="pane-head">
+      <h3>HTTP/3 in &middot; HTTP/3 out</h3>
+      <span class="pane-pkg">ioxide + ioxide.ngtcp2 + ioxide.nghttp3 + ioxide.httpclient</span>
+    </div>
+<pre><code class="language-csharp">// dotnet add package ioxide ioxide.ngtcp2 ioxide.nghttp3 ioxide.httpclient
+//   PLAYGROUND_QUIC_PORT=8444 dotnet run --project Playground/Http3/Nghttp3
+//   curl --http3-only -k https://127.0.0.1:8443/
+
+using ioxide;
+using ioxide.httpclient;
+using ioxide.nghttp3;
+using ioxide.ngtcp2;
+
+const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
+const string keyPath  = &quot;key.pem&quot;;
+
+using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: [&quot;h3&quot;]);
+
+var config = new ServerConfig
+{
+    ReactorCount = Environment.ProcessorCount,
+    Tcp = null,   // h3 in, h3 out: nothing here speaks TCP at all
+    Udp = new UdpOptions { RecvSlots = 16 },
+    Quic = new QuicOptions
+    {
+        Port = 8443,
+        LocalCidLength = 8,
+        ConnectionFactory = engine.CreateFactory(),
+    },
+};
+
+var upstream = new Http3ClientOptions
+{
+    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
+    Port = 8444,         // the upstream&#x27;s QUIC (UDP) port
+    ServerName = &quot;localhost&quot;,
+    PoolSize = 1,         // h3 multiplexes: one connection carries all
+};
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i &lt; threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    // The pool&#x27;s QUIC connections ride this reactor&#x27;s ring on a client socket of their own.
+    reactor.OnStart = r =&gt; Http3ClientPool.Start(r, upstream);
+
+    reactor.QuicHandle = (r, conn) =&gt;
+    {
+        Http3ClientPool client = r.GetService&lt;Http3ClientPool&gt;();
+
+        // The same handler as Proxy.H3ToH1 and Proxy.H3ToH2 - only the pool differs. The clients
+        // share their message types, so the upstream protocol is a pool choice, not a rewrite.
+        return new Nghttp3Connection(conn).RunBufferedAsync(async request =&gt;
+        {
+            try
+            {
+                using HttpClientResponse response = await client.SendAsync(new HttpClientRequest(
+                    request.Method, request.Path) { Body = request.Body });
+
+                // Copy before Dispose: the arena is freed then, and nghttp3 copies the h3
+                // response only after this handler returns.
+                var proxied = new Nghttp3Response
+                {
+                    Status = response.Status,
+                    Body = response.Body.ToArray(),
+                };
+                if (response.TryGetHeader(&quot;content-type&quot;u8, out ReadOnlyMemory&lt;byte&gt; contentType))
+                {
+                    proxied.Headers.Add(&quot;content-type&quot;u8.ToArray(), contentType.ToArray());
+                }
+                return proxied;
+            }
+            catch (Exception e)
+            {
+                return new Nghttp3Response
+                {
+                    Status = 502,
+                    Body = System.Text.Encoding.ASCII.GetBytes($&quot;upstream failed: {e.Message}\n&quot;),
+                };
+            }
+        });
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $&quot;reactor-{i}&quot; };
+    threads[i].Start();
+}
+
+Console.WriteLine($&quot;[proxy h3-&gt;h3] {config.ReactorCount} reactors, h3 on udp :{config.Quic!.Port} &quot;
+                + $&quot;-&gt; h3 {upstream.Host}:{upstream.Port} (per-reactor client socket)&quot;);
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}</code></pre>
+    <p class="ex-foot">QUIC on both sides, and the upstream connections share the serving socket: one fd, both directions. Nothing else in this set collapses that far.</p>
+  </div>
   <div class="pane pane-http">
     <div class="pane-head">
       <h3>HTTP client · reverse proxy</h3>

--- a/ioxide.slnx
+++ b/ioxide.slnx
@@ -66,11 +66,15 @@
   </Folder>
 
   <Folder Name="/apps/playground/proxy/">
-    <Project Path="Playground/Proxy/H1/Playground.Proxy.H1.csproj" />
+    <Project Path="Playground/Proxy/H1ToH1/Playground.Proxy.H1ToH1.csproj" />
+    <Project Path="Playground/Proxy/H1ToH2/Playground.Proxy.H1ToH2.csproj" />
+    <Project Path="Playground/Proxy/H1ToH3/Playground.Proxy.H1ToH3.csproj" />
+    <Project Path="Playground/Proxy/H2ToH1/Playground.Proxy.H2ToH1.csproj" />
+    <Project Path="Playground/Proxy/H2ToH2/Playground.Proxy.H2ToH2.csproj" />
+    <Project Path="Playground/Proxy/H2ToH3/Playground.Proxy.H2ToH3.csproj" />
     <Project Path="Playground/Proxy/H3ToH1/Playground.Proxy.H3ToH1.csproj" />
     <Project Path="Playground/Proxy/H3ToH2/Playground.Proxy.H3ToH2.csproj" />
     <Project Path="Playground/Proxy/H3ToH3/Playground.Proxy.H3ToH3.csproj" />
-    <Project Path="Playground/Proxy/H1ToH3/Playground.Proxy.H1ToH3.csproj" />
   </Folder>
 
   <Folder Name="/apps/playground/clients/">

--- a/scripts/gen-docs-proxy-panes.py
+++ b/scripts/gen-docs-proxy-panes.py
@@ -1,0 +1,138 @@
+"""Generate the docs' proxy panes from the Playground sources, so the two cannot drift.
+
+Each pane is the sample's real Program.cs with the Playground.Shared indirection inlined
+(Env.Int(...) -> the literal default), so what the page shows is a self-contained program.
+"""
+import html
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# slug -> (menu label, pane title, packages, how to run it)
+COMBOS = {
+    "H1ToH1": ("h1 &rarr; h1", "HTTP/1.1 in &middot; HTTP/1.1 out",
+               "ioxide + ioxide.httpclient",
+               ["PLAYGROUND_PORT=8081 dotnet run --project Playground/Tcp/Raw   # the origin",
+                "curl http://127.0.0.1:8080/"]),
+    "H1ToH2": ("h1 &rarr; h2", "HTTP/1.1 in &middot; HTTP/2 out",
+               "ioxide + ioxide.httpclient",
+               ["PLAYGROUND_PORT=8081 dotnet run --project Playground/Http2/Nghttp2",
+                "curl http://127.0.0.1:8080/"]),
+    "H1ToH3": ("h1 &rarr; h3", "HTTP/1.1 in &middot; HTTP/3 out",
+               "ioxide + ioxide.httpclient",
+               ["dotnet run --project Playground/Http3/Nghttp3         # h3 origin on udp :8443",
+                "curl http://127.0.0.1:8080/"]),
+    "H2ToH1": ("h2 &rarr; h1", "HTTP/2 in &middot; HTTP/1.1 out",
+               "ioxide + ioxide.nghttp2 + ioxide.httpclient",
+               ["PLAYGROUND_PORT=8081 dotnet run --project Playground/Tcp/Raw   # the origin",
+                "curl --http2-prior-knowledge http://127.0.0.1:8080/"]),
+    "H2ToH2": ("h2 &rarr; h2", "HTTP/2 in &middot; HTTP/2 out",
+               "ioxide + ioxide.nghttp2 + ioxide.httpclient",
+               ["PLAYGROUND_PORT=8081 dotnet run --project Playground/Http2/Nghttp2",
+                "curl --http2-prior-knowledge http://127.0.0.1:8080/"]),
+    "H2ToH3": ("h2 &rarr; h3", "HTTP/2 in &middot; HTTP/3 out",
+               "ioxide + ioxide.nghttp2 + ioxide.httpclient",
+               ["dotnet run --project Playground/Http3/Nghttp3         # h3 origin on udp :8443",
+                "curl --http2-prior-knowledge http://127.0.0.1:8080/"]),
+    "H3ToH1": ("h3 &rarr; h1", "HTTP/3 in &middot; HTTP/1.1 out",
+               "ioxide + ioxide.ngtcp2 + ioxide.nghttp3 + ioxide.httpclient",
+               ["PLAYGROUND_PORT=8081 dotnet run --project Playground/Tcp/Raw   # the origin",
+                "curl --http3-only -k https://127.0.0.1:8443/"]),
+    "H3ToH2": ("h3 &rarr; h2", "HTTP/3 in &middot; HTTP/2 out",
+               "ioxide + ioxide.ngtcp2 + ioxide.nghttp3 + ioxide.httpclient",
+               ["PLAYGROUND_PORT=8081 dotnet run --project Playground/Http2/Nghttp2",
+                "curl --http3-only -k https://127.0.0.1:8443/"]),
+    "H3ToH3": ("h3 &rarr; h3", "HTTP/3 in &middot; HTTP/3 out",
+               "ioxide + ioxide.ngtcp2 + ioxide.nghttp3 + ioxide.httpclient",
+               ["PLAYGROUND_QUIC_PORT=8444 dotnet run --project Playground/Http3/Nghttp3",
+                "curl --http3-only -k https://127.0.0.1:8443/"]),
+}
+
+# The trailing note on each pane: what this combination is actually for.
+NOTES = {
+    "H1ToH1": "The baseline, and the one to read first. Everything else in this section is this "
+              "program with one type changed.",
+    "H1ToH2": "Identical to <b>h1 &rarr; h1</b> above except for the pool type and its size. h1 needs "
+              "an upstream connection per in-flight request; h2 multiplexes, so <code>PoolSize = 1</code> "
+              "carries every concurrent request on one socket.",
+    "H1ToH3": "Note what the config does <em>not</em> contain: no <code>Quic</code>, no UDP ports, no "
+              "certificate. Being an HTTP/3 <em>client</em> requires no HTTP/3 server - the first connect "
+              "opens an ephemeral UDP socket on this reactor's ring and replies route back by connection ID.",
+    "H2ToH1": "The classic edge: clients get multiplexing and header compression, the origin keeps "
+              "speaking what it already speaks. The one combination here whose pool must size for "
+              "concurrency - a hundred h2 streams need a hundred h1 connections, because h1 has no "
+              "multiplexing to borrow.",
+    "H2ToH2": "The narrowest proxy in this set: two sockets per reactor no matter how many requests "
+              "are in flight. Two independent nghttp2 sessions are involved and they share nothing - "
+              "HPACK state is per-connection, so a proxy always re-encodes. “Just splice the frames” "
+              "is not a shortcut that exists.",
+    "H2ToH3": "TCP in, QUIC out - the client half of a migration where the origin moved to HTTP/3 and "
+              "the clients did not. Both hops are completions on the same ring, one from a TCP recv and "
+              "one from a UDP recv, and both resume inline.",
+    "H3ToH1": "QUIC-only frontend: <code>Tcp = null</code>, so every TCP socket this process owns is "
+              "outbound. The h3 server and the h1 client share the reactor and nothing else.",
+    "H3ToH2": "The same program as <b>h3 &rarr; h1</b> with the pool swapped - which is the whole point "
+              "of the matrix. Concurrent h3 requests fan into one h2c upstream connection instead of "
+              "taking a keep-alive connection each.",
+    "H3ToH3": "QUIC on both sides, and the upstream connections share the serving socket: one fd, both "
+              "directions. Nothing else in this set collapses that far.",
+}
+
+BANNER = re.compile(r"^// ─{5,}.*?^// ─{5,}\n\n", re.S | re.M)
+
+
+def inline_shared(code: str) -> str:
+    """Replace the Playground.Shared helpers with the literals they resolve to."""
+    code = code.replace("using Playground.Shared;\n", "")
+
+    # QuicCert.Ensure(...) spans lines; the sample writes cert.pem / key.pem on first run.
+    code = re.sub(
+        r"\(string certPath, string keyPath\) = QuicCert\.Ensure\(\n(?:.*\n)*?.*?\);\n\n",
+        'const string certPath = "cert.pem";      // any PEM pair; the sample generates one on first run\n'
+        'const string keyPath  = "key.pem";\n\n',
+        code)
+
+    code = re.sub(r'Env\.(?:Int|Port)\("[A-Z_]+", ([^)]+)\)', r"\1", code)
+    code = re.sub(r'Env\.Str\("[A-Z_]+", ("[^"]*")\)', r"\1", code)
+    assert "Env." not in code and "QuicCert" not in code, "an indirection survived"
+    return code
+
+
+def build(slug: str) -> str:
+    label, title, packages, run = COMBOS[slug]
+    src = (ROOT / f"Playground/Proxy/{slug}/Program.cs").read_text()
+
+    body = inline_shared(BANNER.sub("", src)).strip()
+
+    header = "// dotnet add package " + " ".join(packages.split(" + "))
+    header += "\n" + "\n".join(f"//   {line}" for line in run)
+
+    code = html.escape(f"{header}\n\n{body}", quote=False).replace("'", "&#x27;").replace('"', "&quot;")
+
+    return (
+        f'  <div class="pane pane-px{slug.lower()}">\n'
+        f'    <div class="pane-head">\n'
+        f'      <h3>{title}</h3>\n'
+        f'      <span class="pane-pkg">{packages}</span>\n'
+        f'    </div>\n'
+        f'<pre><code class="language-csharp">{code}</code></pre>\n'
+        f'    <p class="ex-foot">{NOTES[slug]}</p>\n'
+        f'  </div>\n')
+
+
+if __name__ == "__main__":
+    out = "".join(build(slug) for slug in COMBOS)
+    index = ROOT / "docs/index.html"
+    page = index.read_text()
+
+    first = page.index('  <div class="pane pane-pxh1toh1">')
+    last = page.index('  <div class="pane pane-http">')
+    if page[first:last] == out:
+        print("docs/index.html is already up to date")
+    else:
+        index.write_text(page[:first] + out + page[last:])
+        print(f"rewrote {len(COMBOS)} panes in docs/index.html")
+
+    for slug in COMBOS:
+        print(f"  pane-px{slug.lower():10} <- Playground/Proxy/{slug}/Program.cs")


### PR DESCRIPTION
Follow-up to #149, which squash-merged before these two landed. The branch still carried the pre-squash history, which is what made this PR conflict; it is reset onto `main` and now holds only the two commits `c259be4` did not absorb. Tree is byte-identical to what was on the branch before the reset.

## kTLS belongs under tcp, and the asp.net example is gone

kTLS is `setsockopt(TCP_ULP, "tls")` — a TCP socket option, and nothing else can carry it. Filing it under a *serving* bucket alongside the ASP.NET drop-in said otherwise. Both kTLS panes move into **tcp**, which left *serving* holding only the ASP.NET example, and that one is removed: the browser is for code that drives the runtime directly, and `UseIoxide()` is the case where you write none.

`ioxide.Kestrel` and `Examples.AspNet` are untouched — this is only about which examples the browser carries. The overview's "all of it runs" line no longer advertises a comparison the page cannot show, and the README's description of the browser matches what is in it.

Incidental: `tab-tlspipe` had no active-label rule under the mobile breakpoint, so that entry never highlighted below 1400px. Pre-existing; fixed while moving it.

## The proxy matrix

The browser filed the reverse proxy under *clients* as "http". It now has its own **proxy** section carrying every frontend × upstream combination, plus a matrix overview pane whose cells jump to each sample, and the existing Alt-Svc-negotiating client as `auto · alt-svc`.

|  | upstream h1 | upstream h2 | upstream h3 |
|---|---|---|---|
| **frontend h1** (raw TCP loop) | `H1ToH1` *(was `H1`)* | **`H1ToH2`** | `H1ToH3` |
| **frontend h2** (`Nghttp2Connection`) | **`H2ToH1`** | **`H2ToH2`** | **`H2ToH3`** |
| **frontend h3** (`Nghttp3Connection`) | `H3ToH1` | `H3ToH2` | `H3ToH3` |

Bold are new. All four missing ones were h2-frontend — the h2 server only landed in #149. `Proxy/H1` → `Proxy/H1ToH1` so the nine read as a matrix rather than eight plus an exception; only `ioxide.slnx` and the Playground README referenced it.

**The docs panes are generated from those programs** by `scripts/gen-docs-proxy-panes.py`, which inlines the `Playground.Shared` env-var defaults into literals so each pane is a self-contained program. Docs that restate code drift; docs printed from it cannot. The script is idempotent and rewrites `docs/index.html` in place, so a change to a sample is one command from the page.

## Verified

- All nine samples build with zero warnings; the full solution builds on the rebased branch.
- All nine panes extracted from the HTML, unescaped, and compiled against **exactly** the package set each pane's own header claims.
- The six TCP-frontend combinations run end to end against real h1/h2/h3 origins:

```
  combo    port   result              combo    port   result
  H1ToH1   9001   200 2b  1.1         H2ToH1   9004   200 2b  2
  H1ToH2   9002   200 2b  1.1         H2ToH2   9005   200 2b  2
  H1ToH3   9003   200 13b 1.1         H2ToH3   9006   200 13b 2
```

13b is the h3 origin's `Hello, World!` arriving over h1 and h2 — the translation actually happened. The three h3-frontend samples are unchanged and this box's curl has no HTTP/3.

**The first run of that smoke test reported three failures that were not real.** Killing `dotnet run` leaves the child listening, and SO_REUSEPORT then load-balances the front port across the stale proxy and the new one, so half the connections reached a server speaking the wrong protocol. Each proxy gets its own port now.

## Not covered

- No suite entry runs the same cases against both HTTP/2 implementations, and h2 is still absent from `bench/run.sh` — both carried over from #149.
- The proxy samples do not filter hop-by-hop headers. Called out in the matrix pane and in the code, because `Connection` / `Keep-Alive` / `Transfer-Encoding` are protocol errors to forward into h2 or h3.
