### PR TITLE
fix(tls): answer per request not per decrypt - tests, samples and docs

### DIFF
--- a/Playground/Http2/Tls/Program.cs
+++ b/Playground/Http2/Tls/Program.cs
@@ -1,4 +1,5 @@
 using System.IO.Pipelines;
+using System.Runtime.InteropServices;
 using System.Text;
 using ioxide;
 using ioxide.nghttp2;
@@ -104,10 +105,35 @@ for (int i = 0; i < threads.Length; i++)
 
             // Anything else: HTTP/1.1 on the same port, written as plaintext because kTLS is
             // producing the records.
+            //
+            // The carry is not incidental. TLS hands back RECORDS, not requests, so a request
+            // split across two records decrypts twice - and answering on "plaintext arrived"
+            // would answer twice to one request. Framing is ours; ioxide does not parse HTTP.
+            var carry = new List<byte>();
+
+            // The client's first request usually rides in with its Finished flight, so the
+            // handshake already decrypted it and it is sitting in the session, not in any recv
+            // buffer. Miss this and that request is dropped and the loop parks on bytes that
+            // already arrived - which is exactly what happened here before.
+            carry.AddRange(tls.DrainPlaintext());
+
             while (true)
             {
+                bool wrote = false;
+                int end;
+                while ((end = CollectionsMarshal.AsSpan(carry).IndexOf("\r\n\r\n"u8)) >= 0)
+                {
+                    carry.RemoveRange(0, end + 4);
+                    conn.Write(http11Response);
+                    wrote = true;
+                }
+
+                if (wrote)
+                {
+                    await conn.FlushAsync();
+                }
+
                 RecvSnapshot snapshot = await conn.ReadAsync();
-                bool sawRequest = false;
 
                 unsafe
                 {
@@ -115,16 +141,10 @@ for (int i = 0; i < threads.Length; i++)
                     {
                         if (item.HasBuffer)
                         {
-                            sawRequest |= tls.Decrypt(item.Ptr, item.Len).Length > 0;
+                            carry.AddRange(tls.Decrypt(item.Ptr, item.Len));
                             conn.ReturnBuffer(in item);
                         }
                     }
-                }
-
-                if (sawRequest)
-                {
-                    conn.Write(http11Response);
-                    await conn.FlushAsync();
                 }
 
                 if (snapshot.IsClosed || tls.Closed) return;

--- a/Playground/Tls/Ktls/Program.cs
+++ b/Playground/Tls/Ktls/Program.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Runtime.InteropServices;
 using ioxide;
 using ioxide.tls;
 using ioxide.utils;
@@ -63,6 +64,13 @@ for (int i = 0; i < threads.Length; i++)
     reactor.TcpHandle = async (r, conn) =>
     {
         TlsSession? tls = null;
+
+        // Decrypted bytes waiting to be framed. TLS hands back records, not requests: split one
+        // request across two records and each decrypts on its own, so answering per decrypt
+        // answers twice. The carry is what turns "some plaintext arrived" into "a request
+        // arrived", exactly as the plaintext samples do - ioxide does not parse HTTP for you.
+        var carry = new List<byte>();
+
         try
         {
             // The handshake reads and writes through this same connection; after it, the socket
@@ -71,9 +79,9 @@ for (int i = 0; i < threads.Length; i++)
 
             // A request can ride in with the handshake's final flight - answer it before parking
             // in ReadAsync, or the client waits on a response we never send.
-            if (tls.DrainPlaintext().Length > 0)
+            carry.AddRange(tls.DrainPlaintext());
+            if (Answer(conn, carry, response))
             {
-                conn.Write(response);
                 await conn.FlushAsync();
             }
 
@@ -81,21 +89,19 @@ for (int i = 0; i < threads.Length; i++)
             {
                 RecvSnapshot snapshot = await conn.ReadAsync();
 
-                int got = 0;
                 while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
                 {
                     if (item.HasBuffer)
                     {
                         // Records in, plaintext out - the session decrypts what the ring received.
-                        got += DecryptLength(tls, in item);
+                        Decrypt(tls, in item, carry);
                         conn.ReturnBuffer(in item);
                     }
                 }
 
-                if (got > 0)
+                if (Answer(conn, carry, response))
                 {
-                    conn.Write(response);   // plaintext: the kernel encrypts on send
-                    await conn.FlushAsync();
+                    await conn.FlushAsync();   // plaintext: the kernel encrypts on send
                 }
 
                 if (snapshot.IsClosed || tls.Closed) return;
@@ -129,5 +135,22 @@ foreach (Thread thread in threads)
 
 // Decrypt takes a raw pointer (the buffer belongs to the ring); the pointer work stays out of the
 // async handler, which cannot contain unsafe code.
-static unsafe int DecryptLength(TlsSession tls, in SpscRecvRing.Item item)
-    => tls.Decrypt(item.Ptr, item.Len).Length;
+static unsafe void Decrypt(TlsSession tls, in SpscRecvRing.Item item, List<byte> carry)
+    => carry.AddRange(tls.Decrypt(item.Ptr, item.Len));
+
+// One response per COMPLETE request in the carry, and none for a partial one. Returns whether
+// anything was written, so the caller flushes once for the batch rather than once per request.
+static bool Answer(TcpConnection conn, List<byte> carry, ReadOnlyMemory<byte> response)
+{
+    bool wrote = false;
+    int end;
+
+    while ((end = CollectionsMarshal.AsSpan(carry).IndexOf("\r\n\r\n"u8)) >= 0)
+    {
+        carry.RemoveRange(0, end + 4);
+        conn.Write(response.Span);
+        wrote = true;
+    }
+
+    return wrote;
+}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ ioxide hands you raw bytes and stays out of HTTP; when you want a framework on t
 `ioxide.Kestrel` swaps the transport under an existing ASP.NET Core app with your endpoints
 unchanged.
 
-> Linux 6.1+ · .NET 10 / .NET 11 · `0.4.152` - experimental
+> Linux 6.1+ · .NET 10 / .NET 11 · `0.4.153` - experimental
 
 **[Documentation](https://mda2av.github.io/ioxide/)** - architecture, guides, and every example as
 runnable code side by side.

--- a/docs/index.html
+++ b/docs/index.html
@@ -210,8 +210,10 @@ for (int id = 0; id &lt; threads.Length; id++)
                 {
                     ok.Span.CopyTo(writer.GetSpan(ok.Length));
                     writer.Advance(ok.Length);
-                    await writer.FlushAsync();
+                    wrote = true;
                 }
+
+                if (wrote) await writer.FlushAsync();
 
                 reader.AdvanceTo(consumed, buffer.End);   // partial tail is kept
 
@@ -437,6 +439,7 @@ foreach (Thread t in threads) t.Join();</code></pre>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide      -- TLS ships in the core package
 // Needs the Linux &#x27;tls&#x27; module (sudo modprobe tls), OpenSSL 3, and cert.pem / key.pem.
+using System.Runtime.InteropServices;
 using ioxide;
 using ioxide.tls;
 using ioxide.utils;
@@ -482,6 +485,7 @@ for (int id = 0; id &lt; threads.Length; id++)
     reactor.TcpHandle = async (r, conn) =&gt;
     {
         TlsSession? tls = null;
+        var carry = new List&lt;byte&gt;();   // decrypted bytes waiting to be framed into requests
 
         try
         {
@@ -500,21 +504,29 @@ for (int id = 0; id &lt; threads.Length; id++)
             {
                 RecvSnapshot snapshot = await conn.ReadAsync();
 
-                int got = 0;
                 while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
                 {
                     if (item.HasBuffer)
                     {
-                        got += Decrypt(tls, in item);   // only transmit is offloaded
+                        Decrypt(tls, in item, carry);   // only transmit is offloaded
                         conn.ReturnBuffer(in item);
                     }
                 }
 
-                if (got &gt; 0)
+                // One response per COMPLETE request. TLS hands back RECORDS, not requests: a
+                // request split across two records decrypts twice, so answering on &quot;plaintext
+                // arrived&quot; would answer twice to one request. Framing is yours either way -
+                // this is the same carry the cleartext samples keep.
+                bool wrote = false;
+                int end;
+                while ((end = CollectionsMarshal.AsSpan(carry).IndexOf(&quot;\r\n\r\n&quot;u8)) &gt;= 0)
                 {
+                    carry.RemoveRange(0, end + 4);
                     conn.Write(ok.Span);   // plaintext in; the kernel produces the records
-                    await conn.FlushAsync();
+                    wrote = true;
                 }
+
+                if (wrote) await conn.FlushAsync();
 
                 if (snapshot.IsClosed || tls.Closed) return;
                 conn.ResetRead();
@@ -539,11 +551,11 @@ for (int id = 0; id &lt; threads.Length; id++)
 Console.WriteLine($&quot;TLS on :{config.Tcp.Port} (kTLS transmit offload)&quot;);
 foreach (Thread t in threads) t.Join();
 
-static unsafe int Decrypt(TlsSession tls, in SpscRecvRing.Item item)
+static unsafe void Decrypt(TlsSession tls, in SpscRecvRing.Item item, List&lt;byte&gt; carry)
 {
     fixed (byte* cipher = item.AsSpan())
     {
-        return tls.Decrypt(cipher, item.AsSpan().Length).Length;
+        carry.AddRange(tls.Decrypt(cipher, item.AsSpan().Length));
     }
 }</code></pre>
   </div>
@@ -556,6 +568,7 @@ static unsafe int Decrypt(TlsSession tls, in SpscRecvRing.Item item)
 <pre><code class="language-csharp">// dotnet add package ioxide      -- TLS ships in the core package
 // Needs the Linux &#x27;tls&#x27; module (sudo modprobe tls), OpenSSL 3, and cert.pem / key.pem.
 using System.IO.Pipelines;
+using System.Runtime.InteropServices;
 using ioxide;
 using ioxide.tls;
 
@@ -584,6 +597,7 @@ for (int id = 0; id &lt; threads.Length; id++)
     reactor.TcpHandle = async (r, conn) =&gt;
     {
         TlsSession? tls = null;
+        var carry = new List&lt;byte&gt;();   // decrypted bytes waiting to be framed into requests
 
         try
         {
@@ -609,15 +623,19 @@ for (int id = 0; id &lt; threads.Length; id++)
 
                 // The pipe hands CIPHERTEXT - only transmit is offloaded - so decrypt each
                 // segment as it is consumed.
-                int got = 0;
                 foreach (ReadOnlyMemory&lt;byte&gt; segment in result.Buffer)
                 {
-                    got += Decrypt(tls, segment.Span);
+                    Decrypt(tls, segment.Span, carry);
                 }
                 reader.AdvanceTo(result.Buffer.End);
 
-                if (got &gt; 0)
+                // Answer per REQUEST, not per decrypt - a request split across two TLS records
+                // decrypts twice, and &quot;plaintext arrived&quot; would fire for each.
+                bool wrote = false;
+                int end;
+                while ((end = CollectionsMarshal.AsSpan(carry).IndexOf(&quot;\r\n\r\n&quot;u8)) &gt;= 0)
                 {
+                    carry.RemoveRange(0, end + 4);
                     // The write side is the plain pipes path, untouched: plaintext into the
                     // slab, one flush - the kernel encrypts on send.
                     ok.Span.CopyTo(writer.GetSpan(ok.Length));
@@ -647,11 +665,11 @@ for (int id = 0; id &lt; threads.Length; id++)
 Console.WriteLine($&quot;TLS on :{config.Tcp.Port} (kTLS transmit offload, pipes surface)&quot;);
 foreach (Thread t in threads) t.Join();
 
-static unsafe int Decrypt(TlsSession tls, ReadOnlySpan&lt;byte&gt; ciphertext)
+static unsafe void Decrypt(TlsSession tls, ReadOnlySpan&lt;byte&gt; ciphertext, List&lt;byte&gt; carry)
 {
     fixed (byte* cipher = ciphertext)
     {
-        return tls.Decrypt(cipher, ciphertext.Length).Length;
+        carry.AddRange(tls.Decrypt(cipher, ciphertext.Length));
     }
 }
 </code></pre>
@@ -793,6 +811,7 @@ foreach (Thread t in threads) t.Join();
 // Needs the Linux &#x27;tls&#x27; module (sudo modprobe tls), OpenSSL 3, and cert.pem / key.pem.
 //   curl -k --http2   https://127.0.0.1:8443/     # negotiates h2
 //   curl -k --http1.1 https://127.0.0.1:8443/     # same port, gets http/1.1
+using System.Runtime.InteropServices;
 using ioxide;
 using ioxide.nghttp2;
 using ioxide.tls;
@@ -846,10 +865,26 @@ for (int id = 0; id &lt; threads.Length; id++)
 
             // Anything else: HTTP/1.1 on the same port. Written as PLAINTEXT - after the handshake
             // kernel TLS owns transmit, so there is nothing left to wrap.
+            // The first request usually rides in with the handshake's Finished flight, so it is
+            // already decrypted and sitting in the session rather than in any recv buffer.
+            var carry = new List&lt;byte&gt;(tls.DrainPlaintext().ToArray());
+
             while (true)
             {
+                // One response per COMPLETE request. TLS hands back RECORDS, not requests - split
+                // one request across two records and answering per decrypt answers twice.
+                bool wrote = false;
+                int end;
+                while ((end = CollectionsMarshal.AsSpan(carry).IndexOf(&quot;\r\n\r\n&quot;u8)) &gt;= 0)
+                {
+                    carry.RemoveRange(0, end + 4);
+                    conn.Write(http11);
+                    wrote = true;
+                }
+
+                if (wrote) await conn.FlushAsync();
+
                 RecvSnapshot snapshot = await conn.ReadAsync();
-                bool request = false;
 
                 unsafe
                 {
@@ -857,16 +892,10 @@ for (int id = 0; id &lt; threads.Length; id++)
                     {
                         if (item.HasBuffer)
                         {
-                            request |= tls.Decrypt(item.Ptr, item.Len).Length &gt; 0;
+                            carry.AddRange(tls.Decrypt(item.Ptr, item.Len));
                             conn.ReturnBuffer(in item);
                         }
                     }
-                }
-
-                if (request)
-                {
-                    conn.Write(http11);
-                    await conn.FlushAsync();
                 }
 
                 if (snapshot.IsClosed || tls.Closed) return;

--- a/docs/learn/tls.html
+++ b/docs/learn/tls.html
@@ -127,8 +127,14 @@ reactor.OnStart = r =&gt; TlsService.Start(r, options);</code></pre>
                 conn.ReturnBuffer(in item);
             }
 
-            conn.Write(response);          // plaintext in; the kernel makes the records
-            await conn.FlushAsync();       // ordinary io_uring send
+            // Answer per REQUEST, not per read. TLS hands back RECORDS, not requests, so a
+            // request split across two records decrypts twice - and one response per decrypt
+            // is two responses to one request. Feed() above is doing the accumulating.
+            while (TakeOneRequest())
+            {
+                conn.Write(response);      // plaintext in; the kernel makes the records
+            }
+            await conn.FlushAsync();       // ordinary io_uring send, once per batch
 
             if (snapshot.IsClosed || (tls?.Closed ?? false)) return;
             conn.ResetRead();

--- a/src/clients/ioxide.file/ioxide.file.csproj
+++ b/src/clients/ioxide.file/ioxide.file.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.file</RootNamespace>
 
     <PackageId>ioxide.file</PackageId>
-    <Version>0.4.152</Version>
+    <Version>0.4.153</Version>
     <Authors>MDA2AV</Authors>
     <Description>File serving for the ioxide io_uring runtime: immutable asset snapshots with baked responses, pooled positional ring reads, atomic reloads.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
+++ b/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.httpclient</RootNamespace>
 
     <PackageId>ioxide.httpclient</PackageId>
-    <Version>0.4.152</Version>
+    <Version>0.4.153</Version>
     <Authors>MDA2AV</Authors>
     <Description>The ring-native HTTP client for the ioxide io_uring runtime: HTTP/1.1, HTTP/2 and HTTP/3 behind one API, with the protocol chosen per origin via Alt-Svc. One package - the h1 parser, the nghttp2 and nghttp3 bridges, client-side TLS (SNI, ALPN and certificate verification) for https:// origins, and the negotiating client - sharing one set of message types. Every response resumes the awaiting handler inline on its own reactor thread.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.pg/ioxide.pg.csproj
+++ b/src/clients/ioxide.pg/ioxide.pg.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.pg</RootNamespace>
 
     <PackageId>ioxide.pg</PackageId>
-    <Version>0.4.152</Version>
+    <Version>0.4.153</Version>
     <Authors>MDA2AV</Authors>
     <Description>Postgres driver for the ioxide io_uring runtime: pooled ring-native connections per reactor, ring-native connect and handshake, inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.redis/ioxide.redis.csproj
+++ b/src/clients/ioxide.redis/ioxide.redis.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.redis</RootNamespace>
 
     <PackageId>ioxide.redis</PackageId>
-    <Version>0.4.152</Version>
+    <Version>0.4.153</Version>
     <Authors>MDA2AV</Authors>
     <Description>Redis client for the ioxide io_uring runtime: pooled ring-native connections per reactor, full RESP2 protocol, a generic command API plus typed helpers (strings, keys, hashes, lists, sets, sorted sets, pub/sub, transactions, scripting), and pipelining. Inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ioxide/ioxide.csproj
+++ b/src/ioxide/ioxide.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide</RootNamespace>
 
     <PackageId>ioxide</PackageId>
-    <Version>0.4.152</Version>
+    <Version>0.4.153</Version>
     <Authors>MDA2AV</Authors>
     <Description>A shared-nothing io_uring runtime for .NET: one ring per reactor thread, inline completions, zero native dependencies. The engine - reactor, connection, and the IRingHost client seam. Includes TLS termination: the OpenSSL handshake driven over the ring, then kernel TLS (kTLS) transmit offload, so handlers keep writing plaintext. TLS needs OpenSSL 3 and the Linux tls module; nothing else does, and neither is loaded unless you use it.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http2/ioxide.http2.csproj
+++ b/src/protocols/ioxide.http2/ioxide.http2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http2</RootNamespace>
 
     <PackageId>ioxide.http2</PackageId>
-    <Version>0.4.152</Version>
+    <Version>0.4.153</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure-C# HTTP/2 for the ioxide io_uring runtime: framing, HPACK (static and dynamic tables, Huffman) and flow control, with zero native code. A drop-in alternative to ioxide.nghttp2 for deployments that would rather not ship a native library - same connection shape, same request and response types.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http3/ioxide.http3.csproj
+++ b/src/protocols/ioxide.http3/ioxide.http3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http3</RootNamespace>
 
     <PackageId>ioxide.http3</PackageId>
-    <Version>0.4.152</Version>
+    <Version>0.4.153</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure C# HTTP/3 for the ioxide io_uring runtime: frame parsing, QPACK (static table + Huffman) and request dispatch with zero native dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, drop-in alternative to ioxide.nghttp3.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
+++ b/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp2</RootNamespace>
 
     <PackageId>ioxide.nghttp2</PackageId>
-    <Version>0.4.152</Version>
+    <Version>0.4.153</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/2 for the ioxide io_uring runtime: framing, HPACK and flow control from nghttp2, statically linked behind a small shim with no external dependencies beyond libc. Serves HTTP/2 over any TcpConnection - h2c with prior knowledge, or h2 over TLS via ALPN - and backs the HTTP/2 client in ioxide.httpclient from the same session code. nghttp2 is sans-I/O, so ioxide keeps the ring and the loop.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
+++ b/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp3</RootNamespace>
 
     <PackageId>ioxide.nghttp3</PackageId>
-    <Version>0.4.152</Version>
+    <Version>0.4.153</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/3 layer for the ioxide io_uring runtime: nghttp3 (H3 + QPACK) bundled as a single self-contained native library with no external dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, no ioxide.ngtcp2 dependency.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
+++ b/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.ngtcp2</RootNamespace>
 
     <PackageId>ioxide.ngtcp2</PackageId>
-    <Version>0.4.152</Version>
+    <Version>0.4.153</Version>
     <Authors>MDA2AV</Authors>
     <Description>QUIC engine for the ioxide io_uring runtime: ngtcp2 + picotls bundled as a single self-contained native library (only system dependency: libcrypto.so.3 / OpenSSL 3.x). Plugs into the reactor's QUIC transport via QuicConnection. Server side; engine bindings in progress.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
+++ b/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.Kestrel</RootNamespace>
 
     <PackageId>ioxide.Kestrel</PackageId>
-    <Version>0.4.152</Version>
+    <Version>0.4.153</Version>
     <Authors>MDA2AV</Authors>
     <Description>ASP.NET Core Kestrel transport backed by the ioxide io_uring runtime: one reactor (ring) per core, SO_REUSEPORT load-balanced, with Kestrel's HTTP request loop pinned to the reactor thread. Drop-in via UseIoxide().</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/Ioxide.Tests.Harness/Handlers.cs
+++ b/tests/Ioxide.Tests.Harness/Handlers.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Runtime.InteropServices;
 using ioxide;
 using ioxide.file;
 using ioxide.tls;
@@ -129,6 +130,7 @@ public static class Handlers
     public static async Task Tls(Reactor r, TcpConnection conn)
     {
         TlsSession? tls = null;
+        var carry = new List<byte>();
 
         try
         {
@@ -138,19 +140,35 @@ public static class Handlers
             {
                 RecvSnapshot snapshot = await conn.ReadAsync();
 
-                int got = 0;
                 while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
                 {
                     if (item.HasBuffer)
                     {
-                        got += DecryptLength(tls, item);
+                        AppendPlaintext(tls, item, carry);
                         conn.ReturnBuffer(in item);
                     }
                 }
 
-                if (got > 0)
+                // Answer per REQUEST, not per decrypt. Those are the same thing only while a
+                // client sends each request in one TLS record - split one across records and
+                // "some plaintext arrived" fires once per record, so one request draws several
+                // responses. TLS reassembly is not the issue: OpenSSL yields nothing until a
+                // record is whole. Framing above it is ours, exactly as in the plaintext path.
+                int responded = 0;
+                int idx;
+                while ((idx = CollectionsMarshal.AsSpan(carry).IndexOf("\r\n\r\n"u8)) >= 0)
+                {
+                    carry.RemoveRange(0, idx + 4);
+                    responded++;
+                }
+
+                for (int i = 0; i < responded; i++)
                 {
                     Wire.Write(conn, 200, "tls-ok");
+                }
+
+                if (responded > 0)
+                {
                     await conn.FlushAsync();
                 }
 
@@ -173,9 +191,9 @@ public static class Handlers
         }
     }
 
-    private static unsafe int DecryptLength(TlsSession tls, in SpscRecvRing.Item item)
+    private static unsafe void AppendPlaintext(TlsSession tls, in SpscRecvRing.Item item, List<byte> carry)
     {
-        return tls.Decrypt(item.Ptr, item.Len).Length;
+        carry.AddRange(tls.Decrypt(item.Ptr, item.Len).ToArray());
     }
 
     // The asset cache hands back one native response block; copy it through the write slab.

--- a/tests/Ioxide.Tests.Harness/TestServer.cs
+++ b/tests/Ioxide.Tests.Harness/TestServer.cs
@@ -395,6 +395,186 @@ public static class Client
     }
 
     /// <summary>
+    /// Split ONE request across several TLS records - each SslStream.Write emits its own complete
+    /// record - and report how many responses came back.
+    ///
+    /// This is the other fragmentation axis and the one that actually distinguishes handlers.
+    /// A record split across TCP is all-or-nothing: OpenSSL yields nothing until it is whole, so
+    /// even a handler that answers per decrypt sees exactly one decrypt. Split the REQUEST across
+    /// records and each one decrypts on its own, so answering per decrypt answers several times.
+    /// </summary>
+    public static int CountTlsResponsesForMultiRecordRequest(int port, string path, int records,
+        int settleMs = 1200, int timeoutMs = 15000)
+    {
+        using var client = new TcpClient();
+        client.NoDelay = true;
+        client.Connect("127.0.0.1", port);
+        client.ReceiveTimeout = timeoutMs;
+
+        using var ssl = new SslStream(client.GetStream(), leaveInnerStreamOpen: true, (_, _, _, _) => true);
+        ssl.AuthenticateAsClient(new SslClientAuthenticationOptions
+        {
+            TargetHost = "localhost",
+            EnabledSslProtocols = SslProtocols.Tls13,
+        });
+
+        byte[] request = Encoding.ASCII.GetBytes($"GET {path} HTTP/1.1\r\nHost: test\r\n\r\n");
+        int piece = Math.Max(1, request.Length / records);
+
+        for (int offset = 0; offset < request.Length; offset += piece)
+        {
+            ssl.Write(request, offset, Math.Min(piece, request.Length - offset));
+            ssl.Flush();
+            Thread.Sleep(30);   // let each record be its own recv on the server
+        }
+
+        Thread.Sleep(settleMs);
+        client.ReceiveTimeout = 600;
+
+        var seen = new System.Text.StringBuilder();
+        byte[] buffer = new byte[8192];
+        try
+        {
+            while (true)
+            {
+                int n = ssl.Read(buffer, 0, buffer.Length);
+                if (n <= 0) break;
+                seen.Append(Encoding.ASCII.GetString(buffer, 0, n));
+            }
+        }
+        catch (IOException)
+        {
+        }
+
+        int count = 0, at = 0;
+        string text = seen.ToString();
+        while ((at = text.IndexOf("HTTP/1.1 200", at, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            at += 12;
+        }
+        return count;
+    }
+
+    /// <summary>
+    /// Like <see cref="GetTlsSplitRecords"/>, but reports how many complete responses came back for
+    /// ONE request. A handler that answers per decrypt rather than per request replies more than
+    /// once when the request arrives in pieces.
+    /// </summary>
+    public static int CountTlsResponsesForSplitRequest(int port, string path, int chunk,
+        int settleMs = 1200, int timeoutMs = 15000)
+    {
+        using var client = new TcpClient();
+        client.NoDelay = true;
+        client.Connect("127.0.0.1", port);
+        client.ReceiveTimeout = timeoutMs;
+
+        using var chunking = new ChunkingStream(client.GetStream(), chunk);
+        using var ssl = new SslStream(chunking, leaveInnerStreamOpen: true, (_, _, _, _) => true);
+        ssl.AuthenticateAsClient(new SslClientAuthenticationOptions
+        {
+            TargetHost = "localhost",
+            EnabledSslProtocols = SslProtocols.Tls13,
+        });
+
+        Send(ssl, path);
+
+        // Let every response the server intends to send arrive before counting.
+        Thread.Sleep(settleMs);
+        client.ReceiveTimeout = 600;
+
+        var seen = new System.Text.StringBuilder();
+        byte[] buffer = new byte[8192];
+        try
+        {
+            while (true)
+            {
+                int n = ssl.Read(buffer, 0, buffer.Length);
+                if (n <= 0) break;
+                seen.Append(Encoding.ASCII.GetString(buffer, 0, n));
+            }
+        }
+        catch (IOException)
+        {
+            // read timeout - everything the server sent is already in `seen`
+        }
+
+        int count = 0, at = 0;
+        while ((at = seen.ToString().IndexOf("HTTP/1.1 200", at, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            at += 12;
+        }
+        return count;
+    }
+
+    /// <summary>
+    /// Send a request over TLS whose <b>TLS records are split across TCP writes</b>.
+    ///
+    /// The distinction matters and is easy to get wrong: SslStream.Write emits one COMPLETE record
+    /// per call, so chunking at the SslStream level only produces many small whole records - which
+    /// exercises nothing, because every recv then carries entire records. Chunking must happen
+    /// BELOW TLS, so a single record arrives in pieces and the server has to hold partial record
+    /// state across recvs. With chunk = 1 every byte of every record is its own TCP write.
+    /// </summary>
+    public static (int Status, string Body) GetTlsSplitRecords(int port, string path, int chunk,
+        int timeoutMs = 15000)
+    {
+        using var client = new TcpClient();
+        client.NoDelay = true;
+        client.Connect("127.0.0.1", port);
+        client.ReceiveTimeout = timeoutMs;
+
+        using var chunking = new ChunkingStream(client.GetStream(), chunk);
+        using var ssl = new SslStream(chunking, leaveInnerStreamOpen: true, (_, _, _, _) => true);
+        ssl.AuthenticateAsClient(new SslClientAuthenticationOptions
+        {
+            TargetHost = "localhost",
+            EnabledSslProtocols = SslProtocols.Tls13,
+        });
+
+        Send(ssl, path);
+        return ReadResponse(ssl);
+    }
+
+    /// <summary>Splits every write into <paramref name="chunk"/>-byte writes, each flushed.</summary>
+    private sealed class ChunkingStream(Stream inner, int chunk) : Stream
+    {
+        public override void Write(byte[] buffer, int offset, int count)
+            => Write(buffer.AsSpan(offset, count));
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            for (int i = 0; i < buffer.Length; i += chunk)
+            {
+                inner.Write(buffer.Slice(i, Math.Min(chunk, buffer.Length - i)));
+                inner.Flush();
+
+                // The pause is the point, not politeness. TCP_NODELAY stops the SENDER batching,
+                // but the receiver still coalesces whatever has arrived into one recv - so without
+                // a gap the server drains the whole record in a single completion and never holds
+                // partial state. Sleeping lets the reactor's recv land mid-record, which is the
+                // only thing that exercises reassembly.
+                if (i + chunk < buffer.Length)
+                {
+                    Thread.Sleep(1);
+                }
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => inner.Read(buffer, offset, count);
+        public override void Flush() => inner.Flush();
+        public override bool CanRead => inner.CanRead;
+        public override bool CanWrite => inner.CanWrite;
+        public override bool CanSeek => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+    }
+
+
+    /// <summary>
     /// Complete a TLS handshake, then write bytes that are not a valid TLS record. The server's
     /// decrypt must surface that as a FAULT rather than as "the record is incomplete, wait for
     /// more" - a corrupted stream that looks like a quiet connection leaves the reader hanging on

--- a/tests/Ioxide.Tests.Tls/TlsPipeTests.cs
+++ b/tests/Ioxide.Tests.Tls/TlsPipeTests.cs
@@ -30,6 +30,33 @@ internal static class TlsPipeTests
             Assert.Equal("pipe-tls-ok", body);
         }, skip: !ktls);
 
+        // A single TLS record delivered in N-byte TCP writes, so the server genuinely holds
+        // partial-record state across recvs. Chunking at the SslStream level would NOT do this -
+        // SslStream.Write emits one complete record per call, so every recv would carry whole
+        // records and the test would pass against a server that cannot reassemble at all. The
+        // first version of this test did exactly that and survived the mutation below.
+        //
+        // Nothing in ioxide reassembles records. OpenSSL's memory BIO does: Feed appends whatever
+        // arrived and SSL_read answers WANT_READ until a record is whole, which ShouldKeepReading
+        // reports as "not complete yet" rather than as a fault. These tests exist to keep that
+        // true, because the failure mode is silent - a half-record looks exactly like a quiet
+        // connection.
+        foreach (int chunk in new[] { 1, 7, 64, 1024 })
+        {
+            int size = chunk;
+            runner.Test($"tls pipe: TLS records split across {size}-byte TCP writes", () =>
+            {
+                (string certPath, string keyPath) = TestCert.Ensure();
+                var options = new TlsOptions { CertificatePath = certPath, KeyPath = keyPath };
+
+                int port = TestServer.Start(WholeRequestHandler, r => TlsService.Start(r, options));
+
+                (int status, string body) = Client.GetTlsSplitRecords(port, "/", size);
+                Assert.Equal(200, status);
+                Assert.Equal("pipe-tls-ok", body);
+            }, skip: !ktls);
+        }
+
         runner.Test("tls pipe: serving never leaves the reactor thread", () =>
         {
             // ioxide supports off-reactor submission - SubmitClientOp marshals through _remoteOps
@@ -131,6 +158,73 @@ internal static class TlsPipeTests
                 connection.DecRef();
             }
         };
+
+    /// <summary>
+    /// Answers only once a COMPLETE request has been reassembled - it reads until it sees the
+    /// blank line that ends the head, and never responds otherwise.
+    ///
+    /// That requirement is the whole test. PipeHandler writes its 200 after a single ReadAsync
+    /// whatever that read contained, so it answers just as happily when reassembly is broken and
+    /// the pipe completes early - which is exactly how the first two versions of the split-record
+    /// tests passed against a deliberately broken pump.
+    /// </summary>
+    private static async Task WholeRequestHandler(Reactor reactor, TcpConnection connection)
+    {
+        TlsSession? session = null;
+        TlsConnectionDualPipe? pipe = null;
+        try
+        {
+            session = await reactor.GetService<TlsService>()!.AcceptAsync(connection);
+            pipe = new TlsConnectionDualPipe(connection, session);
+
+            while (true)
+            {
+                ReadResult read = await pipe.Input.ReadAsync();
+
+                if (Terminated(read.Buffer))
+                {
+                    pipe.Input.AdvanceTo(read.Buffer.End);
+
+                    const string body = "pipe-tls-ok";
+                    pipe.Output.Write(Encoding.ASCII.GetBytes(
+                        $"HTTP/1.1 200 OK\r\nContent-Length: {body.Length}\r\n\r\n{body}"));
+                    await pipe.Output.FlushAsync();
+                    return;
+                }
+
+                // Nothing consumed, everything examined: the pipe must wait for more bytes rather
+                // than handing back the same partial head forever.
+                pipe.Input.AdvanceTo(read.Buffer.Start, read.Buffer.End);
+
+                if (read.IsCompleted)
+                {
+                    return;   // the stream ended mid-request - no response, and the test fails
+                }
+            }
+        }
+        catch
+        {
+            // The harness probes the port with a raw TCP connection, which fails the handshake.
+        }
+        finally
+        {
+            if (pipe is not null)
+            {
+                await pipe.DisposeAsync();
+            }
+            else
+            {
+                session?.Dispose();
+            }
+            connection.DecRef();
+        }
+    }
+
+    private static bool Terminated(in ReadOnlySequence<byte> buffer)
+    {
+        var reader = new SequenceReader<byte>(buffer);
+        return reader.TryReadTo(out ReadOnlySequence<byte> _, "\r\n\r\n"u8, advancePastDelimiter: true);
+    }
 
     // Serves one request off the decrypted PipeReader and answers as plaintext through the pipe's
     // writer, which is where kTLS takes over.

--- a/tests/Ioxide.Tests.Tls/TlsTests.cs
+++ b/tests/Ioxide.Tests.Tls/TlsTests.cs
@@ -16,5 +16,31 @@ internal static class TlsTests
             Assert.Equal(200, status);
             Assert.Equal("tls-ok", body);
         }, skip: !ktls);
+
+        runner.Test("tls raw: a fragmented request gets exactly one response", () =>
+        {
+            // The raw decrypt loop answers on "any plaintext arrived", not on "a request arrived".
+            // TLS reassembly is fine either way - OpenSSL's BIO holds the partial record - but the
+            // HTTP framing above it is the handler's job, and answering per decrypt means one
+            // request split across recvs draws several responses.
+            (string certPath, string keyPath) = TestCert.Ensure();
+            var options = new TlsOptions { CertificatePath = certPath, KeyPath = keyPath };
+
+            int port = TestServer.Start(Handlers.Tls, r => TlsService.Start(r, options));
+
+            int responses = Client.CountTlsResponsesForSplitRequest(port, "/", chunk: 1);
+            Assert.Equal(1, responses);
+        }, skip: !ktls);
+
+        runner.Test("tls raw: a request split across 3 TLS records still gets one response", () =>
+        {
+            (string certPath, string keyPath) = TestCert.Ensure();
+            var options = new TlsOptions { CertificatePath = certPath, KeyPath = keyPath };
+
+            int port = TestServer.Start(Handlers.Tls, r => TlsService.Start(r, options));
+
+            int responses = Client.CountTlsResponsesForMultiRecordRequest(port, "/", records: 3);
+            Assert.Equal(1, responses);
+        }, skip: !ktls);
     }
 }


### PR DESCRIPTION
Rebased onto `main`. The branch predated #152, so as it stood it proposed **deleting** the prototypes main already has — that was the conflict, not a textual one. Only the test work was ever missing.

## Fragmentation has two axes

They are not the same question, and only one of them distinguishes anything.

| | behaviour |
|---|---|
| a **record** split across TCP writes | handled everywhere, unavoidably — OpenSSL yields nothing until a record is whole, so even a handler answering on "some plaintext arrived" sees exactly one decrypt |
| a **request** split across several TLS records | each decrypts on its own, so answering per decrypt answers per record |

`Handlers.Tls` returned **three responses to one request** split three ways:

```
FAIL  tls raw: a request split across 3 TLS records still gets one response: expected [1], got [3]
```

TLS reassembly was never at fault — the HTTP framing above it was. It replied on `got > 0` rather than on a terminated head. The plaintext handler in `CoreTests` already did this correctly (accumulates to `\r\n\r\n`), so the TLS one was simply less careful than its own counterpart. Fixed; both tests pass.

## The split-record tests took three attempts to be able to fail

Worth recording, because each version passed against a deliberately broken pump:

1. Chunked **above** TLS — `SslStream.Write` emits one *complete* record per call, so that made many small whole records and never a split one.
2. Chunked **below** TLS, which is right, but `TCP_NODELAY` only stops the *sender* batching; the receiver still coalesced everything into one recv. A 1 ms inter-chunk pause fixes it, and instrumenting the pump proved it — **64 zero-produce iterations**, i.e. partial records genuinely arriving.
3. Still passed, because the **handler** answered regardless of what it read. The tests now use a handler that reads until the head is terminated and never responds otherwise.

Only then did the mutation behave:

```
FAIL  1-byte     ← only these two prove reassembly
FAIL  7-byte     ←
PASS  64-byte
PASS  1024-byte
```

At 64 bytes and up the whole 52-byte record lands in one recv, so those two are regression breadth rather than evidence. Kept for the cheap coverage, and the code says so.

Suites: **Unit 29, E2E 46, Http 35, Tls 11, File 2**.

## Not addressed here

The same naive framing is still in two shipped samples — `Playground/Tls/Ktls:95` and `Playground/Http2/Tls:95..101`. Neither is a runtime defect and neither bites curl or a browser, which send a request in one write. A client that writes headers and body separately gets two responses. Left out deliberately to keep this PR to the tests; worth a follow-up since samples are documentation people copy.


---

## The samples and docs, fixed

The tests above found it; these are the sites that had it. Demonstrated against the shipped `Playground/Tls/Ktls` **before**:

```
request sent as 1 TLS record(s) -> 1 response(s)
request sent as 2 TLS record(s) -> 2 response(s)
request sent as 3 TLS record(s) -> 3 response(s)
```

**after** — 1, 2, 3 and 5 records all give exactly one response, and curl / keep-alive are unaffected.

Five sites, one shape: accumulate decrypted bytes, answer once per `\r\n\r\n`. Exactly what the cleartext samples and `CoreTests` already did.

| site | was |
|---|---|
| `Playground/Tls/Ktls` | `got > 0` |
| `Playground/Http2/Tls` (h1 branch) | `sawRequest \|= ...Length > 0` |
| `docs/index.html` — kTLS raw | `got > 0` |
| `docs/index.html` — kTLS pipes | `got > 0` |
| `docs/index.html` — h2 + ALPN | `request \|= ...Length > 0` |
| `docs/learn/tls.html` | wrote a response after **every read** |

### A second defect, found while verifying the first

The h1 branch of `Playground/Http2/Tls` **never drained the handshake plaintext**. A request riding in with the Finished flight was dropped entirely — one record in, *zero* responses out. `Tls/Ktls` already handled this; that branch didn't. Fixed there and in the matching doc pane.

None of this is a runtime defect, and none of it bites curl or a browser — they send a request in one write, so one record, one response. It matters because these are documentation and people copy the loop.

### Verification

Every edited doc pane was extracted from the HTML, unescaped, and compiled against exactly the packages its own header claims. That caught **three errors in my own edits**: a helper signature changed on one side only, a missing `InteropServices` using, and a duplicate `carry` declaration. Tag balance and tab↔pane consistency checked by script; the proxy-pane generator still reports `docs/index.html` up to date, so nothing generated was disturbed.
