### PR TITLE
exp(tls): three TLS-over-pipe readers, measured (report, not for merge)

### DIFF
--- a/Playground/Http2/Tls/Program.cs
+++ b/Playground/Http2/Tls/Program.cs
@@ -30,16 +30,19 @@ using Playground.Shared;
 var config = new ServerConfig
 {
     ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    // PLAYGROUND_INCREMENTAL=1 switches the recv path to per-connection incremental buffer rings.
+    Incremental = Env.Flag("PLAYGROUND_INCREMENTAL") ? new IncrementalOptions() : null,
     Tcp = new TcpOptions
     {
         Port = Env.Port("PLAYGROUND_PORT", 8443),
     },
 };
 
-byte[] body = "ok"u8.ToArray();
+int bodyBytes = Env.Int("PLAYGROUND_BODY", 2);
+byte[] body = bodyBytes == 2 ? "ok"u8.ToArray() : [.. Enumerable.Repeat((byte)'x', bodyBytes)];
 
-// PLAYGROUND_INPLACE=1 swaps the inbound TLS pipe for the in-place reader.
-bool inPlace = Env.Flag("PLAYGROUND_INPLACE");
+// PLAYGROUND_TLSPIPE picks the inbound TLS pipe: pump (default) | inplace | direct.
+string tlsPipe = Env.Str("PLAYGROUND_TLSPIPE", "pump");
 byte[] http11Response =
 [
     .. Encoding.ASCII.GetBytes($"HTTP/1.1 200 OK\r\nContent-Length: {body.Length}\r\n\r\n"),
@@ -83,9 +86,12 @@ for (int i = 0; i < threads.Length; i++)
                 // Both are handed to the same Nghttp2Connection, which is the point.
                 // The two share only IDuplexPipe, which is not disposable - hence the second
                 // declaration rather than one `await using`.
-                IDuplexPipe pipe = inPlace
-                    ? new TlsConnectionDualPipeInPlace(conn, tls, ownsSession: false)
-                    : new TlsConnectionDualPipe(conn, tls, ownsSession: false);
+                IDuplexPipe pipe = tlsPipe switch
+                {
+                    "inplace" => new TlsConnectionDualPipeInPlace(conn, tls, ownsSession: false),
+                    "direct"  => new TlsConnectionDualPipeDirect(conn, tls, ownsSession: false),
+                    _         => new TlsConnectionDualPipe(conn, tls, ownsSession: false),
+                };
                 await using IAsyncDisposable owner = (IAsyncDisposable)pipe;
 
                 await new Nghttp2Connection(pipe).RunBufferedAsync(_ => new Nghttp2Response
@@ -142,7 +148,7 @@ for (int i = 0; i < threads.Length; i++)
 
 Console.WriteLine($"[http2-tls] {config.ReactorCount} reactors on :{config.Tcp!.Port}, "
                 + $"ALPN h2 then http/1.1, cert {certPath}, "
-                + $"inbound={(inPlace ? "in-place" : "pump+Pipe")}");
+                + $"inbound={tlsPipe}");
 
 foreach (Thread thread in threads)
 {

--- a/Playground/Http2/Tls/Program.cs
+++ b/Playground/Http2/Tls/Program.cs
@@ -37,6 +37,9 @@ var config = new ServerConfig
 };
 
 byte[] body = "ok"u8.ToArray();
+
+// PLAYGROUND_INPLACE=1 swaps the inbound TLS pipe for the in-place reader.
+bool inPlace = Env.Flag("PLAYGROUND_INPLACE");
 byte[] http11Response =
 [
     .. Encoding.ASCII.GetBytes($"HTTP/1.1 200 OK\r\nContent-Length: {body.Length}\r\n\r\n"),
@@ -68,9 +71,23 @@ for (int i = 0; i < threads.Length; i++)
 
             if (tls.NegotiatedAlpn == "h2")
             {
-                // The decrypt pump lives in the pipe, so the HTTP/2 code below is identical to the
-                // cleartext sample.
-                await using var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
+                // The decrypt lives in the pipe, so the HTTP/2 code below is identical to the
+                // cleartext sample. Two implementations of the same seam:
+                //
+                //   default   TlsConnectionDualPipe          decrypts into a Pipe it owns, fed by
+                //                                            a pump task
+                //   INPLACE=1 TlsConnectionDualPipeInPlace   decrypts inside the recv buffer and
+                //                                            hands that memory out - no pump, no
+                //                                            Pipe, backpressure is the ring
+                //
+                // Both are handed to the same Nghttp2Connection, which is the point.
+                // The two share only IDuplexPipe, which is not disposable - hence the second
+                // declaration rather than one `await using`.
+                IDuplexPipe pipe = inPlace
+                    ? new TlsConnectionDualPipeInPlace(conn, tls, ownsSession: false)
+                    : new TlsConnectionDualPipe(conn, tls, ownsSession: false);
+                await using IAsyncDisposable owner = (IAsyncDisposable)pipe;
+
                 await new Nghttp2Connection(pipe).RunBufferedAsync(_ => new Nghttp2Response
                 {
                     Status = 200,
@@ -124,7 +141,8 @@ for (int i = 0; i < threads.Length; i++)
 }
 
 Console.WriteLine($"[http2-tls] {config.ReactorCount} reactors on :{config.Tcp!.Port}, "
-                + $"ALPN h2 then http/1.1, cert {certPath}");
+                + $"ALPN h2 then http/1.1, cert {certPath}, "
+                + $"inbound={(inPlace ? "in-place" : "pump+Pipe")}");
 
 foreach (Thread thread in threads)
 {

--- a/Playground/Proxy/H1ToH1/Program.cs
+++ b/Playground/Proxy/H1ToH1/Program.cs
@@ -1,39 +1,54 @@
 using System.Text;
 using ioxide;
 using ioxide.httpclient;
+using ioxide.tls;
 using ioxide.utils;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  proxy h1->h1 - a reverse proxy, whole. Every inbound request is forwarded to an upstream origin
-//  through the ring-native HTTP client and the response is relayed back. BOTH hops - the inbound
-//  connection and the outbound call - run on this reactor's ring and resume inline, so a proxied
-//  request never leaves the thread it arrived on. No thread pool, no cross-core handoff.
+//  proxy h1->h1 - a reverse proxy, whole, with TLS on BOTH hops. Every inbound connection is
+//  terminated here and a fresh TLS connection is opened to the origin; both hops run on this
+//  reactor's ring and resume inline, so a proxied request never leaves the thread it arrived on.
 //
-//      # terminal 1: an origin to forward to
-//      PLAYGROUND_PORT=8081 dotnet run -c Release --project Playground/Tcp/Raw
-//      # terminal 2: the proxy
+//  This is the shape every other sample in this folder varies. Read it first.
+//
+//      # a TLS origin to forward to
+//      PLAYGROUND_PORT=8444 dotnet run -c Release --project Playground/Tls/Ktls
 //      dotnet run -c Release --project Playground/Proxy/H1ToH1
-//      curl http://127.0.0.1:8080/
+//      curl -k https://127.0.0.1:8443/
 //
-//  Needs: ioxide.httpclient
+//  Two different TLS stacks are in play and they are not symmetric. INBOUND is kTLS: the OpenSSL
+//  handshake runs over the ring, then the kernel takes over transmit, so everything this handler
+//  writes is PLAINTEXT and the kernel makes the records. OUTBOUND is userspace: the pool wraps
+//  each upstream connection in its own TlsClientStream. Neither shows up in the proxying code.
+//
+//  Needs the Linux 'tls' module (sudo modprobe tls). Needs: ioxide, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(
+    Env.StrOrNull("PLAYGROUND_TLS_CERT"),
+    Env.StrOrNull("PLAYGROUND_TLS_KEY"));
 
 var config = new ServerConfig
 {
     ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port = Env.Port("PLAYGROUND_PORT", 8443),
     },
 };
 
-var upstream = new HttpClientOptions
-{
-    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
-    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8081),
-    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 8),         // keep-alive connections per reactor
-};
+string upstreamHost = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1");   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8444);
+string upstreamName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost");    // sent as SNI, checked against the cert
+int upstreamPool = Env.Int("PLAYGROUND_UPSTREAM_POOL", 8);                // keep-alive connections per reactor
+
+// The playground's origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = Env.StrOrNull("PLAYGROUND_UPSTREAM_CA") ?? certPath;
+bool upstreamInsecure = Env.Flag("PLAYGROUND_UPSTREAM_INSECURE");
 
 var threads = new Thread[config.ReactorCount];
 
@@ -41,60 +56,89 @@ for (int i = 0; i < threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // Opened on the reactor thread, so the outbound sockets ride this reactor's ring too.
-    reactor.OnStart = r => HttpClientPool.Start(r, upstream);
+    reactor.OnStart = r =>
+    {
+        // Inbound: terminate TLS for clients. ALPN is an ordered list and this proxy speaks one
+        // protocol, so it offers exactly one.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = ["http/1.1"],
+        });
+
+        // Outbound: one context per reactor, shared by that reactor's pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        HttpClientPool.Start(r, new HttpClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = ["http/1.1"],
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =>
     {
         HttpClientPool client = r.GetService<HttpClientPool>();
+        TlsSession? tls = null;
 
         try
         {
+            // The handshake reads and writes through this same connection; after it, the socket
+            // carries kTLS records the kernel en/decrypts.
+            tls = await r.GetService<TlsService>().AcceptAsync(conn);
+
+            // A request can ride in with the handshake's final flight - answer it before parking
+            // in ReadAsync, or the client waits on a response we never send.
+            if (TryReadTarget(tls.DrainPlaintext(), out ReadOnlySpan<byte> early))
+            {
+                await ProxyAsync(conn, client, Encoding.ASCII.GetString(early));
+            }
+
             while (true)
             {
                 RecvSnapshot snapshot = await conn.ReadAsync();
 
-                string path = "/";
-                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                string? path = null;
+                unsafe
                 {
-                    if (item.HasBuffer)
+                    while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
                     {
-                        if (TryReadTarget(item.AsSpan(), out ReadOnlySpan<byte> target))
+                        if (item.HasBuffer)
                         {
-                            path = Encoding.ASCII.GetString(target);
+                            // Records in, plaintext out - the session decrypts what the ring got.
+                            if (TryReadTarget(tls.Decrypt(item.Ptr, item.Len), out ReadOnlySpan<byte> target))
+                            {
+                                path = Encoding.ASCII.GetString(target);
+                            }
+                            conn.ReturnBuffer(in item);
                         }
-                        conn.ReturnBuffer(in item);
                     }
                 }
 
-                try
+                if (path is not null)
                 {
-                    // The outbound call. Same ring, same thread - this await resumes inline.
-                    // The response owns its bytes, so dispose it when you're done with them.
-                    using HttpClientResponse response = await client.GetAsync(path);
-
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $"HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n"));
-                    conn.Write(response.Body.Span);   // bytes straight through, no decode
-                }
-                catch (HttpClientException e)
-                {
-                    // A dead origin surfaces here rather than hanging: the pool bounds the whole
-                    // acquire, so you get an exception and can answer with a 502.
-                    byte[] message = Encoding.ASCII.GetBytes($"upstream: {e.Message}");
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $"HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n"));
-                    conn.Write(message);
+                    await ProxyAsync(conn, client, path);
                 }
 
-                await conn.FlushAsync();
-
-                if (snapshot.IsClosed) return;
+                if (snapshot.IsClosed || tls.Closed) return;
                 conn.ResetRead();
             }
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"[proxy h1->h1] connection failed: {e.Message}");
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -103,14 +147,46 @@ for (int i = 0; i < threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($"[proxy h1->h1] {config.ReactorCount} reactors on :{config.Tcp.Port} "
-                + $"-> {upstream.Host}:{upstream.Port}, {upstream.PoolSize} connections each");
+Console.WriteLine($"[proxy h1->h1] {config.ReactorCount} reactors, https on :{config.Tcp!.Port} "
+                + $"-> https://{upstreamName} ({upstreamHost}:{upstreamPort}), "
+                + $"{upstreamPool} connections each, "
+                + $"verify={(upstreamInsecure ? "OFF" : upstreamCa ?? "system store")}");
 
 foreach (Thread thread in threads)
 {
     thread.Join();
 }
 
+// One request out, one response back. Everything written here is PLAINTEXT: after the handshake
+// kTLS owns transmit, so there is nothing left for us to wrap.
+static async ValueTask ProxyAsync(TcpConnection conn, HttpClientPool client, string path)
+{
+    try
+    {
+        // The outbound call. Same ring, same thread - this await resumes inline. The response
+        // owns its bytes, so dispose it when you're done with them.
+        using HttpClientResponse response = await client.GetAsync(path);
+
+        conn.Write(Encoding.ASCII.GetBytes(
+            $"HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n"));
+        conn.Write(response.Body.Span);   // bytes straight through, no decode
+    }
+    catch (Exception e)
+    {
+        // A dead origin surfaces here rather than hanging: the pool bounds the whole acquire. A
+        // REFUSED CERTIFICATE arrives the same way - the handshake is part of opening the
+        // connection, so a name mismatch reads like any other upstream failure.
+        byte[] message = Encoding.ASCII.GetBytes($"upstream: {e.Message}");
+        conn.Write(Encoding.ASCII.GetBytes(
+            $"HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n"));
+        conn.Write(message);
+    }
+
+    await conn.FlushAsync();
+}
+
+// "GET /sleep?x=1 HTTP/1.1" -> "/sleep". Your framework of choice would do this for you; ioxide
+// deliberately doesn't, so here it is in full.
 static bool TryReadTarget(ReadOnlySpan<byte> request, out ReadOnlySpan<byte> target)
 {
     target = default;

--- a/Playground/Proxy/H1ToH2/Program.cs
+++ b/Playground/Proxy/H1ToH2/Program.cs
@@ -1,41 +1,55 @@
 using System.Text;
 using ioxide;
 using ioxide.httpclient;
+using ioxide.tls;
 using ioxide.utils;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  proxy h1->h2 - a plain HTTP/1.1 server whose upstream calls ride HTTP/2 (h2c). The frontend is
-//  Proxy.H1ToH1's, byte for byte; only the pool changed. That is the point of the matrix: the
-//  protocol on each hop is a pool type, not a rewrite.
+//  proxy h1->h2 - HTTPS in, h2-over-TLS out. Identical to Proxy.H1ToH1 except for the upstream:
+//  the pool type changed, its ALPN offer changed from "http/1.1" to "h2", and PoolSize dropped to
+//  1 because h2 multiplexes - one upstream connection carries every concurrent request.
 //
-//  What the swap buys is fan-in. h1 needs one upstream connection per in-flight request, so the
-//  pool sizes for concurrency; h2 multiplexes, so PoolSize 1 carries every concurrent request on
-//  a single socket. A proxy in front of a few origins can hold one connection to each.
+//  ALPN is what selects h2 here. Offering it is not optional: an origin that hears no ALPN has to
+//  assume a protocol, and assuming h2 is not something any origin does.
 //
-//      # the h2c upstream, moved off 8080 so the proxy can have it
-//      PLAYGROUND_PORT=8081 dotnet run -c Release --project Playground/Http2/Nghttp2
+//      # an h2-over-TLS origin to forward to
+//      PLAYGROUND_PORT=8444 dotnet run -c Release --project Playground/Http2/Tls
 //      dotnet run -c Release --project Playground/Proxy/H1ToH2
-//      curl http://127.0.0.1:8080/anything
+//      curl -k https://127.0.0.1:8443/
 //
-//  Needs: ioxide.httpclient
+//  Two different TLS stacks are in play and they are not symmetric. INBOUND is kTLS: the OpenSSL
+//  handshake runs over the ring, then the kernel takes over transmit, so everything this handler
+//  writes is PLAINTEXT and the kernel makes the records. OUTBOUND is userspace: the pool wraps
+//  each upstream connection in its own TlsClientStream. Neither shows up in the proxying code.
+//
+//  Needs the Linux 'tls' module (sudo modprobe tls). Needs: ioxide, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(
+    Env.StrOrNull("PLAYGROUND_TLS_CERT"),
+    Env.StrOrNull("PLAYGROUND_TLS_KEY"));
 
 var config = new ServerConfig
 {
     ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port = Env.Port("PLAYGROUND_PORT", 8443),
     },
 };
 
-var upstream = new Http2ClientOptions
-{
-    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
-    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8081),
-    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1),         // h2 multiplexes: one connection carries all
-};
+string upstreamHost = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1");   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8444);
+string upstreamName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost");    // sent as SNI, checked against the cert
+int upstreamPool = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1);                // h2 multiplexes: one connection carries all
+
+// The playground's origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = Env.StrOrNull("PLAYGROUND_UPSTREAM_CA") ?? certPath;
+bool upstreamInsecure = Env.Flag("PLAYGROUND_UPSTREAM_INSECURE");
 
 var threads = new Thread[config.ReactorCount];
 
@@ -43,57 +57,89 @@ for (int i = 0; i < threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // Opened on the reactor thread, so the upstream socket rides this reactor's ring too.
-    reactor.OnStart = r => Http2ClientPool.Start(r, upstream);
+    reactor.OnStart = r =>
+    {
+        // Inbound: terminate TLS for clients. ALPN is an ordered list and this proxy speaks one
+        // protocol, so it offers exactly one.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = ["http/1.1"],
+        });
+
+        // Outbound: one context per reactor, shared by that reactor's pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        Http2ClientPool.Start(r, new Http2ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = ["h2"],       // h2 over TLS is chosen by ALPN, never assumed
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =>
     {
         Http2ClientPool client = r.GetService<Http2ClientPool>();
+        TlsSession? tls = null;
 
         try
         {
+            // The handshake reads and writes through this same connection; after it, the socket
+            // carries kTLS records the kernel en/decrypts.
+            tls = await r.GetService<TlsService>().AcceptAsync(conn);
+
+            // A request can ride in with the handshake's final flight - answer it before parking
+            // in ReadAsync, or the client waits on a response we never send.
+            if (TryReadTarget(tls.DrainPlaintext(), out ReadOnlySpan<byte> early))
+            {
+                await ProxyAsync(conn, client, Encoding.ASCII.GetString(early));
+            }
+
             while (true)
             {
                 RecvSnapshot snapshot = await conn.ReadAsync();
 
-                string path = "/";
-                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                string? path = null;
+                unsafe
                 {
-                    if (item.HasBuffer)
+                    while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
                     {
-                        if (TryReadTarget(item.AsSpan(), out ReadOnlySpan<byte> target))
+                        if (item.HasBuffer)
                         {
-                            path = Encoding.ASCII.GetString(target);
+                            // Records in, plaintext out - the session decrypts what the ring got.
+                            if (TryReadTarget(tls.Decrypt(item.Ptr, item.Len), out ReadOnlySpan<byte> target))
+                            {
+                                path = Encoding.ASCII.GetString(target);
+                            }
+                            conn.ReturnBuffer(in item);
                         }
-                        conn.ReturnBuffer(in item);
                     }
                 }
 
-                try
+                if (path is not null)
                 {
-                    // h1 request in, h2 stream out - same ring, same thread, inline resume.
-                    using HttpClientResponse response = await client.GetAsync(path);
-
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $"HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n"));
-                    conn.Write(response.Body.Span);   // bytes straight through, no decode
-                }
-                catch (Exception e)
-                {
-                    byte[] message = Encoding.ASCII.GetBytes($"upstream: {e.Message}");
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $"HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n"));
-                    conn.Write(message);
+                    await ProxyAsync(conn, client, path);
                 }
 
-                await conn.FlushAsync();
-
-                if (snapshot.IsClosed) return;
+                if (snapshot.IsClosed || tls.Closed) return;
                 conn.ResetRead();
             }
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"[proxy h1->h2] connection failed: {e.Message}");
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -102,12 +148,42 @@ for (int i = 0; i < threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($"[proxy h1->h2] {config.ReactorCount} reactors on :{config.Tcp!.Port} "
-                + $"-> h2c {upstream.Host}:{upstream.Port}, {upstream.PoolSize} connection(s) each");
+Console.WriteLine($"[proxy h1->h2] {config.ReactorCount} reactors, https on :{config.Tcp!.Port} "
+                + $"-> h2 https://{upstreamName} ({upstreamHost}:{upstreamPort}), "
+                + $"{upstreamPool} connection(s) each, "
+                + $"verify={(upstreamInsecure ? "OFF" : upstreamCa ?? "system store")}");
 
 foreach (Thread thread in threads)
 {
     thread.Join();
+}
+
+// One request out, one response back. Everything written here is PLAINTEXT: after the handshake
+// kTLS owns transmit, so there is nothing left for us to wrap.
+static async ValueTask ProxyAsync(TcpConnection conn, Http2ClientPool client, string path)
+{
+    try
+    {
+        // The outbound call is an h2 stream on a shared connection, not a socket of its own.
+        // Same ring, same thread - this await resumes inline.
+        using HttpClientResponse response = await client.GetAsync(path);
+
+        conn.Write(Encoding.ASCII.GetBytes(
+            $"HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n"));
+        conn.Write(response.Body.Span);   // bytes straight through, no decode
+    }
+    catch (Exception e)
+    {
+        // A dead origin surfaces here rather than hanging: the pool bounds the whole acquire. A
+        // REFUSED CERTIFICATE arrives the same way - the handshake is part of opening the
+        // connection, so a name mismatch reads like any other upstream failure.
+        byte[] message = Encoding.ASCII.GetBytes($"upstream: {e.Message}");
+        conn.Write(Encoding.ASCII.GetBytes(
+            $"HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n"));
+        conn.Write(message);
+    }
+
+    await conn.FlushAsync();
 }
 
 // "GET /sleep?x=1 HTTP/1.1" -> "/sleep". Your framework of choice would do this for you; ioxide

--- a/Playground/Proxy/H1ToH3/Program.cs
+++ b/Playground/Proxy/H1ToH3/Program.cs
@@ -1,39 +1,49 @@
 using System.Text;
 using ioxide;
 using ioxide.httpclient;
+using ioxide.tls;
 using ioxide.utils;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  proxy h1->h3 - a plain HTTP/1.1 server whose upstream calls ride HTTP/3. Note what the
-//  config does NOT contain: no ServerConfig.Quic, no UDP ports, no certificate. Dialing h3 out
-//  needs none of it - the first connect makes the reactor open a UDP socket on an EPHEMERAL
-//  port (the standalone shape of QUIC client mode), and replies route back by connection ID.
-//  Being an h3 client requires no h3 server.
+//  proxy h1->h3 - HTTPS in over TCP, HTTP/3 out over QUIC. The upstream hop needs no TLS options
+//  at all, because QUIC has no cleartext mode: TLS 1.3 is inside the transport, and the handshake
+//  is the connection handshake. Http3ClientOptions carries ServerName for the same reason the h1
+//  and h2 pools do - it is what the certificate has to match - and nothing else.
 //
-//      dotnet run -c Release --project Playground/Http3/Nghttp3        # the h3 upstream on udp :8443
-//      dotnet run -c Release --project Playground/Proxy/H1ToH3
-//      curl http://127.0.0.1:8080/anything
+//  Note also what the config does NOT contain: no ServerConfig.Quic, no UDP ports, no certificate
+//  for the upstream. Being an HTTP/3 client requires no HTTP/3 server - the first connect opens an
+//  ephemeral UDP socket on this reactor's ring and replies route back by connection ID.
 //
-//  Needs: ioxide.httpclient
+//      dotnet run -c Release --project Playground/Http3/Nghttp3     # h3 origin on udp :8443
+//      PLAYGROUND_UPSTREAM_PORT=8443 dotnet run -c Release --project Playground/Proxy/H1ToH3
+//      curl -k https://127.0.0.1:8443/
+//
+//  Two different TLS stacks are in play and they are not symmetric. INBOUND is kTLS: the OpenSSL
+//  handshake runs over the ring, then the kernel takes over transmit, so everything this handler
+//  writes is PLAINTEXT and the kernel makes the records. OUTBOUND is userspace: the pool wraps
+//  each upstream connection in its own TlsClientStream. Neither shows up in the proxying code.
+//
+//  Needs the Linux 'tls' module (sudo modprobe tls). Needs: ioxide, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(
+    Env.StrOrNull("PLAYGROUND_TLS_CERT"),
+    Env.StrOrNull("PLAYGROUND_TLS_KEY"));
 
 var config = new ServerConfig
 {
     ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port = Env.Port("PLAYGROUND_PORT", 8443),
     },
 };
 
-var upstream = new Http3ClientOptions
-{
-    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
-    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8443),         // the upstream's QUIC (UDP) port
-    ServerName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost"),
-    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1),         // h3 multiplexes: one connection carries all
-};
+string upstreamHost = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1");   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8444);       // the upstream's QUIC (UDP) port
+string upstreamName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost");    // sent as SNI, checked against the cert
+int upstreamPool = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1);                // h3 multiplexes: one connection carries all
 
 var threads = new Thread[config.ReactorCount];
 
@@ -41,58 +51,84 @@ for (int i = 0; i < threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // Opening the pool here is what makes the reactor grow its client-side QUIC transport: an
-    // ephemeral UDP socket, armed on this ring, shared by every upstream connection.
-    reactor.OnStart = r => Http3ClientPool.Start(r, upstream);
+    reactor.OnStart = r =>
+    {
+        // Inbound: terminate TLS for clients. ALPN is an ordered list and this proxy speaks one
+        // protocol, so it offers exactly one.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = ["http/1.1"],
+        });
+
+        // Outbound: no TLS options, because QUIC has no cleartext mode - TLS 1.3 is inside the
+        // transport and ALPN ("h3") is negotiated as part of the connection handshake. Opening
+        // this pool is what makes the reactor grow its client-side QUIC transport.
+        Http3ClientPool.Start(r, new Http3ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            ServerName = upstreamName,
+            PoolSize = upstreamPool,
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =>
     {
         Http3ClientPool client = r.GetService<Http3ClientPool>();
+        TlsSession? tls = null;
 
         try
         {
+            // The handshake reads and writes through this same connection; after it, the socket
+            // carries kTLS records the kernel en/decrypts.
+            tls = await r.GetService<TlsService>().AcceptAsync(conn);
+
+            // A request can ride in with the handshake's final flight - answer it before parking
+            // in ReadAsync, or the client waits on a response we never send.
+            if (TryReadTarget(tls.DrainPlaintext(), out ReadOnlySpan<byte> early))
+            {
+                await ProxyAsync(conn, client, Encoding.ASCII.GetString(early));
+            }
+
             while (true)
             {
                 RecvSnapshot snapshot = await conn.ReadAsync();
 
-                string path = "/";
-                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                string? path = null;
+                unsafe
                 {
-                    if (item.HasBuffer)
+                    while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
                     {
-                        if (TryReadTarget(item.AsSpan(), out ReadOnlySpan<byte> target))
+                        if (item.HasBuffer)
                         {
-                            path = Encoding.ASCII.GetString(target);
+                            // Records in, plaintext out - the session decrypts what the ring got.
+                            if (TryReadTarget(tls.Decrypt(item.Ptr, item.Len), out ReadOnlySpan<byte> target))
+                            {
+                                path = Encoding.ASCII.GetString(target);
+                            }
+                            conn.ReturnBuffer(in item);
                         }
-                        conn.ReturnBuffer(in item);
                     }
                 }
 
-                try
+                if (path is not null)
                 {
-                    // h1 request in, h3 request out - same ring, same thread, inline resume.
-                    using HttpClientResponse response = await client.GetAsync(path);
-
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $"HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n"));
-                    conn.Write(response.Body.Span);   // bytes straight through, no decode
-                }
-                catch (Exception e)
-                {
-                    byte[] message = Encoding.ASCII.GetBytes($"upstream: {e.Message}");
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $"HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n"));
-                    conn.Write(message);
+                    await ProxyAsync(conn, client, path);
                 }
 
-                await conn.FlushAsync();
-
-                if (snapshot.IsClosed) return;
+                if (snapshot.IsClosed || tls.Closed) return;
                 conn.ResetRead();
             }
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"[proxy h1->h3] connection failed: {e.Message}");
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -101,12 +137,41 @@ for (int i = 0; i < threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($"[proxy h1->h3] {config.ReactorCount} reactors on :{config.Tcp!.Port} "
-                + $"-> h3 {upstream.Host}:{upstream.Port} (client-only QUIC, ephemeral port)");
+Console.WriteLine($"[proxy h1->h3] {config.ReactorCount} reactors, https on :{config.Tcp!.Port} "
+                + $"-> h3 {upstreamName} ({upstreamHost}:udp {upstreamPort}), "
+                + $"{upstreamPool} connection(s) each");
 
 foreach (Thread thread in threads)
 {
     thread.Join();
+}
+
+// One request out, one response back. Everything written here is PLAINTEXT: after the handshake
+// kTLS owns transmit, so there is nothing left for us to wrap.
+static async ValueTask ProxyAsync(TcpConnection conn, Http3ClientPool client, string path)
+{
+    try
+    {
+        // The outbound call is a QUIC stream. Both hops are completions on this same ring - one
+        // from a TCP recv, one from a UDP recv - and both resume inline.
+        using HttpClientResponse response = await client.GetAsync(path);
+
+        conn.Write(Encoding.ASCII.GetBytes(
+            $"HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n"));
+        conn.Write(response.Body.Span);   // bytes straight through, no decode
+    }
+    catch (Exception e)
+    {
+        // A dead origin surfaces here rather than hanging: the pool bounds the whole acquire. A
+        // refused certificate arrives the same way - for QUIC the TLS handshake IS the connection
+        // handshake, so it fails as a failed connect.
+        byte[] message = Encoding.ASCII.GetBytes($"upstream: {e.Message}");
+        conn.Write(Encoding.ASCII.GetBytes(
+            $"HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n"));
+        conn.Write(message);
+    }
+
+    await conn.FlushAsync();
 }
 
 // "GET /sleep?x=1 HTTP/1.1" -> "/sleep". Your framework of choice would do this for you; ioxide

--- a/Playground/Proxy/H2ToH1/Program.cs
+++ b/Playground/Proxy/H2ToH1/Program.cs
@@ -2,42 +2,61 @@ using System.Text;
 using ioxide;
 using ioxide.httpclient;
 using ioxide.nghttp2;
+using ioxide.tls;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  proxy h2->h1 - an HTTP/2 front door for an HTTP/1.1 upstream. This is the classic edge shape:
-//  clients get multiplexing and header compression, the origin keeps speaking the protocol it
-//  already speaks.
+//  proxy h2->h1 - an HTTP/2 front door for an HTTP/1.1 origin, TLS on both hops. This is the
+//  classic edge shape: clients get multiplexing and header compression over a real https:// URL,
+//  the origin keeps speaking the protocol it already speaks.
 //
-//  Note the asymmetry it creates. One h2 connection can have a hundred streams in flight, and
-//  each one needs its own h1 upstream connection for the duration - h1 has no multiplexing to
-//  borrow. So the pool sizes for concurrency here, unlike every h2/h3 upstream in this folder.
-//  Run out and the request queues behind a waiter rather than the pool opening unbounded, with
-//  the whole acquire bounded by HttpClientOptions.AcquireTimeoutMs - a saturated origin surfaces
-//  as a 502 on that stream, not as an fd leak.
+//  Browsers will not speak h2 in cleartext, so this is the only way the frontend is reachable
+//  from one. ALPN is what makes it work: the server offers "h2" and the client picks it during
+//  the handshake, before a single byte of HTTP exists.
 //
-//      PLAYGROUND_PORT=8081 dotnet run -c Release --project Playground/Tcp/Raw
+//  Note what Nghttp2Connection is handed - a TlsConnectionDualPipe. It never learns that TLS is
+//  involved: the pipe decrypts on the way in and kTLS encrypts on the way out, so the HTTP/2 code
+//  is byte-for-byte the h2c version.
+//
+//      # a TLS origin to forward to
+//      PLAYGROUND_PORT=8444 dotnet run -c Release --project Playground/Tls/Ktls
 //      dotnet run -c Release --project Playground/Proxy/H2ToH1
-//      curl --http2-prior-knowledge http://127.0.0.1:8080/anything
+//      curl -k --http2 https://127.0.0.1:8443/
 //
-//  Needs: ioxide.nghttp2, ioxide.httpclient
+//  Note the asymmetry this combination creates. One h2 connection can have a hundred streams in
+//  flight, and each one needs its own h1 upstream connection for the duration - h1 has no
+//  multiplexing to borrow. So the pool sizes for concurrency here, unlike every h2/h3 upstream in
+//  this folder. Run out and the request queues behind a waiter rather than the pool opening
+//  unbounded, with the whole acquire bounded by HttpClientOptions.AcquireTimeoutMs - a saturated
+//  origin surfaces as a 502 on that stream, not as an fd leak.
+//
+//  Needs the Linux 'tls' module (sudo modprobe tls). Needs: ioxide, ioxide.nghttp2, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(
+    Env.StrOrNull("PLAYGROUND_TLS_CERT"),
+    Env.StrOrNull("PLAYGROUND_TLS_KEY"));
 
 var config = new ServerConfig
 {
     ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port = Env.Port("PLAYGROUND_PORT", 8443),
     },
 };
 
-var upstream = new HttpClientOptions
-{
-    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
-    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8081),
-    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 32),        // h1 has no multiplexing: size for concurrency
-};
+string upstreamHost = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1");   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8444);
+string upstreamName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost");    // sent as SNI, checked against the cert
+int upstreamPool = Env.Int("PLAYGROUND_UPSTREAM_POOL", 32);               // h1 has no multiplexing: size for concurrency
+
+// The playground's origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = Env.StrOrNull("PLAYGROUND_UPSTREAM_CA") ?? certPath;
+bool upstreamInsecure = Env.Flag("PLAYGROUND_UPSTREAM_INSECURE");
 
 var threads = new Thread[config.ReactorCount];
 
@@ -45,19 +64,51 @@ for (int i = 0; i < threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // The pool's connections belong to THIS reactor's ring - one pool per reactor, no locks.
-    reactor.OnStart = r => HttpClientPool.Start(r, upstream);
+    reactor.OnStart = r =>
+    {
+        // Inbound: terminate TLS and offer only h2, because that is all this frontend serves. A
+        // client that cannot do h2 fails ALPN rather than silently getting something else.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = ["h2"],
+        });
+
+        // Outbound: one context per reactor, shared by that reactor's pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        HttpClientPool.Start(r, new HttpClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = ["http/1.1"],
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =>
     {
         HttpClientPool client = r.GetService<HttpClientPool>();
+        TlsSession? tls = null;
 
         try
         {
+            tls = await r.GetService<TlsService>().AcceptAsync(conn);
+
+            // The decrypt pump lives in the pipe, so everything below is the cleartext sample -
+            // and the pipe resumes inline on this reactor, so the upstream call below does too.
+            await using var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
+
             // Buffered + async: each stream dispatches with its body assembled, and the handler
             // may await - the upstream round trip resumes inline on this reactor. Concurrent
             // streams interleave here, which is exactly why the h1 pool has to be deep.
-            await new Nghttp2Connection(conn).RunBufferedAsync(async request =>
+            await new Nghttp2Connection(pipe).RunBufferedAsync(async request =>
             {
                 try
                 {
@@ -84,7 +135,8 @@ for (int i = 0; i < threads.Length; i++)
                 catch (Exception e)
                 {
                     // Upstream down is a gateway error on this stream, not a dead h2 connection:
-                    // every other stream on it keeps working.
+                    // every other stream on it keeps working. A refused certificate arrives the
+                    // same way - the handshake is part of opening the upstream connection.
                     return new Nghttp2Response
                     {
                         Status = 502,
@@ -93,8 +145,13 @@ for (int i = 0; i < threads.Length; i++)
                 }
             });
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"[proxy h2->h1] connection failed: {e.Message}");
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -103,8 +160,10 @@ for (int i = 0; i < threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($"[proxy h2->h1] {config.ReactorCount} reactors, h2c on :{config.Tcp!.Port} "
-                + $"-> http/1.1 {upstream.Host}:{upstream.Port}, {upstream.PoolSize} connections each");
+Console.WriteLine($"[proxy h2->h1] {config.ReactorCount} reactors, h2 over TLS on :{config.Tcp!.Port} "
+                + $"-> https://{upstreamName} ({upstreamHost}:{upstreamPort}), "
+                + $"{upstreamPool} connections each, "
+                + $"verify={(upstreamInsecure ? "OFF" : upstreamCa ?? "system store")}");
 
 foreach (Thread thread in threads)
 {

--- a/Playground/Proxy/H2ToH2/Program.cs
+++ b/Playground/Proxy/H2ToH2/Program.cs
@@ -2,41 +2,55 @@ using System.Text;
 using ioxide;
 using ioxide.httpclient;
 using ioxide.nghttp2;
+using ioxide.tls;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  proxy h2->h2 - HTTP/2 on both sides. The narrowest proxy in this folder: n client streams on
-//  one inbound connection fan out to n streams on ONE outbound connection, so the whole thing
-//  runs on two sockets per reactor no matter how many requests are in flight.
+//  proxy h2->h2 - HTTP/2 on both sides, TLS on both hops. The narrowest proxy in this folder: n
+//  client streams on one inbound connection fan out to n streams on ONE outbound connection, so
+//  the whole thing runs on two sockets per reactor no matter how many requests are in flight.
+//
+//  ALPN carries h2 in both directions - offered by the server on the way in, offered by the
+//  client on the way out. Neither side ever assumes it.
 //
 //  Two different nghttp2 sessions are involved and they share nothing. The inbound one decodes
 //  HPACK against the client's dynamic table; the outbound one re-encodes against the origin's.
 //  Header state is per-connection in HTTP/2 and cannot be forwarded - a proxy always re-encodes,
-//  which is why "just splice the frames" is not a shortcut that exists.
+//  which is why "just splice the frames" is not a shortcut that exists. TLS makes that doubly
+//  true: the two connections do not even share a key.
 //
-//      # the h2c upstream, moved off 8080 so the proxy can have it
-//      PLAYGROUND_PORT=8081 dotnet run -c Release --project Playground/Http2/Nghttp2
+//      # an h2-over-TLS origin to forward to
+//      PLAYGROUND_PORT=8444 dotnet run -c Release --project Playground/Http2/Tls
 //      dotnet run -c Release --project Playground/Proxy/H2ToH2
-//      curl --http2-prior-knowledge http://127.0.0.1:8080/anything
+//      curl -k --http2 https://127.0.0.1:8443/
 //
-//  Needs: ioxide.nghttp2, ioxide.httpclient
+//  Needs the Linux 'tls' module (sudo modprobe tls). Needs: ioxide, ioxide.nghttp2, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(
+    Env.StrOrNull("PLAYGROUND_TLS_CERT"),
+    Env.StrOrNull("PLAYGROUND_TLS_KEY"));
 
 var config = new ServerConfig
 {
     ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port = Env.Port("PLAYGROUND_PORT", 8443),
     },
 };
 
-var upstream = new Http2ClientOptions
-{
-    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
-    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8081),
-    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1),         // h2 multiplexes: one connection carries all
-};
+string upstreamHost = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1");   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8444);
+string upstreamName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost");    // sent as SNI, checked against the cert
+int upstreamPool = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1);                // h2 multiplexes: one connection carries all
+
+// The playground's origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = Env.StrOrNull("PLAYGROUND_UPSTREAM_CA") ?? certPath;
+bool upstreamInsecure = Env.Flag("PLAYGROUND_UPSTREAM_INSECURE");
 
 var threads = new Thread[config.ReactorCount];
 
@@ -44,15 +58,50 @@ for (int i = 0; i < threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    reactor.OnStart = r => Http2ClientPool.Start(r, upstream);
+    reactor.OnStart = r =>
+    {
+        // Inbound: terminate TLS and offer only h2, because that is all this frontend serves. A
+        // client that cannot do h2 fails ALPN rather than silently getting something else.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = ["h2"],
+        });
+
+        // Outbound: one context per reactor, shared by that reactor's pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        Http2ClientPool.Start(r, new Http2ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = ["h2"],       // h2 over TLS is chosen by ALPN, never assumed
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =>
     {
         Http2ClientPool client = r.GetService<Http2ClientPool>();
+        TlsSession? tls = null;
 
         try
         {
-            await new Nghttp2Connection(conn).RunBufferedAsync(async request =>
+            tls = await r.GetService<TlsService>().AcceptAsync(conn);
+
+            // The decrypt pump lives in the pipe, so everything below is the cleartext sample -
+            // and the pipe resumes inline on this reactor, so the upstream call below does too.
+            await using var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
+
+            // Buffered + async: each stream dispatches with its body assembled, and the handler
+            // may await - the upstream round trip resumes inline on this reactor.
+            await new Nghttp2Connection(pipe).RunBufferedAsync(async request =>
             {
                 try
                 {
@@ -62,7 +111,9 @@ for (int i = 0; i < threads.Length; i++)
                         request.Method, request.Path) { Body = request.Body });
 
                     // Copy before Dispose: the response arena is freed then, and nghttp2 copies
-                    // the h2 response only AFTER this handler returns.
+                    // the h2 response only AFTER this handler returns. A real proxy would also
+                    // drop hop-by-hop headers - Connection, Keep-Alive, Transfer-Encoding are all
+                    // illegal in h2 and would be a protocol error to forward.
                     var proxied = new Nghttp2Response
                     {
                         Status = response.Status,
@@ -76,6 +127,9 @@ for (int i = 0; i < threads.Length; i++)
                 }
                 catch (Exception e)
                 {
+                    // Upstream down is a gateway error on this stream, not a dead h2 connection:
+                    // every other stream on it keeps working. A refused certificate arrives the
+                    // same way - the handshake is part of opening the upstream connection.
                     return new Nghttp2Response
                     {
                         Status = 502,
@@ -84,8 +138,13 @@ for (int i = 0; i < threads.Length; i++)
                 }
             });
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"[proxy h2->h2] connection failed: {e.Message}");
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -94,8 +153,10 @@ for (int i = 0; i < threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($"[proxy h2->h2] {config.ReactorCount} reactors, h2c on :{config.Tcp!.Port} "
-                + $"-> h2c {upstream.Host}:{upstream.Port}");
+Console.WriteLine($"[proxy h2->h2] {config.ReactorCount} reactors, h2 over TLS on :{config.Tcp!.Port} "
+                + $"-> h2 https://{upstreamName} ({upstreamHost}:{upstreamPort}), "
+                + $"{upstreamPool} connection(s) each, "
+                + $"verify={(upstreamInsecure ? "OFF" : upstreamCa ?? "system store")}");
 
 foreach (Thread thread in threads)
 {

--- a/Playground/Proxy/H2ToH3/Program.cs
+++ b/Playground/Proxy/H2ToH3/Program.cs
@@ -2,41 +2,47 @@ using System.Text;
 using ioxide;
 using ioxide.httpclient;
 using ioxide.nghttp2;
+using ioxide.tls;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  proxy h2->h3 - HTTP/2 in over TCP, HTTP/3 out over QUIC. The protocol-translating edge: the
-//  client half of a migration where the origin has moved to h3 and the clients have not.
+//  proxy h2->h3 - HTTP/2 in over TCP, HTTP/3 out over QUIC, encrypted end to end. The
+//  protocol-translating edge: the client half of a migration where the origin moved to h3 and the
+//  clients have not.
 //
-//  Look at what the config does NOT contain: no ServerConfig.Quic, no UDP ports, no certificate.
-//  Dialing h3 out needs none of it - the first connect makes the reactor open a UDP socket on an
-//  EPHEMERAL port, and replies route back by connection ID. Being an h3 client requires no h3
-//  server, exactly as in Proxy.H1ToH3; the frontend changing from h1 to h2 changes nothing about
-//  that half.
+//  Both hops are TLS 1.3 and they get there completely differently. INBOUND is kTLS on a TCP
+//  socket: OpenSSL handshake over the ring, then the kernel owns transmit. OUTBOUND is QUIC,
+//  where TLS is inside the transport and the crypto handshake IS the connection handshake - so
+//  the upstream pool takes no TLS options at all, only the ServerName the certificate must match.
 //
-//      dotnet run -c Release --project Playground/Http3/Nghttp3      # the h3 upstream on udp :8443
-//      dotnet run -c Release --project Playground/Proxy/H2ToH3
-//      curl --http2-prior-knowledge http://127.0.0.1:8080/anything
+//  Note also what the config does NOT contain: no ServerConfig.Quic, no UDP ports. Being an
+//  HTTP/3 client requires no HTTP/3 server - the first connect opens an ephemeral UDP socket on
+//  this reactor's ring and replies route back by connection ID.
 //
-//  Needs: ioxide.nghttp2, ioxide.httpclient
+//      dotnet run -c Release --project Playground/Http3/Nghttp3     # h3 origin on udp :8443
+//      PLAYGROUND_UPSTREAM_PORT=8443 dotnet run -c Release --project Playground/Proxy/H2ToH3
+//      curl -k --http2 https://127.0.0.1:8443/
+//
+//  Needs the Linux 'tls' module (sudo modprobe tls). Needs: ioxide, ioxide.nghttp2, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(
+    Env.StrOrNull("PLAYGROUND_TLS_CERT"),
+    Env.StrOrNull("PLAYGROUND_TLS_KEY"));
 
 var config = new ServerConfig
 {
     ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port = Env.Port("PLAYGROUND_PORT", 8443),
     },
 };
 
-var upstream = new Http3ClientOptions
-{
-    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
-    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8443),         // the upstream's QUIC (UDP) port
-    ServerName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost"),
-    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1),         // h3 multiplexes: one connection carries all
-};
+string upstreamHost = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1");   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8444);       // the upstream's QUIC (UDP) port
+string upstreamName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost");    // sent as SNI, checked against the cert
+int upstreamPool = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1);                // h3 multiplexes: one connection carries all
 
 var threads = new Thread[config.ReactorCount];
 
@@ -44,17 +50,45 @@ for (int i = 0; i < threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // Opening the pool here is what makes the reactor grow its client-side QUIC transport: an
-    // ephemeral UDP socket, armed on this ring, shared by every upstream connection.
-    reactor.OnStart = r => Http3ClientPool.Start(r, upstream);
+    reactor.OnStart = r =>
+    {
+        // Inbound: terminate TLS and offer only h2, because that is all this frontend serves. A
+        // client that cannot do h2 fails ALPN rather than silently getting something else.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = ["h2"],
+        });
+
+        // Outbound: no TLS options, because QUIC has no cleartext mode - TLS 1.3 is inside the
+        // transport and ALPN ("h3") is negotiated as part of the connection handshake. Opening
+        // this pool is what makes the reactor grow its client-side QUIC transport.
+        Http3ClientPool.Start(r, new Http3ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            ServerName = upstreamName,
+            PoolSize = upstreamPool,
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =>
     {
         Http3ClientPool client = r.GetService<Http3ClientPool>();
+        TlsSession? tls = null;
 
         try
         {
-            await new Nghttp2Connection(conn).RunBufferedAsync(async request =>
+            tls = await r.GetService<TlsService>().AcceptAsync(conn);
+
+            // The decrypt pump lives in the pipe, so everything below is the cleartext sample -
+            // and the pipe resumes inline on this reactor, so the upstream call below does too.
+            await using var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
+
+            // Buffered + async: each stream dispatches with its body assembled, and the handler
+            // may await - the upstream round trip resumes inline on this reactor.
+            await new Nghttp2Connection(pipe).RunBufferedAsync(async request =>
             {
                 try
                 {
@@ -64,7 +98,9 @@ for (int i = 0; i < threads.Length; i++)
                         request.Method, request.Path) { Body = request.Body });
 
                     // Copy before Dispose: the response arena is freed then, and nghttp2 copies
-                    // the h2 response only AFTER this handler returns.
+                    // the h2 response only AFTER this handler returns. A real proxy would also
+                    // drop hop-by-hop headers - Connection, Keep-Alive, Transfer-Encoding are all
+                    // illegal in h2 and would be a protocol error to forward.
                     var proxied = new Nghttp2Response
                     {
                         Status = response.Status,
@@ -78,6 +114,9 @@ for (int i = 0; i < threads.Length; i++)
                 }
                 catch (Exception e)
                 {
+                    // Upstream down is a gateway error on this stream, not a dead h2 connection:
+                    // every other stream on it keeps working. A refused certificate arrives the
+                    // same way - the handshake is part of opening the upstream connection.
                     return new Nghttp2Response
                     {
                         Status = 502,
@@ -86,8 +125,13 @@ for (int i = 0; i < threads.Length; i++)
                 }
             });
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"[proxy h2->h3] connection failed: {e.Message}");
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -96,8 +140,9 @@ for (int i = 0; i < threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($"[proxy h2->h3] {config.ReactorCount} reactors, h2c on :{config.Tcp!.Port} "
-                + $"-> h3 {upstream.Host}:{upstream.Port} (client-only QUIC, ephemeral port)");
+Console.WriteLine($"[proxy h2->h3] {config.ReactorCount} reactors, h2 over TLS on :{config.Tcp!.Port} "
+                + $"-> h3 {upstreamName} ({upstreamHost}:udp {upstreamPort}), "
+                + $"{upstreamPool} connection(s) each");
 
 foreach (Thread thread in threads)
 {

--- a/Playground/Proxy/H3ToH1/Program.cs
+++ b/Playground/Proxy/H3ToH1/Program.cs
@@ -36,12 +36,18 @@ var config = new ServerConfig
     },
 };
 
-var upstream = new HttpClientOptions
-{
-    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
-    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8081),
-    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 8),         // keep-alive connections per reactor
-};
+string upstreamHost = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1");   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8444);
+int upstreamPool = Env.Int("PLAYGROUND_UPSTREAM_POOL", 8);                // keep-alive connections per reactor
+
+string upstreamName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost");    // sent as SNI, checked against the cert
+
+// The playground's origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = Env.StrOrNull("PLAYGROUND_UPSTREAM_CA") ?? certPath;
+bool upstreamInsecure = Env.Flag("PLAYGROUND_UPSTREAM_INSECURE");
 
 var threads = new Thread[config.ReactorCount];
 
@@ -49,8 +55,24 @@ for (int i = 0; i < threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // The pool's connections belong to THIS reactor's ring - one pool per reactor, no locks.
-    reactor.OnStart = r => HttpClientPool.Start(r, upstream);
+    reactor.OnStart = r =>
+    {
+        // Outbound: one context per reactor, shared by that reactor's pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        HttpClientPool.Start(r, new HttpClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = ["http/1.1"],
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.QuicHandle = (r, conn) =>
     {
@@ -98,7 +120,8 @@ for (int i = 0; i < threads.Length; i++)
 }
 
 Console.WriteLine($"[proxy h3->h1] {config.ReactorCount} reactors, h3 on udp :{config.Quic!.Port} "
-                + $"-> http/1.1 {upstream.Host}:{upstream.Port}");
+                + $"-> https://{upstreamName} ({upstreamHost}:{upstreamPort}), "
+                + $"verify={(upstreamInsecure ? "OFF" : upstreamCa ?? "system store")}");
 
 foreach (Thread thread in threads)
 {

--- a/Playground/Proxy/H3ToH2/Program.cs
+++ b/Playground/Proxy/H3ToH2/Program.cs
@@ -38,12 +38,18 @@ var config = new ServerConfig
     },
 };
 
-var upstream = new Http2ClientOptions
-{
-    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
-    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8081),
-    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1),         // h2 multiplexes: one connection carries all
-};
+string upstreamHost = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1");   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8444);
+int upstreamPool = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1);                // h2 multiplexes: one connection carries all
+
+string upstreamName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost");    // sent as SNI, checked against the cert
+
+// The playground's origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = Env.StrOrNull("PLAYGROUND_UPSTREAM_CA") ?? certPath;
+bool upstreamInsecure = Env.Flag("PLAYGROUND_UPSTREAM_INSECURE");
 
 var threads = new Thread[config.ReactorCount];
 
@@ -51,7 +57,24 @@ for (int i = 0; i < threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    reactor.OnStart = r => Http2ClientPool.Start(r, upstream);
+    reactor.OnStart = r =>
+    {
+        // Outbound: one context per reactor, shared by that reactor's pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        Http2ClientPool.Start(r, new Http2ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = ["h2"],       // h2 over TLS is chosen by ALPN, never assumed
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.QuicHandle = (r, conn) =>
     {
@@ -95,7 +118,8 @@ for (int i = 0; i < threads.Length; i++)
 }
 
 Console.WriteLine($"[proxy h3->h2] {config.ReactorCount} reactors, h3 on udp :{config.Quic!.Port} "
-                + $"-> h2c {upstream.Host}:{upstream.Port}");
+                + $"-> h2 https://{upstreamName} ({upstreamHost}:{upstreamPort}), "
+                + $"verify={(upstreamInsecure ? "OFF" : upstreamCa ?? "system store")}");
 
 foreach (Thread thread in threads)
 {

--- a/Playground/Proxy/H3ToH3/Program.cs
+++ b/Playground/Proxy/H3ToH3/Program.cs
@@ -12,6 +12,12 @@ using Playground.Shared;
 //  connection - each reactor's outbound rides its own ephemeral-port socket instead, which makes
 //  the reply path deterministic.
 //
+//  This is the one combination that needed no TLS wiring: QUIC has no cleartext mode, so both
+//  hops are TLS 1.3 by construction. There is no TlsService on the way in and no
+//  TlsClientContext on the way out because the crypto handshake IS the connection handshake -
+//  the certificate the QuicEngine serves, and the ServerName the pool verifies, are the whole
+//  configuration. Compare the h1 and h2 frontends, where TLS is a layer you add.
+//
 //      PLAYGROUND_QUIC_PORT=8444 PLAYGROUND_PORT=8090 dotnet run -c Release --project Playground/Http3/Nghttp3
 //      dotnet run -c Release --project Playground/Proxy/H3ToH3
 //      curl --http3-only -ks https://127.0.0.1:8443/anything

--- a/Playground/README.md
+++ b/Playground/README.md
@@ -26,15 +26,15 @@ Run any of them with `dotnet run -c Release --project Playground/<Group>/<Name>`
 | [`Http3.Nghttp3`](Http3/Nghttp3/Program.cs) | 169 | HTTP/3 with **streamed** dispatch, and a `SIGTERM` GOAWAY drain. | `ioxide.ngtcp2`, `ioxide.nghttp3` |
 | [`Http3.Buffered`](Http3/Buffered/Program.cs) | 146 | The same server with **buffered** dispatch - one method call is the whole difference. | `ioxide.ngtcp2`, `ioxide.nghttp3` |
 | [`Quic.Alpn`](Quic/Alpn/Program.cs) | 111 | One QUIC listener, two protocols by ALPN: h3, or raw stream echo over the dual pipe. QUIC-only - `Tcp = null`. | `ioxide.ngtcp2`, `ioxide.nghttp3` |
-| [`Proxy.H1ToH1`](Proxy/H1ToH1/Program.cs) | 131 | A reverse proxy, whole - both hops on one reactor thread. Read this one first. | `ioxide.httpclient` |
-| [`Proxy.H1ToH2`](Proxy/H1ToH2/Program.cs) | 132 | The same frontend, h2 upstream: `PoolSize` 1 carries every concurrent request. | `ioxide.httpclient` |
-| [`Proxy.H1ToH3`](Proxy/H1ToH3/Program.cs) | 131 | h1 in, h3 out - with no `Quic` config at all: the first connect opens an ephemeral client socket. | `ioxide.httpclient` |
-| [`Proxy.H2ToH1`](Proxy/H2ToH1/Program.cs) | 112 | The classic edge: clients get multiplexing, the origin keeps h1. The one combination whose pool must size for concurrency. | `ioxide.nghttp2`, `ioxide.httpclient` |
-| [`Proxy.H2ToH2`](Proxy/H2ToH2/Program.cs) | 103 | h2 both sides - two sockets per reactor whatever the load. Two HPACK tables that cannot be spliced. | `ioxide.nghttp2`, `ioxide.httpclient` |
-| [`Proxy.H2ToH3`](Proxy/H2ToH3/Program.cs) | 105 | The protocol-translating edge: TCP in, QUIC out, no server-side QUIC config. | `ioxide.nghttp2`, `ioxide.httpclient` |
-| [`Proxy.H3ToH1`](Proxy/H3ToH1/Program.cs) | 106 | HTTP/3 front door, HTTP/1.1 upstream - QUIC-only frontend, keep-alive h1 pool behind. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
-| [`Proxy.H3ToH2`](Proxy/H3ToH2/Program.cs) | 103 | The same proxy with the pool swapped: requests multiplex onto one h2c upstream connection. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
-| [`Proxy.H3ToH3`](Proxy/H3ToH3/Program.cs) | 105 | h3 on both sides: the upstream QUIC connections share the serving socket - one fd, both directions. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
+| [`Proxy.H1ToH1`](Proxy/H1ToH1/Program.cs) | 207 | TLS both hops, and the one to read first - kTLS in, `TlsClientContext` out. Everything else here is this with one type changed. | `ioxide.httpclient` |
+| [`Proxy.H1ToH2`](Proxy/H1ToH2/Program.cs) | 208 | The same frontend, h2 upstream chosen by ALPN: `PoolSize` 1 carries every concurrent request. | `ioxide.httpclient` |
+| [`Proxy.H1ToH3`](Proxy/H1ToH3/Program.cs) | 196 | h1 in, h3 out. The upstream takes no TLS options at all - QUIC has no cleartext mode, and no `Quic` config is needed to be a client. | `ioxide.httpclient` |
+| [`Proxy.H2ToH1`](Proxy/H2ToH1/Program.cs) | 171 | The classic edge: h2 over TLS in (browsers refuse h2c), h1 origin behind. The one combination whose pool must size for concurrency. | `ioxide.nghttp2`, `ioxide.httpclient` |
+| [`Proxy.H2ToH2`](Proxy/H2ToH2/Program.cs) | 164 | h2 both sides - two sockets per reactor whatever the load. Two HPACK tables that cannot be spliced, and now two keys. | `ioxide.nghttp2`, `ioxide.httpclient` |
+| [`Proxy.H2ToH3`](Proxy/H2ToH3/Program.cs) | 150 | The protocol-translating edge: kTLS on TCP in, QUIC out, encrypted end to end by two completely different mechanisms. | `ioxide.nghttp2`, `ioxide.httpclient` |
+| [`Proxy.H3ToH1`](Proxy/H3ToH1/Program.cs) | 129 | HTTP/3 front door, TLS h1 upstream. `Tcp = null`, so every TCP socket the process owns is an outbound TLS one. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
+| [`Proxy.H3ToH2`](Proxy/H3ToH2/Program.cs) | 127 | The same proxy with the upstream pool swapped: requests multiplex onto one h2-over-TLS connection. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
+| [`Proxy.H3ToH3`](Proxy/H3ToH3/Program.cs) | 111 | The one that needed no TLS wiring at either end - QUIC has no cleartext mode, so both hops are TLS 1.3 by construction. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
 | [`Clients.Pg`](Clients/Pg/Program.cs) | 181 | A `PgPool` per reactor: scalar queries, prepared params (`/add`, `/upper`), row streaming (`/rows`), errors and timeouts. | `ioxide.pg` |
 | [`Clients.Redis`](Clients/Redis/Program.cs) | 194 | A `RedisPool` per reactor: GET hot path, cache-aside, RESP types, explicit pipelining. | `ioxide.redis` |
 | [`Clients.File`](Clients/File/Program.cs) | 253 | Static files: baked responses, ring reads, disk revalidation, `SIGHUP` reload. | `ioxide.file` |
@@ -130,14 +130,24 @@ answers `500`, which is the error path working.
 | `PLAYGROUND_UPSTREAM_HOST` | `127.0.0.1` |
 | `PLAYGROUND_UPSTREAM_PORT` | `8081` |
 | `PLAYGROUND_UPSTREAM_POOL` | `8` h1 upstream, `32` for `H2ToH1`, `1` for any h2/h3 upstream |
+| `PLAYGROUND_UPSTREAM_SNI` | `localhost` - sent as SNI, and what the origin's certificate must match |
+| `PLAYGROUND_UPSTREAM_CA` | the frontend's own self-signed cert - a private CA goes here |
+| `PLAYGROUND_UPSTREAM_INSECURE` | `1` skips verification: encrypted but **unauthenticated** |
 
 Nine samples, one per frontend x upstream combination: the frontend protocol is the server type
 (`Nghttp2Connection`, `Nghttp3Connection`, or a raw TCP loop) and the upstream protocol is the
 pool type (`HttpClientPool`, `Http2ClientPool`, `Http3ClientPool`). Nothing else differs, which
 is the point.
 
-Each needs an origin to forward to - run one of the servers above on `PLAYGROUND_UPSTREAM_PORT`
-in another terminal. With nothing listening they answer `502` once the acquire timeout elapses.
+**Every hop is TLS.** Facing, that is kTLS for the h1 and h2 frontends (`modprobe tls`) and QUIC's
+own TLS 1.3 for the h3 ones; upstream, a `TlsClientContext` for h1 and h2 and again QUIC for h3.
+The h2 frontends offer only `h2` in ALPN, which is what makes them reachable from a browser at all.
+
+Each needs a **TLS** origin to forward to on `PLAYGROUND_UPSTREAM_PORT` - `Tls.Ktls` for an h1
+upstream, `Http2.Tls` for h2, `Http3.Nghttp3` for h3. They verify its certificate against the same
+self-signed cert they serve, so they work against each other out of the box. With nothing listening
+they answer `502` once the acquire timeout elapses, and a certificate that does not verify arrives
+the same way.
 
 ## Docker
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1136,6 +1136,11 @@ foreach (Thread t in threads) t.Join();</code></pre>
       protocol is the server you hand the connection to; the upstream protocol is the pool you
       call. Nothing else changes between the nine samples below - not the reactor, not the
       config, not the handler's shape.</p>
+      <p><b>Every hop is TLS</b>, which is the only way an h2 frontend is reachable from a browser
+      at all. It is reached three different ways: <b>kTLS</b> facing (OpenSSL handshake over the
+      ring, then the kernel owns transmit, so the handler writes plaintext), a
+      <code>TlsClientContext</code> upstream for h1 and h2, and for anything h3 <em>nothing</em> -
+      QUIC has no cleartext mode, so TLS 1.3 is already inside the transport.</p>
       <table>
         <tr><th></th><th>upstream h1</th><th>upstream h2</th><th>upstream h3</th></tr>
         <tr><td><b>frontend h1</b><br><span class="mx-t">a raw TCP loop</span></td>
@@ -1165,10 +1170,13 @@ foreach (Thread t in threads) t.Join();</code></pre>
       <b>h2 &rarr; h1</b> is the one sample here that sizes its pool for concurrency.</p>
       <p>Every pane is the corresponding
       <a href="https://github.com/MDA2AV/ioxide/tree/main/Playground/Proxy">Playground/Proxy</a>
-      program, whole, with the sample's environment-variable defaults inlined. None of them filter
-      hop-by-hop headers; a production proxy must, and <code>Connection</code>,
-      <code>Keep-Alive</code> and <code>Transfer-Encoding</code> are protocol errors to forward
-      into h2 or h3 at all.</p>
+      program, whole, with the sample's environment-variable defaults inlined. Two caveats they
+      share. They do not filter hop-by-hop headers - a production proxy must, and
+      <code>Connection</code>, <code>Keep-Alive</code> and <code>Transfer-Encoding</code> are
+      protocol errors to forward into h2 or h3 at all. And they trust the self-signed certificate
+      the playground generates, so they run against each other out of the box; a real deployment
+      points <code>CaFile</code> at a private CA or leaves it null for the system store. Turning
+      <code>VerifyCertificate</code> off leaves the hop encrypted but <em>unauthenticated</em>.</p>
     </div>
   </div>
   <div class="pane pane-pxh1toh1">
@@ -1177,29 +1185,38 @@ foreach (Thread t in threads) t.Join();</code></pre>
       <span class="pane-pkg">ioxide + ioxide.httpclient</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide ioxide.httpclient
-//   PLAYGROUND_PORT=8081 dotnet run --project Playground/Tcp/Raw   # the origin
-//   curl http://127.0.0.1:8080/
+//   PLAYGROUND_PORT=8444 dotnet run --project Playground/Tls/Ktls   # a TLS origin
+//   curl -k https://127.0.0.1:8443/
 
 using System.Text;
 using ioxide;
 using ioxide.httpclient;
+using ioxide.tls;
 using ioxide.utils;
+
+const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
+const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
     ReactorCount = Environment.ProcessorCount,
     Tcp = new TcpOptions
     {
-        Port = 8080,
+        Port = 8443,
     },
 };
 
-var upstream = new HttpClientOptions
-{
-    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
-    Port = 8081,
-    PoolSize = 8,         // keep-alive connections per reactor
-};
+string upstreamHost = &quot;127.0.0.1&quot;;   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = 8444;
+string upstreamName = &quot;localhost&quot;;    // sent as SNI, checked against the cert
+int upstreamPool = 8;                // keep-alive connections per reactor
+
+// The playground&#x27;s origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = certPath;
+bool upstreamInsecure = false;
 
 var threads = new Thread[config.ReactorCount];
 
@@ -1207,60 +1224,89 @@ for (int i = 0; i &lt; threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // Opened on the reactor thread, so the outbound sockets ride this reactor&#x27;s ring too.
-    reactor.OnStart = r =&gt; HttpClientPool.Start(r, upstream);
+    reactor.OnStart = r =&gt;
+    {
+        // Inbound: terminate TLS for clients. ALPN is an ordered list and this proxy speaks one
+        // protocol, so it offers exactly one.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = [&quot;http/1.1&quot;],
+        });
+
+        // Outbound: one context per reactor, shared by that reactor&#x27;s pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        HttpClientPool.Start(r, new HttpClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = [&quot;http/1.1&quot;],
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =&gt;
     {
         HttpClientPool client = r.GetService&lt;HttpClientPool&gt;();
+        TlsSession? tls = null;
 
         try
         {
+            // The handshake reads and writes through this same connection; after it, the socket
+            // carries kTLS records the kernel en/decrypts.
+            tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
+
+            // A request can ride in with the handshake&#x27;s final flight - answer it before parking
+            // in ReadAsync, or the client waits on a response we never send.
+            if (TryReadTarget(tls.DrainPlaintext(), out ReadOnlySpan&lt;byte&gt; early))
+            {
+                await ProxyAsync(conn, client, Encoding.ASCII.GetString(early));
+            }
+
             while (true)
             {
                 RecvSnapshot snapshot = await conn.ReadAsync();
 
-                string path = &quot;/&quot;;
-                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                string? path = null;
+                unsafe
                 {
-                    if (item.HasBuffer)
+                    while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
                     {
-                        if (TryReadTarget(item.AsSpan(), out ReadOnlySpan&lt;byte&gt; target))
+                        if (item.HasBuffer)
                         {
-                            path = Encoding.ASCII.GetString(target);
+                            // Records in, plaintext out - the session decrypts what the ring got.
+                            if (TryReadTarget(tls.Decrypt(item.Ptr, item.Len), out ReadOnlySpan&lt;byte&gt; target))
+                            {
+                                path = Encoding.ASCII.GetString(target);
+                            }
+                            conn.ReturnBuffer(in item);
                         }
-                        conn.ReturnBuffer(in item);
                     }
                 }
 
-                try
+                if (path is not null)
                 {
-                    // The outbound call. Same ring, same thread - this await resumes inline.
-                    // The response owns its bytes, so dispose it when you&#x27;re done with them.
-                    using HttpClientResponse response = await client.GetAsync(path);
-
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $&quot;HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n&quot;));
-                    conn.Write(response.Body.Span);   // bytes straight through, no decode
-                }
-                catch (HttpClientException e)
-                {
-                    // A dead origin surfaces here rather than hanging: the pool bounds the whole
-                    // acquire, so you get an exception and can answer with a 502.
-                    byte[] message = Encoding.ASCII.GetBytes($&quot;upstream: {e.Message}&quot;);
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $&quot;HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n&quot;));
-                    conn.Write(message);
+                    await ProxyAsync(conn, client, path);
                 }
 
-                await conn.FlushAsync();
-
-                if (snapshot.IsClosed) return;
+                if (snapshot.IsClosed || tls.Closed) return;
                 conn.ResetRead();
             }
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($&quot;[proxy h1-&gt;h1] connection failed: {e.Message}&quot;);
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -1269,14 +1315,46 @@ for (int i = 0; i &lt; threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($&quot;[proxy h1-&gt;h1] {config.ReactorCount} reactors on :{config.Tcp.Port} &quot;
-                + $&quot;-&gt; {upstream.Host}:{upstream.Port}, {upstream.PoolSize} connections each&quot;);
+Console.WriteLine($&quot;[proxy h1-&gt;h1] {config.ReactorCount} reactors, https on :{config.Tcp!.Port} &quot;
+                + $&quot;-&gt; https://{upstreamName} ({upstreamHost}:{upstreamPort}), &quot;
+                + $&quot;{upstreamPool} connections each, &quot;
+                + $&quot;verify={(upstreamInsecure ? &quot;OFF&quot; : upstreamCa ?? &quot;system store&quot;)}&quot;);
 
 foreach (Thread thread in threads)
 {
     thread.Join();
 }
 
+// One request out, one response back. Everything written here is PLAINTEXT: after the handshake
+// kTLS owns transmit, so there is nothing left for us to wrap.
+static async ValueTask ProxyAsync(TcpConnection conn, HttpClientPool client, string path)
+{
+    try
+    {
+        // The outbound call. Same ring, same thread - this await resumes inline. The response
+        // owns its bytes, so dispose it when you&#x27;re done with them.
+        using HttpClientResponse response = await client.GetAsync(path);
+
+        conn.Write(Encoding.ASCII.GetBytes(
+            $&quot;HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n&quot;));
+        conn.Write(response.Body.Span);   // bytes straight through, no decode
+    }
+    catch (Exception e)
+    {
+        // A dead origin surfaces here rather than hanging: the pool bounds the whole acquire. A
+        // REFUSED CERTIFICATE arrives the same way - the handshake is part of opening the
+        // connection, so a name mismatch reads like any other upstream failure.
+        byte[] message = Encoding.ASCII.GetBytes($&quot;upstream: {e.Message}&quot;);
+        conn.Write(Encoding.ASCII.GetBytes(
+            $&quot;HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n&quot;));
+        conn.Write(message);
+    }
+
+    await conn.FlushAsync();
+}
+
+// &quot;GET /sleep?x=1 HTTP/1.1&quot; -&gt; &quot;/sleep&quot;. Your framework of choice would do this for you; ioxide
+// deliberately doesn&#x27;t, so here it is in full.
 static bool TryReadTarget(ReadOnlySpan&lt;byte&gt; request, out ReadOnlySpan&lt;byte&gt; target)
 {
     target = default;
@@ -1303,29 +1381,38 @@ static bool TryReadTarget(ReadOnlySpan&lt;byte&gt; request, out ReadOnlySpan&lt;
       <span class="pane-pkg">ioxide + ioxide.httpclient</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide ioxide.httpclient
-//   PLAYGROUND_PORT=8081 dotnet run --project Playground/Http2/Nghttp2
-//   curl http://127.0.0.1:8080/
+//   PLAYGROUND_PORT=8444 dotnet run --project Playground/Http2/Tls  # an h2-over-TLS origin
+//   curl -k https://127.0.0.1:8443/
 
 using System.Text;
 using ioxide;
 using ioxide.httpclient;
+using ioxide.tls;
 using ioxide.utils;
+
+const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
+const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
     ReactorCount = Environment.ProcessorCount,
     Tcp = new TcpOptions
     {
-        Port = 8080,
+        Port = 8443,
     },
 };
 
-var upstream = new Http2ClientOptions
-{
-    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
-    Port = 8081,
-    PoolSize = 1,         // h2 multiplexes: one connection carries all
-};
+string upstreamHost = &quot;127.0.0.1&quot;;   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = 8444;
+string upstreamName = &quot;localhost&quot;;    // sent as SNI, checked against the cert
+int upstreamPool = 1;                // h2 multiplexes: one connection carries all
+
+// The playground&#x27;s origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = certPath;
+bool upstreamInsecure = false;
 
 var threads = new Thread[config.ReactorCount];
 
@@ -1333,57 +1420,89 @@ for (int i = 0; i &lt; threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // Opened on the reactor thread, so the upstream socket rides this reactor&#x27;s ring too.
-    reactor.OnStart = r =&gt; Http2ClientPool.Start(r, upstream);
+    reactor.OnStart = r =&gt;
+    {
+        // Inbound: terminate TLS for clients. ALPN is an ordered list and this proxy speaks one
+        // protocol, so it offers exactly one.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = [&quot;http/1.1&quot;],
+        });
+
+        // Outbound: one context per reactor, shared by that reactor&#x27;s pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        Http2ClientPool.Start(r, new Http2ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = [&quot;h2&quot;],       // h2 over TLS is chosen by ALPN, never assumed
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =&gt;
     {
         Http2ClientPool client = r.GetService&lt;Http2ClientPool&gt;();
+        TlsSession? tls = null;
 
         try
         {
+            // The handshake reads and writes through this same connection; after it, the socket
+            // carries kTLS records the kernel en/decrypts.
+            tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
+
+            // A request can ride in with the handshake&#x27;s final flight - answer it before parking
+            // in ReadAsync, or the client waits on a response we never send.
+            if (TryReadTarget(tls.DrainPlaintext(), out ReadOnlySpan&lt;byte&gt; early))
+            {
+                await ProxyAsync(conn, client, Encoding.ASCII.GetString(early));
+            }
+
             while (true)
             {
                 RecvSnapshot snapshot = await conn.ReadAsync();
 
-                string path = &quot;/&quot;;
-                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                string? path = null;
+                unsafe
                 {
-                    if (item.HasBuffer)
+                    while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
                     {
-                        if (TryReadTarget(item.AsSpan(), out ReadOnlySpan&lt;byte&gt; target))
+                        if (item.HasBuffer)
                         {
-                            path = Encoding.ASCII.GetString(target);
+                            // Records in, plaintext out - the session decrypts what the ring got.
+                            if (TryReadTarget(tls.Decrypt(item.Ptr, item.Len), out ReadOnlySpan&lt;byte&gt; target))
+                            {
+                                path = Encoding.ASCII.GetString(target);
+                            }
+                            conn.ReturnBuffer(in item);
                         }
-                        conn.ReturnBuffer(in item);
                     }
                 }
 
-                try
+                if (path is not null)
                 {
-                    // h1 request in, h2 stream out - same ring, same thread, inline resume.
-                    using HttpClientResponse response = await client.GetAsync(path);
-
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $&quot;HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n&quot;));
-                    conn.Write(response.Body.Span);   // bytes straight through, no decode
-                }
-                catch (Exception e)
-                {
-                    byte[] message = Encoding.ASCII.GetBytes($&quot;upstream: {e.Message}&quot;);
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $&quot;HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n&quot;));
-                    conn.Write(message);
+                    await ProxyAsync(conn, client, path);
                 }
 
-                await conn.FlushAsync();
-
-                if (snapshot.IsClosed) return;
+                if (snapshot.IsClosed || tls.Closed) return;
                 conn.ResetRead();
             }
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($&quot;[proxy h1-&gt;h2] connection failed: {e.Message}&quot;);
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -1392,12 +1511,42 @@ for (int i = 0; i &lt; threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($&quot;[proxy h1-&gt;h2] {config.ReactorCount} reactors on :{config.Tcp!.Port} &quot;
-                + $&quot;-&gt; h2c {upstream.Host}:{upstream.Port}, {upstream.PoolSize} connection(s) each&quot;);
+Console.WriteLine($&quot;[proxy h1-&gt;h2] {config.ReactorCount} reactors, https on :{config.Tcp!.Port} &quot;
+                + $&quot;-&gt; h2 https://{upstreamName} ({upstreamHost}:{upstreamPort}), &quot;
+                + $&quot;{upstreamPool} connection(s) each, &quot;
+                + $&quot;verify={(upstreamInsecure ? &quot;OFF&quot; : upstreamCa ?? &quot;system store&quot;)}&quot;);
 
 foreach (Thread thread in threads)
 {
     thread.Join();
+}
+
+// One request out, one response back. Everything written here is PLAINTEXT: after the handshake
+// kTLS owns transmit, so there is nothing left for us to wrap.
+static async ValueTask ProxyAsync(TcpConnection conn, Http2ClientPool client, string path)
+{
+    try
+    {
+        // The outbound call is an h2 stream on a shared connection, not a socket of its own.
+        // Same ring, same thread - this await resumes inline.
+        using HttpClientResponse response = await client.GetAsync(path);
+
+        conn.Write(Encoding.ASCII.GetBytes(
+            $&quot;HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n&quot;));
+        conn.Write(response.Body.Span);   // bytes straight through, no decode
+    }
+    catch (Exception e)
+    {
+        // A dead origin surfaces here rather than hanging: the pool bounds the whole acquire. A
+        // REFUSED CERTIFICATE arrives the same way - the handshake is part of opening the
+        // connection, so a name mismatch reads like any other upstream failure.
+        byte[] message = Encoding.ASCII.GetBytes($&quot;upstream: {e.Message}&quot;);
+        conn.Write(Encoding.ASCII.GetBytes(
+            $&quot;HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n&quot;));
+        conn.Write(message);
+    }
+
+    await conn.FlushAsync();
 }
 
 // &quot;GET /sleep?x=1 HTTP/1.1&quot; -&gt; &quot;/sleep&quot;. Your framework of choice would do this for you; ioxide
@@ -1428,30 +1577,32 @@ static bool TryReadTarget(ReadOnlySpan&lt;byte&gt; request, out ReadOnlySpan&lt;
       <span class="pane-pkg">ioxide + ioxide.httpclient</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide ioxide.httpclient
-//   dotnet run --project Playground/Http3/Nghttp3         # h3 origin on udp :8443
-//   curl http://127.0.0.1:8080/
+//   dotnet run --project Playground/Http3/Nghttp3          # h3 origin on udp :8443
+//   PLAYGROUND_UPSTREAM_PORT=8443 dotnet run --project Playground/Proxy/H1ToH3
+//   curl -k https://127.0.0.1:8443/
 
 using System.Text;
 using ioxide;
 using ioxide.httpclient;
+using ioxide.tls;
 using ioxide.utils;
+
+const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
+const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
     ReactorCount = Environment.ProcessorCount,
     Tcp = new TcpOptions
     {
-        Port = 8080,
+        Port = 8443,
     },
 };
 
-var upstream = new Http3ClientOptions
-{
-    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
-    Port = 8443,         // the upstream&#x27;s QUIC (UDP) port
-    ServerName = &quot;localhost&quot;,
-    PoolSize = 1,         // h3 multiplexes: one connection carries all
-};
+string upstreamHost = &quot;127.0.0.1&quot;;   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = 8444;       // the upstream&#x27;s QUIC (UDP) port
+string upstreamName = &quot;localhost&quot;;    // sent as SNI, checked against the cert
+int upstreamPool = 1;                // h3 multiplexes: one connection carries all
 
 var threads = new Thread[config.ReactorCount];
 
@@ -1459,58 +1610,84 @@ for (int i = 0; i &lt; threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // Opening the pool here is what makes the reactor grow its client-side QUIC transport: an
-    // ephemeral UDP socket, armed on this ring, shared by every upstream connection.
-    reactor.OnStart = r =&gt; Http3ClientPool.Start(r, upstream);
+    reactor.OnStart = r =&gt;
+    {
+        // Inbound: terminate TLS for clients. ALPN is an ordered list and this proxy speaks one
+        // protocol, so it offers exactly one.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = [&quot;http/1.1&quot;],
+        });
+
+        // Outbound: no TLS options, because QUIC has no cleartext mode - TLS 1.3 is inside the
+        // transport and ALPN (&quot;h3&quot;) is negotiated as part of the connection handshake. Opening
+        // this pool is what makes the reactor grow its client-side QUIC transport.
+        Http3ClientPool.Start(r, new Http3ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            ServerName = upstreamName,
+            PoolSize = upstreamPool,
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =&gt;
     {
         Http3ClientPool client = r.GetService&lt;Http3ClientPool&gt;();
+        TlsSession? tls = null;
 
         try
         {
+            // The handshake reads and writes through this same connection; after it, the socket
+            // carries kTLS records the kernel en/decrypts.
+            tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
+
+            // A request can ride in with the handshake&#x27;s final flight - answer it before parking
+            // in ReadAsync, or the client waits on a response we never send.
+            if (TryReadTarget(tls.DrainPlaintext(), out ReadOnlySpan&lt;byte&gt; early))
+            {
+                await ProxyAsync(conn, client, Encoding.ASCII.GetString(early));
+            }
+
             while (true)
             {
                 RecvSnapshot snapshot = await conn.ReadAsync();
 
-                string path = &quot;/&quot;;
-                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                string? path = null;
+                unsafe
                 {
-                    if (item.HasBuffer)
+                    while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
                     {
-                        if (TryReadTarget(item.AsSpan(), out ReadOnlySpan&lt;byte&gt; target))
+                        if (item.HasBuffer)
                         {
-                            path = Encoding.ASCII.GetString(target);
+                            // Records in, plaintext out - the session decrypts what the ring got.
+                            if (TryReadTarget(tls.Decrypt(item.Ptr, item.Len), out ReadOnlySpan&lt;byte&gt; target))
+                            {
+                                path = Encoding.ASCII.GetString(target);
+                            }
+                            conn.ReturnBuffer(in item);
                         }
-                        conn.ReturnBuffer(in item);
                     }
                 }
 
-                try
+                if (path is not null)
                 {
-                    // h1 request in, h3 request out - same ring, same thread, inline resume.
-                    using HttpClientResponse response = await client.GetAsync(path);
-
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $&quot;HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n&quot;));
-                    conn.Write(response.Body.Span);   // bytes straight through, no decode
-                }
-                catch (Exception e)
-                {
-                    byte[] message = Encoding.ASCII.GetBytes($&quot;upstream: {e.Message}&quot;);
-                    conn.Write(Encoding.ASCII.GetBytes(
-                        $&quot;HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n&quot;));
-                    conn.Write(message);
+                    await ProxyAsync(conn, client, path);
                 }
 
-                await conn.FlushAsync();
-
-                if (snapshot.IsClosed) return;
+                if (snapshot.IsClosed || tls.Closed) return;
                 conn.ResetRead();
             }
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($&quot;[proxy h1-&gt;h3] connection failed: {e.Message}&quot;);
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -1519,12 +1696,41 @@ for (int i = 0; i &lt; threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($&quot;[proxy h1-&gt;h3] {config.ReactorCount} reactors on :{config.Tcp!.Port} &quot;
-                + $&quot;-&gt; h3 {upstream.Host}:{upstream.Port} (client-only QUIC, ephemeral port)&quot;);
+Console.WriteLine($&quot;[proxy h1-&gt;h3] {config.ReactorCount} reactors, https on :{config.Tcp!.Port} &quot;
+                + $&quot;-&gt; h3 {upstreamName} ({upstreamHost}:udp {upstreamPort}), &quot;
+                + $&quot;{upstreamPool} connection(s) each&quot;);
 
 foreach (Thread thread in threads)
 {
     thread.Join();
+}
+
+// One request out, one response back. Everything written here is PLAINTEXT: after the handshake
+// kTLS owns transmit, so there is nothing left for us to wrap.
+static async ValueTask ProxyAsync(TcpConnection conn, Http3ClientPool client, string path)
+{
+    try
+    {
+        // The outbound call is a QUIC stream. Both hops are completions on this same ring - one
+        // from a TCP recv, one from a UDP recv - and both resume inline.
+        using HttpClientResponse response = await client.GetAsync(path);
+
+        conn.Write(Encoding.ASCII.GetBytes(
+            $&quot;HTTP/1.1 {response.Status} OK\r\nContent-Length: {response.Body.Length}\r\n\r\n&quot;));
+        conn.Write(response.Body.Span);   // bytes straight through, no decode
+    }
+    catch (Exception e)
+    {
+        // A dead origin surfaces here rather than hanging: the pool bounds the whole acquire. A
+        // refused certificate arrives the same way - for QUIC the TLS handshake IS the connection
+        // handshake, so it fails as a failed connect.
+        byte[] message = Encoding.ASCII.GetBytes($&quot;upstream: {e.Message}&quot;);
+        conn.Write(Encoding.ASCII.GetBytes(
+            $&quot;HTTP/1.1 502 Bad Gateway\r\nContent-Length: {message.Length}\r\n\r\n&quot;));
+        conn.Write(message);
+    }
+
+    await conn.FlushAsync();
 }
 
 // &quot;GET /sleep?x=1 HTTP/1.1&quot; -&gt; &quot;/sleep&quot;. Your framework of choice would do this for you; ioxide
@@ -1555,29 +1761,38 @@ static bool TryReadTarget(ReadOnlySpan&lt;byte&gt; request, out ReadOnlySpan&lt;
       <span class="pane-pkg">ioxide + ioxide.nghttp2 + ioxide.httpclient</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide ioxide.nghttp2 ioxide.httpclient
-//   PLAYGROUND_PORT=8081 dotnet run --project Playground/Tcp/Raw   # the origin
-//   curl --http2-prior-knowledge http://127.0.0.1:8080/
+//   PLAYGROUND_PORT=8444 dotnet run --project Playground/Tls/Ktls   # a TLS origin
+//   curl -k --http2 https://127.0.0.1:8443/
 
 using System.Text;
 using ioxide;
 using ioxide.httpclient;
 using ioxide.nghttp2;
+using ioxide.tls;
+
+const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
+const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
     ReactorCount = Environment.ProcessorCount,
     Tcp = new TcpOptions
     {
-        Port = 8080,
+        Port = 8443,
     },
 };
 
-var upstream = new HttpClientOptions
-{
-    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
-    Port = 8081,
-    PoolSize = 32,        // h1 has no multiplexing: size for concurrency
-};
+string upstreamHost = &quot;127.0.0.1&quot;;   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = 8444;
+string upstreamName = &quot;localhost&quot;;    // sent as SNI, checked against the cert
+int upstreamPool = 32;               // h1 has no multiplexing: size for concurrency
+
+// The playground&#x27;s origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = certPath;
+bool upstreamInsecure = false;
 
 var threads = new Thread[config.ReactorCount];
 
@@ -1585,19 +1800,51 @@ for (int i = 0; i &lt; threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // The pool&#x27;s connections belong to THIS reactor&#x27;s ring - one pool per reactor, no locks.
-    reactor.OnStart = r =&gt; HttpClientPool.Start(r, upstream);
+    reactor.OnStart = r =&gt;
+    {
+        // Inbound: terminate TLS and offer only h2, because that is all this frontend serves. A
+        // client that cannot do h2 fails ALPN rather than silently getting something else.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = [&quot;h2&quot;],
+        });
+
+        // Outbound: one context per reactor, shared by that reactor&#x27;s pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        HttpClientPool.Start(r, new HttpClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = [&quot;http/1.1&quot;],
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =&gt;
     {
         HttpClientPool client = r.GetService&lt;HttpClientPool&gt;();
+        TlsSession? tls = null;
 
         try
         {
+            tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
+
+            // The decrypt pump lives in the pipe, so everything below is the cleartext sample -
+            // and the pipe resumes inline on this reactor, so the upstream call below does too.
+            await using var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
+
             // Buffered + async: each stream dispatches with its body assembled, and the handler
             // may await - the upstream round trip resumes inline on this reactor. Concurrent
             // streams interleave here, which is exactly why the h1 pool has to be deep.
-            await new Nghttp2Connection(conn).RunBufferedAsync(async request =&gt;
+            await new Nghttp2Connection(pipe).RunBufferedAsync(async request =&gt;
             {
                 try
                 {
@@ -1624,7 +1871,8 @@ for (int i = 0; i &lt; threads.Length; i++)
                 catch (Exception e)
                 {
                     // Upstream down is a gateway error on this stream, not a dead h2 connection:
-                    // every other stream on it keeps working.
+                    // every other stream on it keeps working. A refused certificate arrives the
+                    // same way - the handshake is part of opening the upstream connection.
                     return new Nghttp2Response
                     {
                         Status = 502,
@@ -1633,8 +1881,13 @@ for (int i = 0; i &lt; threads.Length; i++)
                 }
             });
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($&quot;[proxy h2-&gt;h1] connection failed: {e.Message}&quot;);
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -1643,8 +1896,10 @@ for (int i = 0; i &lt; threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($&quot;[proxy h2-&gt;h1] {config.ReactorCount} reactors, h2c on :{config.Tcp!.Port} &quot;
-                + $&quot;-&gt; http/1.1 {upstream.Host}:{upstream.Port}, {upstream.PoolSize} connections each&quot;);
+Console.WriteLine($&quot;[proxy h2-&gt;h1] {config.ReactorCount} reactors, h2 over TLS on :{config.Tcp!.Port} &quot;
+                + $&quot;-&gt; https://{upstreamName} ({upstreamHost}:{upstreamPort}), &quot;
+                + $&quot;{upstreamPool} connections each, &quot;
+                + $&quot;verify={(upstreamInsecure ? &quot;OFF&quot; : upstreamCa ?? &quot;system store&quot;)}&quot;);
 
 foreach (Thread thread in threads)
 {
@@ -1658,29 +1913,38 @@ foreach (Thread thread in threads)
       <span class="pane-pkg">ioxide + ioxide.nghttp2 + ioxide.httpclient</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide ioxide.nghttp2 ioxide.httpclient
-//   PLAYGROUND_PORT=8081 dotnet run --project Playground/Http2/Nghttp2
-//   curl --http2-prior-knowledge http://127.0.0.1:8080/
+//   PLAYGROUND_PORT=8444 dotnet run --project Playground/Http2/Tls  # an h2-over-TLS origin
+//   curl -k --http2 https://127.0.0.1:8443/
 
 using System.Text;
 using ioxide;
 using ioxide.httpclient;
 using ioxide.nghttp2;
+using ioxide.tls;
+
+const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
+const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
     ReactorCount = Environment.ProcessorCount,
     Tcp = new TcpOptions
     {
-        Port = 8080,
+        Port = 8443,
     },
 };
 
-var upstream = new Http2ClientOptions
-{
-    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
-    Port = 8081,
-    PoolSize = 1,         // h2 multiplexes: one connection carries all
-};
+string upstreamHost = &quot;127.0.0.1&quot;;   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = 8444;
+string upstreamName = &quot;localhost&quot;;    // sent as SNI, checked against the cert
+int upstreamPool = 1;                // h2 multiplexes: one connection carries all
+
+// The playground&#x27;s origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = certPath;
+bool upstreamInsecure = false;
 
 var threads = new Thread[config.ReactorCount];
 
@@ -1688,15 +1952,50 @@ for (int i = 0; i &lt; threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    reactor.OnStart = r =&gt; Http2ClientPool.Start(r, upstream);
+    reactor.OnStart = r =&gt;
+    {
+        // Inbound: terminate TLS and offer only h2, because that is all this frontend serves. A
+        // client that cannot do h2 fails ALPN rather than silently getting something else.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = [&quot;h2&quot;],
+        });
+
+        // Outbound: one context per reactor, shared by that reactor&#x27;s pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        Http2ClientPool.Start(r, new Http2ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = [&quot;h2&quot;],       // h2 over TLS is chosen by ALPN, never assumed
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =&gt;
     {
         Http2ClientPool client = r.GetService&lt;Http2ClientPool&gt;();
+        TlsSession? tls = null;
 
         try
         {
-            await new Nghttp2Connection(conn).RunBufferedAsync(async request =&gt;
+            tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
+
+            // The decrypt pump lives in the pipe, so everything below is the cleartext sample -
+            // and the pipe resumes inline on this reactor, so the upstream call below does too.
+            await using var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
+
+            // Buffered + async: each stream dispatches with its body assembled, and the handler
+            // may await - the upstream round trip resumes inline on this reactor.
+            await new Nghttp2Connection(pipe).RunBufferedAsync(async request =&gt;
             {
                 try
                 {
@@ -1706,7 +2005,9 @@ for (int i = 0; i &lt; threads.Length; i++)
                         request.Method, request.Path) { Body = request.Body });
 
                     // Copy before Dispose: the response arena is freed then, and nghttp2 copies
-                    // the h2 response only AFTER this handler returns.
+                    // the h2 response only AFTER this handler returns. A real proxy would also
+                    // drop hop-by-hop headers - Connection, Keep-Alive, Transfer-Encoding are all
+                    // illegal in h2 and would be a protocol error to forward.
                     var proxied = new Nghttp2Response
                     {
                         Status = response.Status,
@@ -1720,6 +2021,9 @@ for (int i = 0; i &lt; threads.Length; i++)
                 }
                 catch (Exception e)
                 {
+                    // Upstream down is a gateway error on this stream, not a dead h2 connection:
+                    // every other stream on it keeps working. A refused certificate arrives the
+                    // same way - the handshake is part of opening the upstream connection.
                     return new Nghttp2Response
                     {
                         Status = 502,
@@ -1728,8 +2032,13 @@ for (int i = 0; i &lt; threads.Length; i++)
                 }
             });
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($&quot;[proxy h2-&gt;h2] connection failed: {e.Message}&quot;);
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -1738,8 +2047,10 @@ for (int i = 0; i &lt; threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($&quot;[proxy h2-&gt;h2] {config.ReactorCount} reactors, h2c on :{config.Tcp!.Port} &quot;
-                + $&quot;-&gt; h2c {upstream.Host}:{upstream.Port}&quot;);
+Console.WriteLine($&quot;[proxy h2-&gt;h2] {config.ReactorCount} reactors, h2 over TLS on :{config.Tcp!.Port} &quot;
+                + $&quot;-&gt; h2 https://{upstreamName} ({upstreamHost}:{upstreamPort}), &quot;
+                + $&quot;{upstreamPool} connection(s) each, &quot;
+                + $&quot;verify={(upstreamInsecure ? &quot;OFF&quot; : upstreamCa ?? &quot;system store&quot;)}&quot;);
 
 foreach (Thread thread in threads)
 {
@@ -1753,30 +2064,32 @@ foreach (Thread thread in threads)
       <span class="pane-pkg">ioxide + ioxide.nghttp2 + ioxide.httpclient</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide ioxide.nghttp2 ioxide.httpclient
-//   dotnet run --project Playground/Http3/Nghttp3         # h3 origin on udp :8443
-//   curl --http2-prior-knowledge http://127.0.0.1:8080/
+//   dotnet run --project Playground/Http3/Nghttp3          # h3 origin on udp :8443
+//   PLAYGROUND_UPSTREAM_PORT=8443 dotnet run --project Playground/Proxy/H2ToH3
+//   curl -k --http2 https://127.0.0.1:8443/
 
 using System.Text;
 using ioxide;
 using ioxide.httpclient;
 using ioxide.nghttp2;
+using ioxide.tls;
+
+const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
+const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
     ReactorCount = Environment.ProcessorCount,
     Tcp = new TcpOptions
     {
-        Port = 8080,
+        Port = 8443,
     },
 };
 
-var upstream = new Http3ClientOptions
-{
-    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
-    Port = 8443,         // the upstream&#x27;s QUIC (UDP) port
-    ServerName = &quot;localhost&quot;,
-    PoolSize = 1,         // h3 multiplexes: one connection carries all
-};
+string upstreamHost = &quot;127.0.0.1&quot;;   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = 8444;       // the upstream&#x27;s QUIC (UDP) port
+string upstreamName = &quot;localhost&quot;;    // sent as SNI, checked against the cert
+int upstreamPool = 1;                // h3 multiplexes: one connection carries all
 
 var threads = new Thread[config.ReactorCount];
 
@@ -1784,17 +2097,45 @@ for (int i = 0; i &lt; threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // Opening the pool here is what makes the reactor grow its client-side QUIC transport: an
-    // ephemeral UDP socket, armed on this ring, shared by every upstream connection.
-    reactor.OnStart = r =&gt; Http3ClientPool.Start(r, upstream);
+    reactor.OnStart = r =&gt;
+    {
+        // Inbound: terminate TLS and offer only h2, because that is all this frontend serves. A
+        // client that cannot do h2 fails ALPN rather than silently getting something else.
+        TlsService.Start(r, new TlsOptions
+        {
+            CertificatePath = certPath,
+            KeyPath = keyPath,
+            Alpn = [&quot;h2&quot;],
+        });
+
+        // Outbound: no TLS options, because QUIC has no cleartext mode - TLS 1.3 is inside the
+        // transport and ALPN (&quot;h3&quot;) is negotiated as part of the connection handshake. Opening
+        // this pool is what makes the reactor grow its client-side QUIC transport.
+        Http3ClientPool.Start(r, new Http3ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            ServerName = upstreamName,
+            PoolSize = upstreamPool,
+        });
+    };
 
     reactor.TcpHandle = async (r, conn) =&gt;
     {
         Http3ClientPool client = r.GetService&lt;Http3ClientPool&gt;();
+        TlsSession? tls = null;
 
         try
         {
-            await new Nghttp2Connection(conn).RunBufferedAsync(async request =&gt;
+            tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
+
+            // The decrypt pump lives in the pipe, so everything below is the cleartext sample -
+            // and the pipe resumes inline on this reactor, so the upstream call below does too.
+            await using var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
+
+            // Buffered + async: each stream dispatches with its body assembled, and the handler
+            // may await - the upstream round trip resumes inline on this reactor.
+            await new Nghttp2Connection(pipe).RunBufferedAsync(async request =&gt;
             {
                 try
                 {
@@ -1804,7 +2145,9 @@ for (int i = 0; i &lt; threads.Length; i++)
                         request.Method, request.Path) { Body = request.Body });
 
                     // Copy before Dispose: the response arena is freed then, and nghttp2 copies
-                    // the h2 response only AFTER this handler returns.
+                    // the h2 response only AFTER this handler returns. A real proxy would also
+                    // drop hop-by-hop headers - Connection, Keep-Alive, Transfer-Encoding are all
+                    // illegal in h2 and would be a protocol error to forward.
                     var proxied = new Nghttp2Response
                     {
                         Status = response.Status,
@@ -1818,6 +2161,9 @@ for (int i = 0; i &lt; threads.Length; i++)
                 }
                 catch (Exception e)
                 {
+                    // Upstream down is a gateway error on this stream, not a dead h2 connection:
+                    // every other stream on it keeps working. A refused certificate arrives the
+                    // same way - the handshake is part of opening the upstream connection.
                     return new Nghttp2Response
                     {
                         Status = 502,
@@ -1826,8 +2172,13 @@ for (int i = 0; i &lt; threads.Length; i++)
                 }
             });
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($&quot;[proxy h2-&gt;h3] connection failed: {e.Message}&quot;);
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -1836,8 +2187,9 @@ for (int i = 0; i &lt; threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($&quot;[proxy h2-&gt;h3] {config.ReactorCount} reactors, h2c on :{config.Tcp!.Port} &quot;
-                + $&quot;-&gt; h3 {upstream.Host}:{upstream.Port} (client-only QUIC, ephemeral port)&quot;);
+Console.WriteLine($&quot;[proxy h2-&gt;h3] {config.ReactorCount} reactors, h2 over TLS on :{config.Tcp!.Port} &quot;
+                + $&quot;-&gt; h3 {upstreamName} ({upstreamHost}:udp {upstreamPort}), &quot;
+                + $&quot;{upstreamPool} connection(s) each&quot;);
 
 foreach (Thread thread in threads)
 {
@@ -1851,7 +2203,7 @@ foreach (Thread thread in threads)
       <span class="pane-pkg">ioxide + ioxide.ngtcp2 + ioxide.nghttp3 + ioxide.httpclient</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide ioxide.ngtcp2 ioxide.nghttp3 ioxide.httpclient
-//   PLAYGROUND_PORT=8081 dotnet run --project Playground/Tcp/Raw   # the origin
+//   PLAYGROUND_PORT=8444 dotnet run --project Playground/Tls/Ktls   # a TLS origin
 //   curl --http3-only -k https://127.0.0.1:8443/
 
 using ioxide;
@@ -1877,12 +2229,18 @@ var config = new ServerConfig
     },
 };
 
-var upstream = new HttpClientOptions
-{
-    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
-    Port = 8081,
-    PoolSize = 8,         // keep-alive connections per reactor
-};
+string upstreamHost = &quot;127.0.0.1&quot;;   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = 8444;
+int upstreamPool = 8;                // keep-alive connections per reactor
+
+string upstreamName = &quot;localhost&quot;;    // sent as SNI, checked against the cert
+
+// The playground&#x27;s origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = certPath;
+bool upstreamInsecure = false;
 
 var threads = new Thread[config.ReactorCount];
 
@@ -1890,8 +2248,24 @@ for (int i = 0; i &lt; threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    // The pool&#x27;s connections belong to THIS reactor&#x27;s ring - one pool per reactor, no locks.
-    reactor.OnStart = r =&gt; HttpClientPool.Start(r, upstream);
+    reactor.OnStart = r =&gt;
+    {
+        // Outbound: one context per reactor, shared by that reactor&#x27;s pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        HttpClientPool.Start(r, new HttpClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = [&quot;http/1.1&quot;],
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.QuicHandle = (r, conn) =&gt;
     {
@@ -1939,7 +2313,8 @@ for (int i = 0; i &lt; threads.Length; i++)
 }
 
 Console.WriteLine($&quot;[proxy h3-&gt;h1] {config.ReactorCount} reactors, h3 on udp :{config.Quic!.Port} &quot;
-                + $&quot;-&gt; http/1.1 {upstream.Host}:{upstream.Port}&quot;);
+                + $&quot;-&gt; https://{upstreamName} ({upstreamHost}:{upstreamPort}), &quot;
+                + $&quot;verify={(upstreamInsecure ? &quot;OFF&quot; : upstreamCa ?? &quot;system store&quot;)}&quot;);
 
 foreach (Thread thread in threads)
 {
@@ -1953,7 +2328,7 @@ foreach (Thread thread in threads)
       <span class="pane-pkg">ioxide + ioxide.ngtcp2 + ioxide.nghttp3 + ioxide.httpclient</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide ioxide.ngtcp2 ioxide.nghttp3 ioxide.httpclient
-//   PLAYGROUND_PORT=8081 dotnet run --project Playground/Http2/Nghttp2
+//   PLAYGROUND_PORT=8444 dotnet run --project Playground/Http2/Tls  # an h2-over-TLS origin
 //   curl --http3-only -k https://127.0.0.1:8443/
 
 using ioxide;
@@ -1979,12 +2354,18 @@ var config = new ServerConfig
     },
 };
 
-var upstream = new Http2ClientOptions
-{
-    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
-    Port = 8081,
-    PoolSize = 1,         // h2 multiplexes: one connection carries all
-};
+string upstreamHost = &quot;127.0.0.1&quot;;   // IPv4 literal: DNS would block the reactor
+ushort upstreamPort = 8444;
+int upstreamPool = 1;                // h2 multiplexes: one connection carries all
+
+string upstreamName = &quot;localhost&quot;;    // sent as SNI, checked against the cert
+
+// The playground&#x27;s origins use a self-signed cert, so trust that file rather than the system
+// store. PLAYGROUND_UPSTREAM_CA points at a private CA instead; PLAYGROUND_UPSTREAM_INSECURE=1
+// skips verification, which leaves the hop encrypted but UNAUTHENTICATED - anything in the path
+// can present its own certificate and rewrite the whole exchange.
+string? upstreamCa = certPath;
+bool upstreamInsecure = false;
 
 var threads = new Thread[config.ReactorCount];
 
@@ -1992,7 +2373,24 @@ for (int i = 0; i &lt; threads.Length; i++)
 {
     var reactor = new Reactor(i, config);
 
-    reactor.OnStart = r =&gt; Http2ClientPool.Start(r, upstream);
+    reactor.OnStart = r =&gt;
+    {
+        // Outbound: one context per reactor, shared by that reactor&#x27;s pool - it holds no
+        // per-connection state, so every connection opened from it gets its own SSL.
+        Http2ClientPool.Start(r, new Http2ClientOptions
+        {
+            Host = upstreamHost,
+            Port = upstreamPort,
+            PoolSize = upstreamPool,
+            Tls = TlsClientContext.Create(new TlsClientOptions
+            {
+                ServerName = upstreamName,
+                AlpnProtocols = [&quot;h2&quot;],       // h2 over TLS is chosen by ALPN, never assumed
+                CaFile = upstreamInsecure ? null : upstreamCa,
+                VerifyCertificate = !upstreamInsecure,
+            }),
+        });
+    };
 
     reactor.QuicHandle = (r, conn) =&gt;
     {
@@ -2036,7 +2434,8 @@ for (int i = 0; i &lt; threads.Length; i++)
 }
 
 Console.WriteLine($&quot;[proxy h3-&gt;h2] {config.ReactorCount} reactors, h3 on udp :{config.Quic!.Port} &quot;
-                + $&quot;-&gt; h2c {upstream.Host}:{upstream.Port}&quot;);
+                + $&quot;-&gt; h2 https://{upstreamName} ({upstreamHost}:{upstreamPort}), &quot;
+                + $&quot;verify={(upstreamInsecure ? &quot;OFF&quot; : upstreamCa ?? &quot;system store&quot;)}&quot;);
 
 foreach (Thread thread in threads)
 {

--- a/scripts/gen-docs-proxy-panes.py
+++ b/scripts/gen-docs-proxy-panes.py
@@ -13,40 +13,51 @@ ROOT = pathlib.Path(__file__).resolve().parent.parent
 COMBOS = {
     "H1ToH1": ("h1 &rarr; h1", "HTTP/1.1 in &middot; HTTP/1.1 out",
                "ioxide + ioxide.httpclient",
-               ["PLAYGROUND_PORT=8081 dotnet run --project Playground/Tcp/Raw   # the origin",
-                "curl http://127.0.0.1:8080/"]),
+               [
+                'PLAYGROUND_PORT=8444 dotnet run --project Playground/Tls/Ktls   # a TLS origin',
+                'curl -k https://127.0.0.1:8443/']),
     "H1ToH2": ("h1 &rarr; h2", "HTTP/1.1 in &middot; HTTP/2 out",
                "ioxide + ioxide.httpclient",
-               ["PLAYGROUND_PORT=8081 dotnet run --project Playground/Http2/Nghttp2",
-                "curl http://127.0.0.1:8080/"]),
+               [
+                'PLAYGROUND_PORT=8444 dotnet run --project Playground/Http2/Tls  # an h2-over-TLS origin',
+                'curl -k https://127.0.0.1:8443/']),
     "H1ToH3": ("h1 &rarr; h3", "HTTP/1.1 in &middot; HTTP/3 out",
                "ioxide + ioxide.httpclient",
-               ["dotnet run --project Playground/Http3/Nghttp3         # h3 origin on udp :8443",
-                "curl http://127.0.0.1:8080/"]),
+               [
+                'dotnet run --project Playground/Http3/Nghttp3          # h3 origin on udp :8443',
+                'PLAYGROUND_UPSTREAM_PORT=8443 dotnet run --project Playground/Proxy/H1ToH3',
+                'curl -k https://127.0.0.1:8443/']),
     "H2ToH1": ("h2 &rarr; h1", "HTTP/2 in &middot; HTTP/1.1 out",
                "ioxide + ioxide.nghttp2 + ioxide.httpclient",
-               ["PLAYGROUND_PORT=8081 dotnet run --project Playground/Tcp/Raw   # the origin",
-                "curl --http2-prior-knowledge http://127.0.0.1:8080/"]),
+               [
+                'PLAYGROUND_PORT=8444 dotnet run --project Playground/Tls/Ktls   # a TLS origin',
+                'curl -k --http2 https://127.0.0.1:8443/']),
     "H2ToH2": ("h2 &rarr; h2", "HTTP/2 in &middot; HTTP/2 out",
                "ioxide + ioxide.nghttp2 + ioxide.httpclient",
-               ["PLAYGROUND_PORT=8081 dotnet run --project Playground/Http2/Nghttp2",
-                "curl --http2-prior-knowledge http://127.0.0.1:8080/"]),
+               [
+                'PLAYGROUND_PORT=8444 dotnet run --project Playground/Http2/Tls  # an h2-over-TLS origin',
+                'curl -k --http2 https://127.0.0.1:8443/']),
     "H2ToH3": ("h2 &rarr; h3", "HTTP/2 in &middot; HTTP/3 out",
                "ioxide + ioxide.nghttp2 + ioxide.httpclient",
-               ["dotnet run --project Playground/Http3/Nghttp3         # h3 origin on udp :8443",
-                "curl --http2-prior-knowledge http://127.0.0.1:8080/"]),
+               [
+                'dotnet run --project Playground/Http3/Nghttp3          # h3 origin on udp :8443',
+                'PLAYGROUND_UPSTREAM_PORT=8443 dotnet run --project Playground/Proxy/H2ToH3',
+                'curl -k --http2 https://127.0.0.1:8443/']),
     "H3ToH1": ("h3 &rarr; h1", "HTTP/3 in &middot; HTTP/1.1 out",
                "ioxide + ioxide.ngtcp2 + ioxide.nghttp3 + ioxide.httpclient",
-               ["PLAYGROUND_PORT=8081 dotnet run --project Playground/Tcp/Raw   # the origin",
-                "curl --http3-only -k https://127.0.0.1:8443/"]),
+               [
+                'PLAYGROUND_PORT=8444 dotnet run --project Playground/Tls/Ktls   # a TLS origin',
+                'curl --http3-only -k https://127.0.0.1:8443/']),
     "H3ToH2": ("h3 &rarr; h2", "HTTP/3 in &middot; HTTP/2 out",
                "ioxide + ioxide.ngtcp2 + ioxide.nghttp3 + ioxide.httpclient",
-               ["PLAYGROUND_PORT=8081 dotnet run --project Playground/Http2/Nghttp2",
-                "curl --http3-only -k https://127.0.0.1:8443/"]),
+               [
+                'PLAYGROUND_PORT=8444 dotnet run --project Playground/Http2/Tls  # an h2-over-TLS origin',
+                'curl --http3-only -k https://127.0.0.1:8443/']),
     "H3ToH3": ("h3 &rarr; h3", "HTTP/3 in &middot; HTTP/3 out",
                "ioxide + ioxide.ngtcp2 + ioxide.nghttp3 + ioxide.httpclient",
-               ["PLAYGROUND_QUIC_PORT=8444 dotnet run --project Playground/Http3/Nghttp3",
-                "curl --http3-only -k https://127.0.0.1:8443/"]),
+               [
+                'PLAYGROUND_QUIC_PORT=8444 dotnet run --project Playground/Http3/Nghttp3',
+                'curl --http3-only -k https://127.0.0.1:8443/']),
 }
 
 # The trailing note on each pane: what this combination is actually for.
@@ -93,9 +104,17 @@ def inline_shared(code: str) -> str:
         'const string keyPath  = "key.pem";\n\n',
         code)
 
+    # The upstream trust anchor defaults to the same self-signed cert the frontend serves, so the
+    # samples run against each other out of the box. Collapse the override to that default.
+    code = code.replace('Env.StrOrNull("PLAYGROUND_UPSTREAM_CA") ?? certPath', "certPath")
+
     code = re.sub(r'Env\.(?:Int|Port)\("[A-Z_]+", ([^)]+)\)', r"\1", code)
     code = re.sub(r'Env\.Str\("[A-Z_]+", ("[^"]*")\)', r"\1", code)
-    assert "Env." not in code and "QuicCert" not in code, "an indirection survived"
+    code = re.sub(r'Env\.Flag\("[A-Z_]+"\)', "false", code)
+
+    assert "Env." not in code and "QuicCert" not in code, \
+        "an indirection survived: " + "; ".join(
+            l.strip() for l in code.splitlines() if "Env." in l or "QuicCert" in l)
     return code
 
 

--- a/src/ioxide/Tls/OpenSsl.cs
+++ b/src/ioxide/Tls/OpenSsl.cs
@@ -40,6 +40,12 @@ internal static unsafe partial class OpenSsl
     [LibraryImport(Ssl)] public static partial int SSL_read(nint ssl, byte* buf, int num);
     [LibraryImport(Ssl)] public static partial int SSL_get_error(nint ssl, int ret);
 
+    /// <summary>
+    /// Plaintext already decrypted and waiting, in bytes. Distinguishes "the destination filled but
+    /// there is more" from "that was everything", which a zero-length SSL_read cannot.
+    /// </summary>
+    [LibraryImport(Ssl)] public static partial int SSL_pending(nint ssl);
+
     /// <summary>What ALPN settled on, or nothing when the client offered none we serve.</summary>
     [LibraryImport(Ssl)] public static partial void SSL_get0_alpn_selected(nint ssl, byte** data, uint* length);
 

--- a/src/ioxide/Tls/TlsConnectionDualPipe.cs
+++ b/src/ioxide/Tls/TlsConnectionDualPipe.cs
@@ -56,7 +56,15 @@ public sealed class TlsConnectionDualPipe : IDuplexPipe, IAsyncDisposable
         _tls = session;
         _ownsSession = ownsSession;
 
-        _inbound = new Pipe(options ?? new PipeOptions(useSynchronizationContext: false));
+        // Inline schedulers, so a read resumes on the thread that completed the write - the
+        // reactor. A Pipe defaults to PipeScheduler.ThreadPool, and combined with
+        // useSynchronizationContext:false that hands the connection to a pool thread with a NULL
+        // SynchronizationContext, so nothing can post it back and the loop never returns. Every
+        // other awaitable in ioxide says the same thing as RunContinuationsAsynchronously = false.
+        _inbound = new Pipe(options ?? new PipeOptions(
+            readerScheduler: PipeScheduler.Inline,
+            writerScheduler: PipeScheduler.Inline,
+            useSynchronizationContext: false));
         _outbound = new TcpConnectionDualPipe(connection);
 
         _pump = PumpInboundAsync();

--- a/src/ioxide/Tls/TlsConnectionDualPipeDirect.cs
+++ b/src/ioxide/Tls/TlsConnectionDualPipeDirect.cs
@@ -1,0 +1,257 @@
+using System.Buffers;
+using System.IO.Pipelines;
+using ioxide.utils;
+
+namespace ioxide.tls;
+
+/// <summary>
+/// <see cref="TcpConnectionDualPipe"/> with one thing changed: OpenSSL decrypts the recv buffer
+/// before the caller sees it. No pump, no second <see cref="Pipe"/>, no chaining - the plaintext is
+/// handed out from the same memory the ciphertext arrived in.
+///
+/// It works because a memory BIO copies. Once <see cref="TlsSession.Feed"/> hands the ciphertext to
+/// OpenSSL the buffer is dead as a source and free to be the destination, and the plaintext always
+/// fits: a TLS 1.3 record spends 5 bytes of header, 1 of content type and a 16-byte tag, so it is
+/// at least 22 bytes shorter than the ciphertext it came from (RFC 8446 section 5.2).
+///
+/// One buffer is held at a time. That is not a simplification with a cost - it is what removes the
+/// only hard case. A record can straddle recvs, so the buffer completing one may release more
+/// plaintext than it holds; here the held buffer is simply drained again once the caller has
+/// consumed it, so the overflow needs no spill array and no second code path.
+/// </summary>
+/// <remarks>Reactor thread only. Experimental.</remarks>
+public sealed class TlsConnectionDualPipeDirect : IDuplexPipe, IAsyncDisposable
+{
+    private readonly TlsSession _tls;
+    private readonly bool _ownsSession;
+    private readonly TlsDirectPipeReader _inbound;
+    private readonly TcpConnectionDualPipe _outbound;   // only its writer is used
+
+    public TlsConnectionDualPipeDirect(TcpConnection connection, TlsSession session,
+        bool ownsSession = true)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(session);
+
+        _tls = session;
+        _ownsSession = ownsSession;
+        _inbound = new TlsDirectPipeReader(connection, session);
+        _outbound = new TcpConnectionDualPipe(connection);
+    }
+
+    /// <summary>Decrypted request bytes, in the buffer they arrived in.</summary>
+    public PipeReader Input => _inbound;
+
+    /// <summary>Response bytes, written as PLAINTEXT - kTLS makes the records.</summary>
+    public PipeWriter Output => _outbound.Output;
+
+    public ValueTask DisposeAsync()
+    {
+        _inbound.Complete();
+
+        if (_ownsSession)
+        {
+            _tls.Dispose();
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}
+
+/// <summary>
+/// The read half of <see cref="TlsConnectionDualPipeDirect"/>: one recv buffer at a time,
+/// decrypted where it lies.
+/// </summary>
+public sealed class TlsDirectPipeReader : PipeReader
+{
+    private readonly TcpConnection _conn;
+    private readonly TlsSession _tls;
+
+    // The single held buffer, its plaintext length, and how much the caller has taken.
+    private SpscRecvRing.Item _item;
+    private bool _held;
+    private int _length;
+    private int _consumed;
+
+    // The handshake's final flight usually carries the first request, and that plaintext lives in
+    // the session rather than in any recv buffer - so it is the one thing that needs a copy.
+    private byte[]? _prologue;
+    private bool _prologueTaken;
+
+    private bool _closed;
+    private bool _canceled;
+    private bool _completed;
+
+    internal TlsDirectPipeReader(TcpConnection connection, TlsSession session)
+    {
+        _conn = connection;
+        _tls = session;
+    }
+
+    public override async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_completed, this);
+
+        while (true)
+        {
+            if (TryBuild(out ReadResult ready))
+            {
+                return ready;
+            }
+
+            if (_closed || _tls.Closed)
+            {
+                return new ReadResult(default, isCanceled: Take(ref _canceled), isCompleted: true);
+            }
+
+            RecvSnapshot snapshot = await _conn.ReadAsync();
+
+            TakeOne(snapshot);
+            _conn.ResetRead();
+
+            if (snapshot.IsClosed)
+            {
+                _closed = true;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Decrypt one recv buffer in place and hold it. Whatever else the snapshot carries stays
+    /// queued: TcpConnection.ReadAsync completes without waiting while its recv queue is non-empty,
+    /// so the next pass picks it up synchronously.
+    /// </summary>
+    private unsafe void TakeOne(in RecvSnapshot snapshot)
+    {
+        while (!_held && _conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+        {
+            if (!item.HasBuffer)
+            {
+                continue;
+            }
+
+            _tls.Feed(item.Ptr, item.Len);            // OpenSSL now owns a copy of the ciphertext
+            int produced = _tls.DrainInto(item.Ptr, item.Len, out _);
+
+            if (produced == 0)
+            {
+                // A partial record, or a post-handshake message. Nothing to hand out and the bytes
+                // live in the BIO now, so the buffer goes straight back.
+                _conn.ReturnBuffer(in item);
+                continue;
+            }
+
+            _item = item;
+            _held = true;
+            _length = produced;
+            _consumed = 0;
+        }
+    }
+
+    // The prologue first, then whatever the held buffer still has. Returns false when the caller
+    // must wait for more ciphertext.
+    private unsafe bool TryBuild(out ReadResult result)
+    {
+        if (!_prologueTaken)
+        {
+            _prologueTaken = true;
+            ReadOnlySpan<byte> initial = _tls.DrainPlaintext();
+
+            if (!initial.IsEmpty)
+            {
+                _prologue = ArrayPool<byte>.Shared.Rent(initial.Length);
+                initial.CopyTo(_prologue);
+                _length = initial.Length;
+                _consumed = 0;
+            }
+        }
+
+        int available = _length - _consumed;
+        if (available <= 0)
+        {
+            result = default;
+            return false;
+        }
+
+        ReadOnlyMemory<byte> plaintext = _prologue is not null
+            ? _prologue.AsMemory(_consumed, available)
+            : new UnmanagedMemoryManager(_item.Ptr + _consumed, available).Memory;
+
+        result = new ReadResult(new ReadOnlySequence<byte>(plaintext),
+            isCanceled: Take(ref _canceled), isCompleted: false);
+        return true;
+    }
+
+    public override void AdvanceTo(SequencePosition consumed) => AdvanceTo(consumed, consumed);
+
+    public override unsafe void AdvanceTo(SequencePosition consumed, SequencePosition examined)
+    {
+        // Single segment, so the position IS the offset into what the last read handed out.
+        _consumed += consumed.GetInteger();
+
+        if (_consumed < _length)
+        {
+            return;   // the caller left some behind; the next read hands back the rest
+        }
+
+        _consumed = 0;
+        _length = 0;
+
+        if (_prologue is not null)
+        {
+            ArrayPool<byte>.Shared.Return(_prologue);
+            _prologue = null;
+            return;
+        }
+
+        if (!_held)
+        {
+            return;
+        }
+
+        // The buffer is free again - and a record that straddled recvs may have released more
+        // plaintext than it could hold, so drain into it once more before giving it up. This is
+        // what replaces a spill buffer.
+        int more = _tls.DrainInto(_item.Ptr, _item.Len, out _);
+        if (more > 0)
+        {
+            _length = more;
+            return;
+        }
+
+        _conn.ReturnBuffer(in _item);
+        _held = false;
+    }
+
+    public override bool TryRead(out ReadResult result) => TryBuild(out result);
+
+    public override void CancelPendingRead() => _canceled = true;
+
+    public override unsafe void Complete(Exception? exception = null)
+    {
+        if (_completed)
+        {
+            return;
+        }
+        _completed = true;
+
+        if (_prologue is not null)
+        {
+            ArrayPool<byte>.Shared.Return(_prologue);
+            _prologue = null;
+        }
+
+        if (_held)
+        {
+            _conn.ReturnBuffer(in _item);
+            _held = false;
+        }
+    }
+
+    private static bool Take(ref bool flag)
+    {
+        bool value = flag;
+        flag = false;
+        return value;
+    }
+}

--- a/src/ioxide/Tls/TlsConnectionDualPipeInPlace.cs
+++ b/src/ioxide/Tls/TlsConnectionDualPipeInPlace.cs
@@ -1,0 +1,80 @@
+using System.IO.Pipelines;
+
+namespace ioxide.tls;
+
+/// <summary>
+/// <see cref="TlsConnectionDualPipe"/> without the pump: the inbound half decrypts records
+/// <b>in place inside the ring buffer</b> and hands that memory straight out, so there is no owned
+/// plaintext buffer, no background task and no <see cref="Pipe"/> anywhere in the connection.
+///
+/// Both classes present the same seam and either can be handed to <c>Nghttp2Connection</c>,
+/// Kestrel or GenHTTP unchanged. What differs is what sits behind <see cref="Input"/>:
+///
+/// <code>
+///                        TlsConnectionDualPipe          TlsConnectionDualPipeInPlace
+///   plaintext lives in    a Pipe this class owns         the recv buffer it arrived in
+///   moving parts          pump Task + Pipe               neither
+///   backpressure          the Pipe's pause threshold     the ring itself
+///   copies                ring -> BIO, BIO -> Pipe       ring -> BIO, BIO -> ring
+/// </code>
+///
+/// The copy count is the same - the saving is the second buffer, the task and the threshold. And
+/// because the ring is the backpressure, a consumer that stops reading stops the kernel filling,
+/// which is the same mechanism TCP already has rather than a number someone picked.
+///
+/// The outbound half is identical in both: kTLS TX means the kernel makes the records, so writes
+/// go straight to the connection as plaintext.
+/// </summary>
+/// <remarks>
+/// Reactor thread only. Experimental - <see cref="TlsConnectionDualPipe"/> is the one in use.
+/// </remarks>
+public sealed class TlsConnectionDualPipeInPlace : IDuplexPipe, IAsyncDisposable
+{
+    private readonly TlsSession _tls;
+    private readonly bool _ownsSession;
+
+    private readonly TlsInPlacePipeReader _inbound;
+    private readonly TcpConnectionDualPipe _outbound;   // only its writer is used
+
+    /// <summary>
+    /// Wrap a connection whose TLS handshake has already completed (see
+    /// <see cref="TlsService.AcceptAsync"/>).
+    /// </summary>
+    /// <param name="connection">The accepted connection, post-handshake.</param>
+    /// <param name="session">The session that handshake produced.</param>
+    /// <param name="ownsSession">
+    /// When true (the default) disposing this also disposes <paramref name="session"/>, which is
+    /// what sends the closing close_notify.
+    /// </param>
+    public TlsConnectionDualPipeInPlace(TcpConnection connection, TlsSession session,
+        bool ownsSession = true)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(session);
+
+        _tls = session;
+        _ownsSession = ownsSession;
+
+        _inbound = new TlsInPlacePipeReader(connection, session);
+        _outbound = new TcpConnectionDualPipe(connection);
+    }
+
+    /// <summary>Decrypted request bytes, pointing into the ring buffers they arrived in.</summary>
+    public PipeReader Input => _inbound;
+
+    /// <summary>Response bytes, written as PLAINTEXT - the kernel encrypts them.</summary>
+    public PipeWriter Output => _outbound.Output;
+
+    public ValueTask DisposeAsync()
+    {
+        // No pump to await: completing the reader is what hands every held buffer back to the ring.
+        _inbound.Complete();
+
+        if (_ownsSession)
+        {
+            _tls.Dispose();   // sends close_notify over kTLS when the peer has not already closed
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/ioxide/Tls/TlsInPlacePipeReader.cs
+++ b/src/ioxide/Tls/TlsInPlacePipeReader.cs
@@ -1,0 +1,416 @@
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks.Sources;
+using ioxide.utils;
+
+namespace ioxide.tls;
+
+/// <summary>
+/// A <see cref="PipeReader"/> that decrypts TLS records <b>in place, inside the ring buffer</b> and
+/// hands that same memory to the caller - no owned plaintext buffer, no pump task, and no
+/// <see cref="Pipe"/>.
+///
+/// The trick is that a memory BIO copies: <see cref="TlsSession.Feed"/> hands the ciphertext to
+/// OpenSSL, and from that instant the recv buffer is dead as a <em>source</em> and free to be the
+/// <em>destination</em>. It always fits, because a TLS 1.3 record spends 5 bytes of header, 1 byte
+/// of content type and a 16-byte AEAD tag - so plaintext is at least 22 bytes shorter than the
+/// ciphertext it came from (RFC 8446 section 5.2).
+///
+/// Compare <see cref="TlsConnectionDualPipe"/>, which decrypts into a Pipe it owns. This one keeps
+/// the plaintext where the ciphertext landed, so backpressure is the ring itself: unconsumed
+/// buffers are not returned, the ring runs dry, and the kernel stops filling. There is no pause
+/// threshold to pick.
+/// </summary>
+/// <remarks>Reactor thread only. Mirrors TcpConnectionPipeReader's structure deliberately.</remarks>
+public sealed unsafe class TlsInPlacePipeReader : PipeReader, IValueTaskSource<ReadResult>
+{
+    // A held slice is either ring memory decrypted in place, or - for the straddle case below -
+    // a rented array. Both look identical to the caller; only the release path differs.
+    private sealed class Slice : ReadOnlySequenceSegment<byte>
+    {
+        public readonly UnmanagedMemoryManager Manager = new(null, 0);
+        public SpscRecvRing.Item Item;
+        public byte[]? Owned;          // non-null => rented, return to the pool not the ring
+        public Slice? NextSlice;
+
+        public void SetRing(in SpscRecvRing.Item item, int plaintextLength)
+        {
+            Item = item;
+            Owned = null;
+            Manager.Reset(item.Ptr, plaintextLength, item.Bid, item.Gen);
+            Memory = Manager.Memory;
+            Reset();
+        }
+
+        public void SetOwned(byte[] buffer, int length)
+        {
+            Owned = buffer;
+            Memory = buffer.AsMemory(0, length);
+            Reset();
+        }
+
+        private void Reset()
+        {
+            Next = null;
+            NextSlice = null;
+            RunningIndex = 0;
+        }
+
+        public void Link(Slice next)
+        {
+            next.RunningIndex = RunningIndex + Memory.Length;
+            Next = next;
+            NextSlice = next;
+        }
+    }
+
+    private readonly TcpConnection _conn;
+    private readonly TlsSession _tls;
+
+    private Slice? _head;
+    private Slice? _tail;
+    private int _headConsumed;
+    private long _heldBytes;
+    private long _examined;
+
+    private readonly Stack<Slice> _pool = new();
+    private ReadOnlySequence<byte> _lastSequence;
+
+    private ManualResetValueTaskSourceCore<ReadResult> _core = new()
+    {
+        RunContinuationsAsynchronously = false,
+    };
+    private ValueTaskAwaiter<RecvSnapshot> _pendingRead;
+    private readonly Action _onRecvReady;
+
+    private bool _completed;
+    private bool _cancelRequested;
+    private bool _connectionClosed;
+    private bool _prologueDone;
+
+    public TlsInPlacePipeReader(TcpConnection connection, TlsSession session)
+    {
+        _conn = connection ?? throw new ArgumentNullException(nameof(connection));
+        _tls = session ?? throw new ArgumentNullException(nameof(session));
+        _onRecvReady = OnRecvReady;
+    }
+
+    public override ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfCompleted();
+        TakeHandshakePlaintext();
+
+        if (_cancelRequested)
+        {
+            _cancelRequested = false;
+            return new ValueTask<ReadResult>(BuildResult(isCanceled: true));
+        }
+
+        if (_heldBytes > _examined || _connectionClosed)
+        {
+            return new ValueTask<ReadResult>(BuildResult(isCanceled: false));
+        }
+
+        while (true)
+        {
+            ValueTask<RecvSnapshot> pending = _conn.ReadAsync();
+
+            if (!pending.IsCompletedSuccessfully)
+            {
+                _core.Reset();
+                _pendingRead = pending.GetAwaiter();
+                _pendingRead.UnsafeOnCompleted(_onRecvReady);
+                return new ValueTask<ReadResult>(this, _core.Version);
+            }
+
+            if (Ingest(pending.Result) || _connectionClosed || _cancelRequested)
+            {
+                bool canceled = _cancelRequested;
+                _cancelRequested = false;
+                return new ValueTask<ReadResult>(BuildResult(canceled));
+            }
+        }
+    }
+
+    private void OnRecvReady()
+    {
+        RecvSnapshot snapshot = _pendingRead.GetResult();
+
+        if (!Ingest(snapshot) && !_connectionClosed && !_cancelRequested)
+        {
+            while (true)
+            {
+                ValueTask<RecvSnapshot> pending = _conn.ReadAsync();
+
+                if (!pending.IsCompletedSuccessfully)
+                {
+                    _pendingRead = pending.GetAwaiter();
+                    _pendingRead.UnsafeOnCompleted(_onRecvReady);
+                    return;
+                }
+
+                if (Ingest(pending.Result) || _connectionClosed || _cancelRequested)
+                {
+                    break;
+                }
+            }
+        }
+
+        bool canceled = _cancelRequested;
+        _cancelRequested = false;
+        _core.SetResult(BuildResult(canceled));
+    }
+
+    /// <summary>
+    /// The client's first request usually rides in with its Finished flight, so the handshake
+    /// already decrypted it and it is sitting in the session, not in any recv buffer. Miss this and
+    /// the first request is dropped and the reader parks on bytes that already arrived.
+    /// </summary>
+    private void TakeHandshakePlaintext()
+    {
+        if (_prologueDone)
+        {
+            return;
+        }
+        _prologueDone = true;
+
+        ReadOnlySpan<byte> initial = _tls.DrainPlaintext();
+        if (initial.IsEmpty)
+        {
+            return;
+        }
+
+        byte[] owned = ArrayPool<byte>.Shared.Rent(initial.Length);
+        initial.CopyTo(owned);
+
+        Slice slice = Rent();
+        slice.SetOwned(owned, initial.Length);
+        Append(slice, initial.Length);
+    }
+
+    private bool Ingest(in RecvSnapshot snapshot)
+    {
+        bool any = false;
+
+        while (_conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+        {
+            if (!item.HasBuffer)
+            {
+                continue;
+            }
+
+            // Hand the ciphertext over first: after this the buffer is only a destination.
+            _tls.Feed(item.Ptr, item.Len);
+
+            int produced = _tls.DrainInto(item.Ptr, item.Len, out bool more);
+
+            if (produced == 0)
+            {
+                // A partial record, or a post-handshake message OpenSSL swallowed. Nothing for the
+                // caller and the bytes live in the BIO now, so the buffer goes straight back.
+                _conn.ReturnBuffer(in item);
+            }
+            else
+            {
+                Slice slice = Rent();
+                slice.SetRing(in item, produced);
+                Append(slice, produced);
+                any = true;
+            }
+
+            // The buffer filled while the record layer still had plaintext. That happens when a
+            // record straddles recvs and the buffer completing it is smaller than the plaintext it
+            // releases - the one case in-place cannot serve, so the remainder spills to rented
+            // memory. Rare, and correctness depends on it.
+            while (more)
+            {
+                byte[] owned = ArrayPool<byte>.Shared.Rent(TlsSession.MaxRecordPlaintext);
+                int spilled;
+                fixed (byte* p = owned)
+                {
+                    spilled = _tls.DrainInto(p, owned.Length, out more);
+                }
+
+                if (spilled == 0)
+                {
+                    ArrayPool<byte>.Shared.Return(owned);
+                    break;
+                }
+
+                Slice spill = Rent();
+                spill.SetOwned(owned, spilled);
+                Append(spill, spilled);
+                any = true;
+            }
+        }
+
+        _conn.ResetRead();
+
+        if (snapshot.IsClosed || _tls.Closed)
+        {
+            _connectionClosed = true;
+        }
+
+        return any;
+    }
+
+    private Slice Rent() => _pool.TryPop(out Slice? pooled) ? pooled : new Slice();
+
+    private void Append(Slice slice, int length)
+    {
+        if (_tail == null)
+        {
+            _head = _tail = slice;
+            _headConsumed = 0;
+        }
+        else
+        {
+            _tail.Link(slice);
+            _tail = slice;
+        }
+
+        _heldBytes += length;
+    }
+
+    private void Release(Slice slice)
+    {
+        if (slice.Owned is { } owned)
+        {
+            ArrayPool<byte>.Shared.Return(owned);
+            slice.Owned = null;
+        }
+        else
+        {
+            _conn.ReturnBuffer(in slice.Item);
+        }
+
+        _pool.Push(slice);
+    }
+
+    private ReadResult BuildResult(bool isCanceled)
+    {
+        _lastSequence = _head == null
+            ? default
+            : new ReadOnlySequence<byte>(_head, _headConsumed, _tail!, _tail!.Memory.Length);
+
+        return new ReadResult(_lastSequence, isCanceled, _connectionClosed);
+    }
+
+    public override bool TryRead(out ReadResult result)
+    {
+        ThrowIfCompleted();
+        TakeHandshakePlaintext();
+
+        if (_cancelRequested)
+        {
+            _cancelRequested = false;
+            result = BuildResult(isCanceled: true);
+            return true;
+        }
+
+        if (_heldBytes > _examined || _connectionClosed)
+        {
+            result = BuildResult(isCanceled: false);
+            return true;
+        }
+
+        result = default;
+        return false;
+    }
+
+    public override void AdvanceTo(SequencePosition consumed) => AdvanceTo(consumed, consumed);
+
+    public override void AdvanceTo(SequencePosition consumed, SequencePosition examined)
+    {
+        if (_head == null)
+        {
+            return;
+        }
+
+        // Rebase by the sequence start: GetOffset measures from the head SEGMENT, so a partially
+        // consumed head would over-count by _headConsumed and drive _heldBytes negative.
+        long startOffset = _lastSequence.GetOffset(_lastSequence.Start);
+        long consumedBytes = _lastSequence.GetOffset(consumed) - startOffset;
+        long examinedBytes = _lastSequence.GetOffset(examined) - startOffset;
+        if (examinedBytes < consumedBytes)
+        {
+            examinedBytes = consumedBytes;
+        }
+
+        long remaining = consumedBytes;
+        while (remaining > 0 && _head != null)
+        {
+            int available = _head.Memory.Length - _headConsumed;
+
+            if (remaining >= available)
+            {
+                Slice released = _head;
+                _head = released.NextSlice;
+                if (_head == null)
+                {
+                    _tail = null;
+                }
+                _headConsumed = 0;
+                Release(released);
+
+                remaining -= available;
+            }
+            else
+            {
+                _headConsumed += (int)remaining;
+                remaining = 0;
+            }
+        }
+
+        _heldBytes -= consumedBytes;
+        _examined = Math.Min(examinedBytes - consumedBytes, _heldBytes);
+    }
+
+    public override void CancelPendingRead() => _cancelRequested = true;
+
+    public override void Complete(Exception? exception = null)
+    {
+        if (_completed)
+        {
+            return;
+        }
+
+        _completed = true;
+
+        while (_head != null)
+        {
+            Slice released = _head;
+            _head = released.NextSlice;
+            Release(released);
+        }
+
+        _tail = null;
+        _headConsumed = 0;
+        _heldBytes = 0;
+        _examined = 0;
+    }
+
+    private void ThrowIfCompleted()
+    {
+        if (_completed)
+        {
+            throw new InvalidOperationException("Reading is not allowed after the reader was completed.");
+        }
+    }
+
+    ReadResult IValueTaskSource<ReadResult>.GetResult(short token) => _core.GetResult(token);
+
+    ValueTaskSourceStatus IValueTaskSource<ReadResult>.GetStatus(short token) => _core.GetStatus(token);
+
+    void IValueTaskSource<ReadResult>.OnCompleted(
+        Action<object?> continuation,
+        object? state,
+        short token,
+        ValueTaskSourceOnCompletedFlags flags)
+    {
+        // Reactor thread only - strip the context-post so resumes stay inline.
+        _core.OnCompleted(continuation, state, token,
+            flags & ~ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
+    }
+}

--- a/src/ioxide/Tls/TlsSession.cs
+++ b/src/ioxide/Tls/TlsSession.cs
@@ -120,8 +120,11 @@ public sealed unsafe class TlsSession : IDisposable
         }
     }
 
-    /// <summary>Maximum plaintext in one TLS record, RFC 8446 section 5.1.</summary>
-    private const int MaxRecordPlaintext = 16 * 1024;
+    /// <summary>
+    /// The most plaintext one TLS record can carry (RFC 8446 section 5.1). A destination this size
+    /// can always take a whole record, which is the protocol's own bound rather than a tuning knob.
+    /// </summary>
+    public const int MaxRecordPlaintext = 16 * 1024;
 
     /// <summary>
     /// Classify a non-positive SSL_read. False means stop and wait for more ciphertext; a genuine
@@ -150,6 +153,50 @@ public sealed unsafe class TlsSession : IDisposable
             default:
                 throw new IOException($"TLS decrypt failed (error {err}): {OpenSsl.LastError()}");
         }
+    }
+
+    /// <summary>
+    /// Hand ciphertext to the record layer without asking for plaintext back. Pair it with
+    /// <see cref="DrainInto"/>, which is what makes decrypting IN PLACE legal: a memory BIO copies
+    /// into its own buffer, so once this returns the caller's memory is dead as a source and may be
+    /// reused as the destination.
+    /// </summary>
+    public void Feed(byte* ciphertext, int length) => OpenSsl.BIO_write(_rbio, ciphertext, length);
+
+    /// <summary>
+    /// Pull up to <paramref name="length"/> bytes of plaintext out of whatever <see cref="Feed"/>
+    /// has already delivered, writing straight into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="more">
+    /// True when the destination filled and the record layer still has plaintext ready. The caller
+    /// must drain the rest somewhere else before feeding again - a record can straddle recvs, so
+    /// the buffer that completes one may be far smaller than the plaintext it releases.
+    /// </param>
+    /// <returns>Bytes written. Zero means nothing was ready, not that the connection ended.</returns>
+    public int DrainInto(byte* destination, int length, out bool more)
+    {
+        more = false;
+        int total = 0;
+
+        while (total < length)
+        {
+            int n = OpenSsl.SSL_read(_ssl, destination + total, length - total);
+
+            if (n > 0)
+            {
+                total += n;
+                continue;
+            }
+
+            // WANT_READ here means the record layer is empty, which is the ordinary end of a drain.
+            ShouldKeepReading(n);
+            return total;
+        }
+
+        // The destination is full. One more probe decides whether anything is still queued: a
+        // zero-length SSL_read cannot tell us, so ask OpenSSL directly.
+        more = OpenSsl.SSL_pending(_ssl) > 0;
+        return total;
     }
 
     internal void DrainPending()

--- a/tests/Ioxide.Tests.Harness/ReactorAffinity.cs
+++ b/tests/Ioxide.Tests.Harness/ReactorAffinity.cs
@@ -1,0 +1,59 @@
+using ioxide;
+
+namespace Ioxide.Tests;
+
+/// <summary>
+/// Records whether a handler is still running on the reactor that owns its ring, at points the
+/// test picks.
+///
+/// The invariant this exists to protect: <b>ioxide's own code must never be the reason a handler
+/// leaves its reactor.</b> The runtime does support off-reactor callers - <c>SubmitClientOp</c>
+/// hands them to <c>_remoteOps</c> and wakes the ring - but that path is an escape hatch for USER
+/// code that deliberately goes cross-thread. When one of ioxide's own seams trips it, every client
+/// call on that connection silently becomes a queue push plus an eventfd write plus a reactor
+/// wake-up, for the life of the connection, and nothing anywhere reports it.
+///
+/// The check is deliberately <see cref="Reactor.OnReactorThread"/> - the very predicate
+/// <c>SubmitClientOp</c> branches on - rather than a thread name or a SynchronizationContext, so
+/// a passing test means precisely "the marshal path would not have been taken here".
+/// </summary>
+public sealed class ReactorAffinity
+{
+    private readonly object _gate = new();
+    private readonly List<string> _drift = [];
+    private int _checks;
+
+    /// <summary>
+    /// Assert-and-record. Never throws: a handler that threw here would look like a connection
+    /// fault and the test would report the wrong thing.
+    /// </summary>
+    public void Check(Reactor reactor, string where)
+    {
+        lock (_gate)
+        {
+            _checks++;
+
+            if (reactor.OnReactorThread)
+            {
+                return;
+            }
+
+            Thread thread = Thread.CurrentThread;
+            _drift.Add($"{where}: tid={Environment.CurrentManagedThreadId} "
+                     + $"name={thread.Name ?? "<none>"} pool={thread.IsThreadPoolThread} "
+                     + $"ctx={SynchronizationContext.Current?.GetType().Name ?? "<null>"}");
+        }
+    }
+
+    /// <summary>How many observations were taken - zero means the handler never ran.</summary>
+    public int Checks
+    {
+        get { lock (_gate) { return _checks; } }
+    }
+
+    /// <summary>Every point that ran off-reactor, for the failure message.</summary>
+    public IReadOnlyList<string> Drift
+    {
+        get { lock (_gate) { return _drift.ToArray(); } }
+    }
+}

--- a/tests/Ioxide.Tests.Tls/TlsPipeTests.cs
+++ b/tests/Ioxide.Tests.Tls/TlsPipeTests.cs
@@ -30,6 +30,39 @@ internal static class TlsPipeTests
             Assert.Equal("pipe-tls-ok", body);
         }, skip: !ktls);
 
+        runner.Test("tls pipe: serving never leaves the reactor thread", () =>
+        {
+            // ioxide supports off-reactor submission - SubmitClientOp marshals through _remoteOps
+            // and wakes the ring - but that is an escape hatch for USER code that deliberately goes
+            // cross-thread. None of ioxide's own seams may trip it.
+            //
+            // TlsConnectionDualPipe did. Its inbound Pipe was built with
+            // PipeOptions(useSynchronizationContext: false) and nothing else, and a Pipe's
+            // schedulers default to PipeScheduler.ThreadPool - so the first genuinely-async
+            // ReadAsync completed on a pool thread with a NULL SynchronizationContext, which is
+            // what makes it permanent: with no context, nothing can post the connection back. From
+            // there every client call on that connection paid a queue hop and an eventfd wake, and
+            // nothing reported it. Only UdpSendTo throws on the wrong thread; the TCP path is
+            // silent, so an h3 upstream was the only way to see it at all.
+            //
+            // Checking OnReactorThread is checking the exact predicate SubmitClientOp branches on.
+            (string certPath, string keyPath) = TestCert.Ensure();
+            var options = new TlsOptions { CertificatePath = certPath, KeyPath = keyPath };
+
+            var affinity = new ReactorAffinity();
+            int port = TestServer.Start(AffinityHandler(affinity), r => TlsService.Start(r, options));
+
+            (int status, string body) = Client.GetTls(port, "/");
+            Assert.Equal(200, status);
+            Assert.Equal("pipe-tls-ok", body);
+
+            // A handler that never ran would leave Drift empty and pass vacuously.
+            Assert.True(affinity.Checks >= 2,
+                $"expected at least two observations, got {affinity.Checks}");
+            Assert.True(affinity.Drift.Count == 0,
+                "ioxide moved the handler off its reactor: " + string.Join("; ", affinity.Drift));
+        }, skip: !ktls);
+
         runner.Test("tls pipe: garbage after the handshake faults the reader, not a clean EOF", () =>
         {
             // The property both hand-rolled pumps get wrong. A TLS protocol error must reach the
@@ -55,6 +88,49 @@ internal static class TlsPipeTests
                 $"expected the decrypt to fault, got: {reason}");
         }, skip: !ktls);
     }
+
+    // Same shape as PipeHandler, with an affinity observation on either side of the await that
+    // matters: the one on the TLS pipe's reader.
+    private static Func<Reactor, TcpConnection, Task> AffinityHandler(ReactorAffinity affinity)
+        => async (reactor, connection) =>
+        {
+            TlsSession? session = null;
+            TlsConnectionDualPipe? pipe = null;
+            try
+            {
+                session = await reactor.GetService<TlsService>()!.AcceptAsync(connection);
+                affinity.Check(reactor, "after AcceptAsync");
+
+                pipe = new TlsConnectionDualPipe(connection, session);
+
+                ReadResult read = await pipe.Input.ReadAsync();
+                affinity.Check(reactor, "after Input.ReadAsync");
+                pipe.Input.AdvanceTo(read.Buffer.End);
+
+                const string body = "pipe-tls-ok";
+                pipe.Output.Write(Encoding.ASCII.GetBytes(
+                    $"HTTP/1.1 200 OK\r\nContent-Length: {body.Length}\r\n\r\n{body}"));
+                await pipe.Output.FlushAsync();
+                affinity.Check(reactor, "after Output.FlushAsync");
+            }
+            catch
+            {
+                // The client hung up, or the handshake failed - the harness probes the port with a
+                // raw TCP connection, so this fires once per run and is not a test failure.
+            }
+            finally
+            {
+                if (pipe is not null)
+                {
+                    await pipe.DisposeAsync();
+                }
+                else
+                {
+                    session?.Dispose();
+                }
+                connection.DecRef();
+            }
+        };
 
     // Serves one request off the decrypted PipeReader and answers as plaintext through the pipe's
     // writer, which is where kTLS takes over.


### PR DESCRIPTION
Three ways to serve TLS over an `IDuplexPipe`, measured against each other. **Nothing here is proposed for merge** — it is an experiment plus a report, and one of the three currently has an unexplained SIGSEGV.

## The three

| | plaintext lives in | moving parts | backpressure | lines |
|---|---|---|---|---|
| **pump** `TlsConnectionDualPipe` (on main) | a `Pipe` it owns | pump `Task` + `Pipe` | the Pipe's pause threshold | ~195 |
| **inplace** `TlsConnectionDualPipeInPlace` | the recv buffer | none | the ring | ~460 |
| **direct** `TlsConnectionDualPipeDirect` | the recv buffer | none | the ring | ~220 |

All three work because a memory BIO copies: once `TlsSession.Feed` hands the ciphertext to OpenSSL the buffer is dead as a *source* and free to be the *destination*. Plaintext always fits — a TLS 1.3 record spends 5 bytes of header, 1 of content type and a 16-byte tag, so it is at least 22 bytes shorter than its ciphertext.

**inplace** copies `TcpConnectionPipeReader` wholesale — chaining, segment pooling, consumed/examined bookkeeping — and adds a spill array for records straddling recvs. **direct** holds exactly one buffer, which is what deletes all of that: leftovers stay queued (`TcpConnection.ReadAsync` returns synchronously while its recv queue is non-empty), and the straddle case is handled by draining the held buffer a *second* time once the caller has consumed it. Overflow and ordinary path become the same code.

## Correctness

Byte-exact, independently computed FNV-1a over the request body, all three implementations:

```
size        pump   inplace  direct
0             ok     ok       ok
100           ok     ok       ok
8192          ok     ok       ok
65536         ok     ok       ok
1048576       ok     ok       ok
4194304       ok     ok       ok
```

The handler originally ignored the body, so a corrupted one would still have returned 200 — it echoes length+checksum now. For **inplace**, counters showed `spill=47` of 375 slices, so the straddle path genuinely executes rather than being untested code.

## Throughput

`h2load -c 32 -m 32`, 4 reactors, TLS, interleaved warm, mean of 3.

**Response size** (this is the kTLS write path — identical in all three, included to show it):

```
body       2B   pump 1,575,720   inplace 1,595,374 (1.01x)   direct 1,639,286 (1.04x)
body    1024B   pump 1,171,929   inplace 1,212,290 (1.03x)   direct 1,200,318 (1.02x)
body   16384B   pump   154,806   inplace   159,039 (1.03x)   direct   157,189 (1.02x)
body  262144B   pump    14,482   inplace    14,461 (1.00x)   direct    14,560 (1.01x)
```

**Request size** — the read path, where they actually differ:

```
req      64B   pump 1,110,965   inplace 1,048,134 (0.94x)   direct 1,077,454 (0.97x)
req    4096B   pump   375,963   inplace   377,963 (1.01x)   direct   362,778 (0.96x)
req   16384B   pump   124,544   inplace   125,096 (1.00x)   direct   124,035 (1.00x)
req   65536B   pump    34,964   inplace    34,161 (0.98x)   direct    34,759 (0.99x)
req  262144B   pump     9,123   inplace     9,047 (0.99x)   direct    CRASHED
```

**All three are within noise.** That is the expected result and worth stating plainly: the copy count is identical in every variant — ring→BIO, then BIO→destination. In-place changes *where* the plaintext lands, not how many times it is copied. Nobody should adopt either prototype expecting throughput.

## Memory

Idle: identical (165 MiB). Under 1000 concurrent connections with 64 KiB bodies, **one sample**:

```
pump 2124 MiB   inplace 2211 MiB   (+87, 1.04x)
```

In-place went the *wrong* way, and the mechanism explains it: holding a slice pins a whole `RecvBufferSize` (32 KiB) of ring memory however few plaintext bytes it carries, where the pump copies into a compact Pipe and hands the ring buffer straight back. That is the buffer-hoarding failure mode the shared-ring docs already warn about. One sample, so treat it as directional.

## Incremental buffers: compatible

I expected these to be mutually exclusive. They are not.

```csharp
// Data lands at the buffer's running offset; the kernel keeps appending
// to this bid until the buffer is full (F_BUF_MORE clear).
byte* ptr = conn.BufSlab + (nuint)bid * (nuint)_incRecvBufferSize + (nuint)conn.CumOffset![bid];
conn.CumOffset[bid] += res;
```

Each CQE hands you a slice inside a buffer the kernel is still writing to — but `CumOffset` has already advanced, so the next append lands at `ptr + res`, while in-place decrypt only ever writes `[ptr, ptr + produced)` with `produced <= res`. **Disjoint.** Confirmed empirically with 4 KiB buffers, 16 per connection:

```
INCREMENTAL MODE - correctness
request     pump   inplace  direct
100           ok     ok       ok
8192          ok     ok       ok
65536         ok     ok       ok
262144        ok     ok       ok
```

Throughput under incremental does drop for the in-place variants, though:

```
shared ring  16KiB req   pump 122,599   inplace 122,351 (1.00x)   direct 118,533 (0.97x)
incremental  16KiB req   pump 121,392   inplace 116,675 (0.96x)   direct 109,586 (0.90x)
```

Consistent with buffer pinning: incremental rings are far smaller (16 x 4 KiB per connection vs 4096 x 32 KiB shared), so holding one buffer costs proportionally much more, and `-ENOBUFS` starvation gets closer. `Reactor.Tcp.cs` already comments this case ("a body larger than the ring while the handler still holds buffers").

## The open defect

**`direct` exited 139 (SIGSEGV) once**, at 256 KiB request bodies, during the sweep where all three servers ran concurrently. Silent — no managed exception, nothing in the log.

It has **not** reproduced in isolation:
- 1 reactor, 20 x 256 KiB: 20/20 succeeded
- 4 reactors, `-c 32 -m 32`, 40000 x 256 KiB: 40000/40000 succeeded, server alive

So it needs memory pressure or contention. Until it is understood, `direct` is not a candidate regardless of how the numbers look. My leading suspects are the per-read `UnmanagedMemoryManager` allocated inline in `TryBuild` (not stored, unlike `TcpConnectionPipeReader` which keeps it in the `Slice`), and the second `DrainInto` in `AdvanceTo` running against an `_item` whose generation may have moved.

## Where this leaves it

The pump is not obviously worse than either replacement. It costs a `Task`, a `Pipe` and a tuning knob; it buys compact memory under concurrency and it is the only one of the three with no open defect. `direct` is the interesting one — it is the smallest by a wide margin and the only one whose complexity feels proportional to "decrypt some bytes" — but it needs the segfault understood first.

Reproduce anything above with `PLAYGROUND_TLSPIPE=pump|inplace|direct` and `PLAYGROUND_INCREMENTAL=1` on `Playground/Http2/Tls`.
