### PR TITLE
docs(tls): document KernelRx, and drop the last stale recommendation

### DIFF
--- a/Playground/Http2/Tls/Program.cs
+++ b/Playground/Http2/Tls/Program.cs
@@ -24,22 +24,43 @@ using Playground.Shared;
 //  code is byte-for-byte the same as the h2c sample. Needs: ioxide, ioxide.nghttp2
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
-(string certPath, string keyPath) = QuicCert.Ensure(
-    Env.StrOrNull("PLAYGROUND_TLS_CERT"),
-    Env.StrOrNull("PLAYGROUND_TLS_KEY"));
+// ── Knobs ────────────────────────────────────────────────────────────────────────────────────
+// Edit these. That is the whole mechanism - there is no config file and nothing else to find.
+// Env.Override exists only so bench/run.sh can drive the sample from outside; delete that line
+// when you copy this out and the literals above it are the entire configuration.
+
+ushort port      = 8443;                        // https://127.0.0.1:8443/
+int    reactors  = Environment.ProcessorCount;  // one ring per reactor, one reactor per core
+int    bodyBytes = 2;                           // "ok" - this sample is about ALPN, not throughput
+
+Env.Override(ref port, ref reactors, ref bodyBytes);
+
+// A real PEM pair, or null to generate a self-signed localhost cert on first run.
+string? certOverride = null;
+string? keyOverride  = null;
+
+// Per-connection incremental buffer rings instead of the shared ring (kernel 6.12+). The h2 code
+// is identical either way; this only changes how recv buffers are handed out.
+bool incrementalBuffers = false;
+
+// Hand INBOUND decryption to the kernel as well as outbound. Experimental and off for a reason:
+// a TLS 1.3 KeyUpdate cannot be read through IORING_OP_RECV, and roughly one first connection in
+// twelve fails outright. See docs/learn/tls.html.
+bool kernelRx = false;
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(certOverride, keyOverride);
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
-    // PLAYGROUND_INCREMENTAL=1 switches the recv path to per-connection incremental buffer rings.
-    Incremental = Env.Flag("PLAYGROUND_INCREMENTAL") ? new IncrementalOptions() : null,
+    ReactorCount = reactors,
+    Incremental = incrementalBuffers ? new IncrementalOptions() : null,
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8443),
+        Port = port,
     },
 };
 
-int bodyBytes = Env.Int("PLAYGROUND_BODY", 2);
 byte[] body = bodyBytes == 2 ? "ok"u8.ToArray() : [.. Enumerable.Repeat((byte)'x', bodyBytes)];
 
 byte[] http11Response =
@@ -56,8 +77,7 @@ for (int i = 0; i < threads.Length; i++)
 
     reactor.OnStart = r => TlsService.Start(r, new TlsOptions
     {
-        // PLAYGROUND_KTLS_RX=1 hands inbound decryption to the kernel as well as outbound.
-        KernelRx = Env.Flag("PLAYGROUND_KTLS_RX"),
+        KernelRx = kernelRx,
         CertificatePath = certPath,
         KeyPath = keyPath,
 
@@ -167,8 +187,7 @@ for (int i = 0; i < threads.Length; i++)
 
 Console.WriteLine($"[http2-tls] {config.ReactorCount} reactors on :{config.Tcp!.Port}, "
                 + $"ALPN h2 then http/1.1, cert {certPath}, "
-                + $"rx={(Env.Flag("PLAYGROUND_KTLS_RX") ? "kernel" : "openssl")}, "
-                + $"tx={(Env.Flag("PLAYGROUND_NO_KTLS_TX") ? "openssl" : "kernel")}");
+                + $"rx={(kernelRx ? "kernel" : "openssl")}, tx=kernel");
 
 foreach (Thread thread in threads)
 {

--- a/Playground/README.md
+++ b/Playground/README.md
@@ -17,9 +17,10 @@ Run any of them with `dotnet run -c Release --project Playground/<Group>/<Name>`
 | [`Tcp.TaskRun`](Tcp/TaskRun/Program.cs) | 84 | Awaiting ordinary thread-pool work and still resuming on the reactor. | `ioxide` |
 | [`Tcp.Incremental`](Tcp/Incremental/Program.cs) | 95 | `Tcp.Raw` with the per-connection buffer-ring mode - one config block is the whole diff. Kernel 6.12+. | `ioxide` |
 | [`Tcp.Big`](Tcp/Big/Program.cs) | 101 | The write path under a 100 KB body: `SEND_ZC`, slab overflow (`grow` vs `seg`), checksum-able output. | `ioxide` |
-| [`Tls.Ktls`](Tls/Ktls/Program.cs) | 133 | OpenSSL handshake on the ring, then **kernel TLS** transmit - the handler writes plaintext. | `ioxide` |
-| [`Tls.OpenSsl`](Tls/OpenSsl/Program.cs) | 181 | The same termination with **kernel TLS off** - OpenSSL both ways, no `modprobe tls`, and TLS 1.2 / resumption / any suite become available again. | `ioxide` |
-| [`Tls.Pipes`](Tls/Pipes/Program.cs) | 151 | TLS over an `IDuplexPipe`. Both backends run the **same handler code** - `TlsConnectionDualPipe` picks its halves from the session, so nothing below it branches on kTLS vs OpenSSL. | `ioxide` |
+| [`Tls.Ktls`](Tls/Ktls/Program.cs) | 172 | OpenSSL handshake on the ring, then **kernel TLS** transmit - the handler writes plaintext. | `ioxide` |
+| [`Tls.OpenSsl`](Tls/OpenSsl/Program.cs) | 194 | The same server with kernel TLS **off**: OpenSSL both ways, no `modprobe tls`, and TLS 1.2 / any suite / resumption come back. | `ioxide` |
+| [`Tls.KtlsPipes`](Tls/KtlsPipes/Program.cs) | 163 | kTLS served through an `IDuplexPipe`. | `ioxide` |
+| [`Tls.OpenSslPipes`](Tls/OpenSslPipes/Program.cs) | 164 | The same, with OpenSSL. Its serve loop is byte-identical to `Tls.KtlsPipes` - over a pipe the backend is invisible. | `ioxide` |
 | [`Tls.SslStream`](Tls/SslStream/Program.cs) | 100 | The BCL `SslStream` over `TcpConnectionStream` - portable userspace TLS, the kTLS comparison point. | `ioxide` |
 | [`Http2.Nghttp2`](Http2/Nghttp2/Program.cs) | 66 | HTTP/2 (h2c, prior knowledge) with nghttp2 doing framing, HPACK and flow control. | `ioxide.nghttp2` |
 | [`Http2.Managed`](Http2/Managed/Program.cs) | 66 | The same server with **zero native code** - framing, HPACK and flow control in C#. Drop-in for the above. | `ioxide.http2` |

--- a/Playground/Shared/Env.cs
+++ b/Playground/Shared/Env.cs
@@ -23,4 +23,25 @@ public static class Env
 
     public static bool Flag(string name)
         => Environment.GetEnvironmentVariable(name) == "1";
+
+    /// <summary>
+    /// Apply the harness overrides to a sample's knobs, in one call, so the sample itself can
+    /// declare them as plain literals you edit.
+    ///
+    /// The knobs are the sample's real configuration; this exists only because bench/run.sh and
+    /// the Dockerfile drive every sample from the outside. Delete the call when you copy a sample
+    /// out - the literals above it are the whole configuration and nothing else reads these.
+    /// </summary>
+    public static void Override(ref ushort port, ref int reactors)
+    {
+        port = Port("PLAYGROUND_PORT", port);
+        reactors = Int("PLAYGROUND_REACTORS", reactors);
+    }
+
+    /// <inheritdoc cref="Override(ref ushort, ref int)"/>
+    public static void Override(ref ushort port, ref int reactors, ref int bodyBytes)
+    {
+        Override(ref port, ref reactors);
+        bodyBytes = Int("PLAYGROUND_BODY", bodyBytes);
+    }
 }

--- a/Playground/Tls/Ktls/Program.cs
+++ b/Playground/Tls/Ktls/Program.cs
@@ -19,41 +19,48 @@ using Playground.Shared;
 //  payload, since TLS overhead only shows against real bodies). Needs: ioxide.tls
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
-(string certPath, string keyPath) = QuicCert.Ensure(
-    Env.StrOrNull("PLAYGROUND_TLS_CERT"),
-    Env.StrOrNull("PLAYGROUND_TLS_KEY"));
+// ── Knobs ────────────────────────────────────────────────────────────────────────────────────
+// Edit these. That is the whole mechanism - there is no config file and nothing else to find.
+// Env.Override exists only so bench/run.sh can drive the sample from outside; delete that line
+// when you copy this out and the literals above it are the entire configuration.
+
+ushort port      = 8443;                        // https://127.0.0.1:8443/
+int    reactors  = Environment.ProcessorCount;  // one ring per reactor, one reactor per core
+int    bodyBytes = 8 * 1024;                    // TLS cost is per-byte, so a 2-byte "ok" would hide it
+
+Env.Override(ref port, ref reactors, ref bodyBytes);
+
+// A real PEM pair, or null to generate a self-signed localhost cert on first run.
+string? certOverride = null;
+string? keyOverride  = null;
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(certOverride, keyOverride);
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    ReactorCount = reactors,
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8443),
+        Port = port,
     },
 };
 
 var tlsOptions = new TlsOptions
 {
-    // PLAYGROUND_KTLS_RX=1 lets the kernel decrypt inbound too, so recv returns plaintext and
-    // TlsSession.Decrypt becomes a pass-through.
-    KernelRx = Env.Flag("PLAYGROUND_KTLS_RX"),
-    // PLAYGROUND_KTLS_TX=0 drops kernel TLS entirely - OpenSSL both directions.
-    KernelTx = !Env.Flag("PLAYGROUND_NO_KTLS_TX"),
     CertificatePath = certPath,
     KeyPath         = keyPath,
 };
 
-// A medium fixed response, built once. TLS cost is per-byte, so "ok" would hide it.
-int bodySize = Env.Int("PLAYGROUND_BODY", 8 * 1024);
-byte[] body = new byte[bodySize];
+byte[] body = new byte[bodyBytes];
 ReadOnlySpan<byte> fill = "ioxide-ktls-payload "u8;
-for (int i = 0; i < bodySize; i++)
+for (int i = 0; i < bodyBytes; i++)
 {
     body[i] = fill[i % fill.Length];
 }
 byte[] response =
 [
-    .. Encoding.ASCII.GetBytes($"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {bodySize}\r\n\r\n"),
+    .. Encoding.ASCII.GetBytes($"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {bodyBytes}\r\n\r\n"),
     .. body,
 ];
 
@@ -85,7 +92,7 @@ for (int i = 0; i < threads.Length; i++)
             // A request can ride in with the handshake's final flight - answer it before parking
             // in ReadAsync, or the client waits on a response we never send.
             carry.AddRange(tls.DrainPlaintext());
-            if (Answer(conn, tls, carry, response))
+            if (Answer(conn, carry, response))
             {
                 await conn.FlushAsync();
             }
@@ -104,7 +111,7 @@ for (int i = 0; i < threads.Length; i++)
                     }
                 }
 
-                if (Answer(conn, tls, carry, response))
+                if (Answer(conn, carry, response))
                 {
                     await conn.FlushAsync();   // plaintext: the kernel encrypts on send
                 }
@@ -131,7 +138,7 @@ for (int i = 0; i < threads.Length; i++)
 }
 
 Console.WriteLine($"[tls-ktls] {config.ReactorCount} reactors on :{config.Tcp!.Port}, "
-                + $"{bodySize}-byte body, cert {certPath}");
+                + $"{bodyBytes}-byte body, cert {certPath}");
 
 foreach (Thread thread in threads)
 {
@@ -145,7 +152,7 @@ static unsafe void Decrypt(TlsSession tls, in SpscRecvRing.Item item, List<byte>
 
 // One response per COMPLETE request in the carry, and none for a partial one. Returns whether
 // anything was written, so the caller flushes once for the batch rather than once per request.
-static bool Answer(TcpConnection conn, TlsSession tls, List<byte> carry, ReadOnlyMemory<byte> response)
+static bool Answer(TcpConnection conn, List<byte> carry, ReadOnlyMemory<byte> response)
 {
     bool wrote = false;
     int end;
@@ -154,16 +161,9 @@ static bool Answer(TcpConnection conn, TlsSession tls, List<byte> carry, ReadOnl
     {
         carry.RemoveRange(0, end + 4);
 
-        // With kTLS the kernel makes the records, so plaintext goes straight in. Without it,
-        // OpenSSL has to encrypt first - the one line that differs between the two worlds.
-        if (tls.KernelTx)
-        {
-            conn.Write(response.Span);
-        }
-        else
-        {
-            tls.WriteEncrypted(conn, response.Span);
-        }
+        // kTLS is producing the records, so this is PLAINTEXT going into the slab. Compare
+        // Playground/Tls/OpenSsl, where the same line is tls.WriteEncrypted(conn, ...).
+        conn.Write(response.Span);
 
         wrote = true;
     }

--- a/Playground/Tls/KtlsPipes/Playground.Tls.KtlsPipes.csproj
+++ b/Playground/Tls/KtlsPipes/Playground.Tls.KtlsPipes.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net11.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace>Playground.Tls.KtlsPipes</RootNamespace>
+    <AssemblyName>Playground.Tls.KtlsPipes</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Shared/Playground.Shared.csproj" />
+    <ProjectReference Include="../../../src/ioxide/ioxide.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Playground/Tls/KtlsPipes/Program.cs
+++ b/Playground/Tls/KtlsPipes/Program.cs
@@ -6,15 +6,14 @@ using ioxide.tls;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  tls-pipes - TLS served through an IDuplexPipe, and the point of the sample is what ISN'T here.
+//  tls-ktls-pipes - TLS served through an IDuplexPipe, with kernel TLS doing the crypto.
 //
-//      dotnet run -c Release --project Playground/Tls/Pipes                    # kTLS
-//      PLAYGROUND_NO_KTLS_TX=1 dotnet run -c Release --project Playground/Tls/Pipes   # OpenSSL
+//      sudo modprobe tls        # kTLS needs the module
 //      curl -ks https://127.0.0.1:8443/ | head -c 40
 //
-//  Those two commands run the SAME handler code. Not similar - identical. The only difference is
-//  one TlsOptions flag, and no branch below it: no "if kernel then write plaintext else encrypt",
-//  no second pipe type, no separate loop.
+//  The read/serve loop below is byte-for-byte identical to Playground/Tls/OpenSslPipes - diff
+//  them and the only functional difference is the KernelTx line, the rest being the banner and
+//  the log tag.
 //
 //  TlsConnectionDualPipe composes rather than implements. Each direction has two possible halves:
 //
@@ -29,24 +28,37 @@ using Playground.Shared;
 //  It picks them from the SESSION, not from configuration - because the two are not the same
 //  thing. TlsOptions is intent; TlsService decides per connection at the handoff, and a handshake
 //  that left a partial record cannot hand off to kTLS RX at all, so that connection keeps the
-//  userspace reader whatever the config said. TlsSession reports what actually happened, and that
-//  is what the pipe reads.
+//  userspace reader whatever the config said. TlsSession reports what actually happened.
 //
-//  Compare Playground/Tls/Ktls and Playground/Tls/OpenSsl, which serve the same responses off the
-//  RAW ring. Those two differ in the handler, because at that level the backend is visible: kTLS
-//  writes plaintext, OpenSSL calls WriteEncrypted. Here it is not. Needs: ioxide
+//  Compare the raw-ring pair, Playground/Tls/Ktls and Playground/Tls/OpenSsl. Those two DO differ
+//  in the handler, because at that level the backend is visible: kTLS writes plaintext, OpenSSL
+//  calls WriteEncrypted. Over a pipe it is not. Needs: ioxide
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
-(string certPath, string keyPath) = QuicCert.Ensure(
-    Env.StrOrNull("PLAYGROUND_TLS_CERT"),
-    Env.StrOrNull("PLAYGROUND_TLS_KEY"));
+// ── Knobs ────────────────────────────────────────────────────────────────────────────────────
+// Edit these. That is the whole mechanism - there is no config file and nothing else to find.
+// Env.Override exists only so bench/run.sh can drive the sample from outside; delete that line
+// when you copy this out and the literals above it are the entire configuration.
+
+ushort port      = 8443;                        // https://127.0.0.1:8443/
+int    reactors  = Environment.ProcessorCount;  // one ring per reactor, one reactor per core
+int    bodyBytes = 8 * 1024;                    // TLS cost is per-byte, so a 2-byte "ok" would hide it
+
+Env.Override(ref port, ref reactors, ref bodyBytes);
+
+// A real PEM pair, or null to generate a self-signed localhost cert on first run.
+string? certOverride = null;
+string? keyOverride  = null;
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(certOverride, keyOverride);
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    ReactorCount = reactors,
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8443),
+        Port = port,
     },
 };
 
@@ -55,21 +67,21 @@ var tlsOptions = new TlsOptions
     CertificatePath = certPath,
     KeyPath = keyPath,
 
-    // The only line that changes between the two runs above.
-    KernelTx = !Env.Flag("PLAYGROUND_NO_KTLS_TX"),
+    // The default. The kernel encrypts outbound records; see Playground/Tls/OpenSslPipes for the
+    // same server with this line flipped.
+    KernelTx = true,
 };
 
-int bodySize = Env.Int("PLAYGROUND_BODY", 8 * 1024);
-byte[] body = new byte[bodySize];
+byte[] body = new byte[bodyBytes];
 "ioxide-tls-pipes "u8.CopyTo(body);
-for (int i = "ioxide-tls-pipes "u8.Length; i < bodySize; i++)
+for (int i = "ioxide-tls-pipes "u8.Length; i < bodyBytes; i++)
 {
     body[i] = (byte)('a' + (i % 26));
 }
 
 byte[] response =
 [
-    .. Encoding.ASCII.GetBytes($"HTTP/1.1 200 OK\r\nContent-Length: {bodySize}\r\n\r\n"),
+    .. Encoding.ASCII.GetBytes($"HTTP/1.1 200 OK\r\nContent-Length: {bodyBytes}\r\n\r\n"),
     .. body,
 ];
 
@@ -129,7 +141,7 @@ for (int i = 0; i < threads.Length; i++)
         }
         catch (Exception e)
         {
-            Console.Error.WriteLine($"[tls-pipes] connection failed: {e.Message}");
+            Console.Error.WriteLine($"[tls-ktls-pipes] connection failed: {e.Message}");
         }
         finally
         {
@@ -142,8 +154,8 @@ for (int i = 0; i < threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($"[tls-pipes] {config.ReactorCount} reactors on :{config.Tcp!.Port}, "
-                + $"{bodySize}-byte body, tx={(tlsOptions.KernelTx ? "kernel" : "openssl")}");
+Console.WriteLine($"[tls-ktls-pipes] {config.ReactorCount} reactors on :{config.Tcp!.Port}, "
+                + $"{bodyBytes}-byte body, tx={(tlsOptions.KernelTx ? "kernel" : "openssl")}");
 
 foreach (Thread thread in threads)
 {

--- a/Playground/Tls/OpenSsl/Program.cs
+++ b/Playground/Tls/OpenSsl/Program.cs
@@ -37,16 +37,30 @@ using Playground.Shared;
 //  generated. PLAYGROUND_BODY sizes the response. Needs: ioxide
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
-(string certPath, string keyPath) = QuicCert.Ensure(
-    Env.StrOrNull("PLAYGROUND_TLS_CERT"),
-    Env.StrOrNull("PLAYGROUND_TLS_KEY"));
+// ── Knobs ────────────────────────────────────────────────────────────────────────────────────
+// Edit these. That is the whole mechanism - there is no config file and nothing else to find.
+// Env.Override exists only so bench/run.sh can drive the sample from outside; delete that line
+// when you copy this out and the literals above it are the entire configuration.
+
+ushort port      = 8443;                        // https://127.0.0.1:8443/
+int    reactors  = Environment.ProcessorCount;  // one ring per reactor, one reactor per core
+int    bodyBytes = 8 * 1024;                    // TLS cost is per-byte, so a 2-byte "ok" would hide it
+
+Env.Override(ref port, ref reactors, ref bodyBytes);
+
+// A real PEM pair, or null to generate a self-signed localhost cert on first run.
+string? certOverride = null;
+string? keyOverride  = null;
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(certOverride, keyOverride);
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    ReactorCount = reactors,
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8443),
+        Port = port,
     },
 };
 
@@ -59,17 +73,15 @@ var tlsOptions = new TlsOptions
     KeyPath         = keyPath,
 };
 
-// A medium fixed response, built once. TLS cost is per-byte, so "ok" would hide it.
-int bodySize = Env.Int("PLAYGROUND_BODY", 8 * 1024);
-byte[] body = new byte[bodySize];
+byte[] body = new byte[bodyBytes];
 ReadOnlySpan<byte> fill = "ioxide-ktls-payload "u8;
-for (int i = 0; i < bodySize; i++)
+for (int i = 0; i < bodyBytes; i++)
 {
     body[i] = fill[i % fill.Length];
 }
 byte[] response =
 [
-    .. Encoding.ASCII.GetBytes($"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {bodySize}\r\n\r\n"),
+    .. Encoding.ASCII.GetBytes($"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {bodyBytes}\r\n\r\n"),
     .. body,
 ];
 
@@ -148,7 +160,7 @@ for (int i = 0; i < threads.Length; i++)
 }
 
 Console.WriteLine($"[tls-openssl] {config.ReactorCount} reactors on :{config.Tcp!.Port}, "
-                + $"{bodySize}-byte body, cert {certPath}, no kernel TLS");
+                + $"{bodyBytes}-byte body, cert {certPath}, no kernel TLS");
 
 foreach (Thread thread in threads)
 {

--- a/Playground/Tls/OpenSslPipes/Playground.Tls.OpenSslPipes.csproj
+++ b/Playground/Tls/OpenSslPipes/Playground.Tls.OpenSslPipes.csproj
@@ -6,8 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <RootNamespace>Playground.Tls.Pipes</RootNamespace>
-    <AssemblyName>Playground.Tls.Pipes</AssemblyName>
+    <RootNamespace>Playground.Tls.OpenSslPipes</RootNamespace>
+    <AssemblyName>Playground.Tls.OpenSslPipes</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Playground/Tls/OpenSslPipes/Program.cs
+++ b/Playground/Tls/OpenSslPipes/Program.cs
@@ -1,0 +1,164 @@
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Text;
+using ioxide;
+using ioxide.tls;
+using Playground.Shared;
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+//  tls-openssl-pipes - TLS served through an IDuplexPipe, with OpenSSL doing the crypto in userspace.
+//
+//      dotnet run -c Release --project Playground/Tls/OpenSslPipes   # NO modprobe needed
+//      curl -ks https://127.0.0.1:8443/ | head -c 40
+//
+//  The read/serve loop below is byte-for-byte identical to Playground/Tls/KtlsPipes - diff them
+//  and the only functional difference is the KernelTx line, the rest being the banner and the
+//  log tag.
+//
+//  TlsConnectionDualPipe composes rather than implements. Each direction has two possible halves:
+//
+//              kernel                       OpenSSL
+//    read      TcpConnectionPipeReader      TlsPumpPipeReader
+//              (plaintext is already in     (decrypts into a Pipe
+//               ring memory - zero copy)     it owns)
+//    write     TcpConnectionPipeWriter      TlsEncryptingPipeWriter
+//              (plaintext into the slab,    (SSL_write, then the records
+//               kernel makes records)        go into the slab)
+//
+//  It picks them from the SESSION, not from configuration - because the two are not the same
+//  thing. TlsOptions is intent; TlsService decides per connection at the handoff, and a handshake
+//  that left a partial record cannot hand off to kTLS RX at all, so that connection keeps the
+//  userspace reader whatever the config said. TlsSession reports what actually happened.
+//
+//  Compare the raw-ring pair, Playground/Tls/Ktls and Playground/Tls/OpenSsl. Those two DO differ
+//  in the handler, because at that level the backend is visible: kTLS writes plaintext, OpenSSL
+//  calls WriteEncrypted. Over a pipe it is not. Needs: ioxide
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+// ── Knobs ────────────────────────────────────────────────────────────────────────────────────
+// Edit these. That is the whole mechanism - there is no config file and nothing else to find.
+// Env.Override exists only so bench/run.sh can drive the sample from outside; delete that line
+// when you copy this out and the literals above it are the entire configuration.
+
+ushort port      = 8443;                        // https://127.0.0.1:8443/
+int    reactors  = Environment.ProcessorCount;  // one ring per reactor, one reactor per core
+int    bodyBytes = 8 * 1024;                    // TLS cost is per-byte, so a 2-byte "ok" would hide it
+
+Env.Override(ref port, ref reactors, ref bodyBytes);
+
+// A real PEM pair, or null to generate a self-signed localhost cert on first run.
+string? certOverride = null;
+string? keyOverride  = null;
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(certOverride, keyOverride);
+
+var config = new ServerConfig
+{
+    ReactorCount = reactors,
+    Tcp = new TcpOptions
+    {
+        Port = port,
+    },
+};
+
+var tlsOptions = new TlsOptions
+{
+    CertificatePath = certPath,
+    KeyPath = keyPath,
+
+    // The whole difference from Playground/Tls/KtlsPipes. No TLS ULP on the socket, so OpenSSL
+    // encrypts and decrypts and nothing here needs the 'tls' kernel module - which also gives back
+    // TLS 1.2, any ciphersuite and session resumption.
+    KernelTx = false,
+};
+
+byte[] body = new byte[bodyBytes];
+"ioxide-tls-pipes "u8.CopyTo(body);
+for (int i = "ioxide-tls-pipes "u8.Length; i < bodyBytes; i++)
+{
+    body[i] = (byte)('a' + (i % 26));
+}
+
+byte[] response =
+[
+    .. Encoding.ASCII.GetBytes($"HTTP/1.1 200 OK\r\nContent-Length: {bodyBytes}\r\n\r\n"),
+    .. body,
+];
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i < threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    reactor.OnStart = r => TlsService.Start(r, tlsOptions);
+
+    reactor.TcpHandle = async (r, conn) =>
+    {
+        TlsSession? tls = null;
+        try
+        {
+            tls = await r.GetService<TlsService>().AcceptAsync(conn);
+
+            // From here down, nothing knows or cares which backend is in use.
+            await using var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
+
+            while (true)
+            {
+                ReadResult read = await pipe.Input.ReadAsync();
+
+                // Answer per REQUEST, not per read. TLS hands back RECORDS, so one request split
+                // across two records would otherwise draw two responses.
+                int answered = 0;
+                SequencePosition consumed = read.Buffer.Start;
+
+                var reader = new SequenceReader<byte>(read.Buffer);
+                while (reader.TryReadTo(out ReadOnlySequence<byte> _, "\r\n\r\n"u8, advancePastDelimiter: true))
+                {
+                    consumed = reader.Position;
+                    answered++;
+                }
+
+                // Consumed only whole requests; examined everything, so a partial head parks
+                // until more arrives instead of spinning on the same bytes.
+                pipe.Input.AdvanceTo(consumed, read.Buffer.End);
+
+                for (int n = 0; n < answered; n++)
+                {
+                    pipe.Output.Write(response);
+                }
+
+                if (answered > 0)
+                {
+                    await pipe.Output.FlushAsync();
+                }
+
+                if (read.IsCompleted || read.IsCanceled)
+                {
+                    return;
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"[tls-openssl-pipes] connection failed: {e.Message}");
+        }
+        finally
+        {
+            tls?.Dispose();
+            conn.DecRef();
+        }
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $"reactor-{i}" };
+    threads[i].Start();
+}
+
+Console.WriteLine($"[tls-openssl-pipes] {config.ReactorCount} reactors on :{config.Tcp!.Port}, "
+                + $"{bodyBytes}-byte body, tx={(tlsOptions.KernelTx ? "kernel" : "openssl")}");
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -210,6 +210,7 @@ nav.top .links a.gh svg { display: block; }
 #tab-inc:checked ~ .ex-menu label[for="tab-inc"],
 #tab-pipe:checked ~ .ex-menu label[for="tab-pipe"],
 #tab-vs:checked ~ .ex-menu label[for="tab-vs"],
+#tab-tlsosslpipe:checked ~ .ex-menu label[for="tab-tlsosslpipe"],
 #tab-tlsossl:checked ~ .ex-menu label[for="tab-tlsossl"],
 #tab-h2:checked ~ .ex-menu label[for="tab-h2"],
 #tab-h2cs:checked ~ .ex-menu label[for="tab-h2cs"],
@@ -309,6 +310,7 @@ nav.top .links a.gh svg { display: block; }
 #tab-inc:checked ~ .pane-inc { display: block; }
 #tab-pipe:checked ~ .pane-pipe { display: block; }
 #tab-vs:checked ~ .pane-vs { display: block; }
+#tab-tlsosslpipe:checked ~ .pane-tlsosslpipe { display: block; }
 #tab-tlsossl:checked ~ .pane-tlsossl { display: block; }
 #tab-h2:checked ~ .pane-h2 { display: block; }
 #tab-h2cs:checked ~ .pane-h2cs { display: block; }
@@ -428,6 +430,7 @@ nav.top .links a.gh svg { display: block; }
   #tab-inc:checked ~ .ex-menu label[for="tab-inc"],
   #tab-pipe:checked ~ .ex-menu label[for="tab-pipe"],
   #tab-vs:checked ~ .ex-menu label[for="tab-vs"],
+  #tab-tlsosslpipe:checked ~ .ex-menu label[for="tab-tlsosslpipe"],
   #tab-tlsossl:checked ~ .ex-menu label[for="tab-tlsossl"],
   #tab-h2:checked ~ .ex-menu label[for="tab-h2"],
   #tab-h2cs:checked ~ .ex-menu label[for="tab-h2cs"],

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,8 +27,9 @@
   <input type="radio" name="mode-tabs" id="tab-inc">
   <input type="radio" name="mode-tabs" id="tab-vs">
   <input type="radio" name="mode-tabs" id="tab-tls">
-  <input type="radio" name="mode-tabs" id="tab-tlspipe">
   <input type="radio" name="mode-tabs" id="tab-tlsossl">
+  <input type="radio" name="mode-tabs" id="tab-tlspipe">
+  <input type="radio" name="mode-tabs" id="tab-tlsosslpipe">
   <input type="radio" name="mode-tabs" id="tab-h2">
   <input type="radio" name="mode-tabs" id="tab-h2cs">
   <input type="radio" name="mode-tabs" id="tab-h2tls">
@@ -59,8 +60,9 @@
       <label for="tab-inc">raw &middot; incremental</label>
       <label for="tab-vs">shared vs incremental</label>
       <label for="tab-tls">ktls &middot; raw</label>
-      <label for="tab-tlspipe">tls &middot; pipes</label>
-      <label for="tab-tlsossl">tls &middot; openssl only</label>
+      <label for="tab-tlsossl">openssl &middot; raw</label>
+      <label for="tab-tlspipe">ktls &middot; pipes</label>
+      <label for="tab-tlsosslpipe">openssl &middot; pipes</label>
     </details>
 
     <details class="ex-sect">
@@ -436,69 +438,87 @@ foreach (Thread t in threads) t.Join();</code></pre>
   </div>
   <div class="pane pane-tls">
     <div class="pane-head">
-      <h3>kTLS</h3>
+      <h3>kTLS &middot; raw ring</h3>
       <span class="pane-pkg">ioxide</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide      -- TLS ships in the core package
-// Needs the Linux &#x27;tls&#x27; module (sudo modprobe tls), OpenSSL 3, and cert.pem / key.pem.
+//   sudo modprobe tls        # kTLS needs the Linux &#x27;tls&#x27; module + OpenSSL 3
+//   curl -k https://127.0.0.1:8443/
+
+using System.Text;
 using System.Runtime.InteropServices;
 using ioxide;
 using ioxide.tls;
 using ioxide.utils;
 
+// ── Knobs ────────────────────────────────────────────────────────────────────────────────────
+
+ushort port      = 8443;                        // https://127.0.0.1:8443/
+int    reactors  = Environment.ProcessorCount;  // one ring per reactor, one reactor per core
+int    bodyBytes = 8 * 1024;                    // TLS cost is per-byte, so a 2-byte &quot;ok&quot; would hide it
+
+const string certPath = &quot;cert.pem&quot;;   // any PEM pair
+const string keyPath  = &quot;key.pem&quot;;
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+
 var config = new ServerConfig
 {
-    ReactorCount = Environment.ProcessorCount,   // one ring per reactor, one reactor per core
-    RingEntries  = 8192,                         // io_uring SQ/CQ depth
-    DualStack    = false,                        // true = one AF_INET6 socket takes v6 + v4-mapped
-
-    // Shared recv ring - the default mode, used while Incremental is null.
-    RecvBufferSize = 32 * 1024,
-    RecvSlots      = 4096,
-
+    ReactorCount = reactors,
     Tcp = new TcpOptions
     {
-        Port             = 8443,
-        ExtraPorts       = [],                   // more listeners; conn.ListenerPort says which
-        ListenBacklog    = 1024,                 // accept queue per SO_REUSEPORT listener
-        WriteSlabSize    = 16 * 1024,            // per-connection write buffer
-        PoolMax          = 1024,                 // connection objects recycled per reactor
-        WriteOverflow    = WriteOverflowStrategy.Grow,   // Segmented = chained slabs, one SENDMSG
-        ZeroCopySend     = false,                // SEND_ZC; only pays off on large responses
-        RecvQueueEntries = 64,                   // per-connection SPSC queue, power of two
+        Port = port,
     },
-
 };
 
-ReadOnlyMemory&lt;byte&gt; ok = &quot;HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok&quot;u8.ToArray();
+var tlsOptions = new TlsOptions
+{
+    CertificatePath = certPath,
+    KeyPath         = keyPath,
+};
+
+byte[] body = new byte[bodyBytes];
+ReadOnlySpan&lt;byte&gt; fill = &quot;ioxide-ktls-payload &quot;u8;
+for (int i = 0; i &lt; bodyBytes; i++)
+{
+    body[i] = fill[i % fill.Length];
+}
+byte[] response =
+[
+    .. Encoding.ASCII.GetBytes($&quot;HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {bodyBytes}\r\n\r\n&quot;),
+    .. body,
+];
+
 var threads = new Thread[config.ReactorCount];
 
-for (int id = 0; id &lt; threads.Length; id++)
+for (int i = 0; i &lt; threads.Length; i++)
 {
-    var reactor = new Reactor(id, config);
+    var reactor = new Reactor(i, config);
 
-    reactor.OnStart = r =&gt; TlsService.Start(r, new TlsOptions
-    {
-        CertificatePath = &quot;cert.pem&quot;,
-        KeyPath         = &quot;key.pem&quot;,
-        Alpn            = [&quot;http/1.1&quot;],   // ordered, most preferred first
-    });
+    // One TlsService per reactor: it owns the OpenSSL contexts and drives handshakes on this ring.
+    reactor.OnStart = r =&gt; TlsService.Start(r, tlsOptions);
 
     reactor.TcpHandle = async (r, conn) =&gt;
     {
         TlsSession? tls = null;
-        var carry = new List&lt;byte&gt;();   // decrypted bytes waiting to be framed into requests
+
+        // Decrypted bytes waiting to be framed. TLS hands back records, not requests: split one
+        // request across two records and each decrypts on its own, so answering per decrypt
+        // answers twice. The carry is what turns &quot;some plaintext arrived&quot; into &quot;a request
+        // arrived&quot;, exactly as the plaintext samples do - ioxide does not parse HTTP for you.
+        var carry = new List&lt;byte&gt;();
 
         try
         {
-            // The OpenSSL handshake is driven over the ring, so it awaits like everything else.
-            // After it, kernel TLS owns transmit: everything below is written as PLAINTEXT.
+            // The handshake reads and writes through this same connection; after it, the socket
+            // carries kTLS records the kernel en/decrypts.
             tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
 
-            // A request can ride in with the handshake&#x27;s final flight - answer it first.
-            if (tls.DrainPlaintext().Length &gt; 0)
+            // A request can ride in with the handshake&#x27;s final flight - answer it before parking
+            // in ReadAsync, or the client waits on a response we never send.
+            carry.AddRange(tls.DrainPlaintext());
+            if (Answer(conn, carry, response))
             {
-                conn.Write(ok.Span);
                 await conn.FlushAsync();
             }
 
@@ -510,25 +530,16 @@ for (int id = 0; id &lt; threads.Length; id++)
                 {
                     if (item.HasBuffer)
                     {
-                        Decrypt(tls, in item, carry);   // only transmit is offloaded
+                        // Records in, plaintext out - the session decrypts what the ring received.
+                        Decrypt(tls, in item, carry);
                         conn.ReturnBuffer(in item);
                     }
                 }
 
-                // One response per COMPLETE request. TLS hands back RECORDS, not requests: a
-                // request split across two records decrypts twice, so answering on &quot;plaintext
-                // arrived&quot; would answer twice to one request. Framing is yours either way -
-                // this is the same carry the cleartext samples keep.
-                bool wrote = false;
-                int end;
-                while ((end = CollectionsMarshal.AsSpan(carry).IndexOf(&quot;\r\n\r\n&quot;u8)) &gt;= 0)
+                if (Answer(conn, carry, response))
                 {
-                    carry.RemoveRange(0, end + 4);
-                    conn.Write(ok.Span);   // plaintext in; the kernel produces the records
-                    wrote = true;
+                    await conn.FlushAsync();   // plaintext: the kernel encrypts on send
                 }
-
-                if (wrote) await conn.FlushAsync();
 
                 if (snapshot.IsClosed || tls.Closed) return;
                 conn.ResetRead();
@@ -536,8 +547,9 @@ for (int id = 0; id &lt; threads.Length; id++)
         }
         catch (Exception e)
         {
-            // Handlers run fire-and-forget, so a missing &#x27;tls&#x27; module would vanish silently.
-            Console.Error.WriteLine($&quot;tls: {e.Message}&quot;);
+            // Handlers run fire-and-forget, so a thrown handshake error would vanish silently -
+            // and a missing &#x27;tls&#x27; kernel module manifests exactly here.
+            Console.Error.WriteLine($&quot;[tls-ktls] connection failed: {e.Message}&quot;);
         }
         finally
         {
@@ -546,20 +558,44 @@ for (int id = 0; id &lt; threads.Length; id++)
         }
     };
 
-    threads[id] = new Thread(reactor.Run) { Name = $&quot;reactor-{id}&quot; };
-    threads[id].Start();
+    threads[i] = new Thread(reactor.Run) { Name = $&quot;reactor-{i}&quot; };
+    threads[i].Start();
 }
 
-Console.WriteLine($&quot;TLS on :{config.Tcp.Port} (kTLS transmit offload)&quot;);
-foreach (Thread t in threads) t.Join();
+Console.WriteLine($&quot;[tls-ktls] {config.ReactorCount} reactors on :{config.Tcp!.Port}, &quot;
+                + $&quot;{bodyBytes}-byte body, cert {certPath}&quot;);
 
-static unsafe void Decrypt(TlsSession tls, in SpscRecvRing.Item item, List&lt;byte&gt; carry)
+foreach (Thread thread in threads)
 {
-    fixed (byte* cipher = item.AsSpan())
+    thread.Join();
+}
+
+// Decrypt takes a raw pointer (the buffer belongs to the ring); the pointer work stays out of the
+// async handler, which cannot contain unsafe code.
+static unsafe void Decrypt(TlsSession tls, in SpscRecvRing.Item item, List&lt;byte&gt; carry)
+    =&gt; carry.AddRange(tls.Decrypt(item.Ptr, item.Len));
+
+// One response per COMPLETE request in the carry, and none for a partial one. Returns whether
+// anything was written, so the caller flushes once for the batch rather than once per request.
+static bool Answer(TcpConnection conn, List&lt;byte&gt; carry, ReadOnlyMemory&lt;byte&gt; response)
+{
+    bool wrote = false;
+    int end;
+
+    while ((end = CollectionsMarshal.AsSpan(carry).IndexOf(&quot;\r\n\r\n&quot;u8)) &gt;= 0)
     {
-        carry.AddRange(tls.Decrypt(cipher, item.AsSpan().Length));
+        carry.RemoveRange(0, end + 4);
+
+        // kTLS is producing the records, so this is PLAINTEXT going into the slab. Compare
+        // Playground/Tls/OpenSsl, where the same line is tls.WriteEncrypted(conn, ...).
+        conn.Write(response.Span);
+
+        wrote = true;
     }
+
+    return wrote;
 }</code></pre>
+    <p class="ex-foot">The default. The OpenSSL handshake runs over the ring, then <b>transmit</b> is handed to the kernel - so <code>conn.Write</code> below is putting PLAINTEXT into the slab and the kernel produces the records. Receive stays in userspace, which is the asymmetry the rest of the TLS docs are about. Compare <label for="tab-tlsossl" class="ex-jump">openssl &middot; raw</label>: same server, one <code>TlsOptions</code> line different, and <code>conn.Write</code> becomes <code>tls.WriteEncrypted</code>.</p>
   </div>
 
   <div class="pane pane-tlspipe">
@@ -568,7 +604,7 @@ static unsafe void Decrypt(TlsSession tls, in SpscRecvRing.Item item, List&lt;by
       <span class="pane-pkg">ioxide</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide      -- TLS ships in the core package
-// The SAME handler serves both backends; only TlsOptions.KernelTx differs.
+//   sudo modprobe tls
 //   curl -k https://127.0.0.1:8443/
 
 using System.Buffers;
@@ -577,15 +613,23 @@ using System.Text;
 using ioxide;
 using ioxide.tls;
 
-const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
+// ── Knobs ────────────────────────────────────────────────────────────────────────────────────
+
+ushort port      = 8443;                        // https://127.0.0.1:8443/
+int    reactors  = Environment.ProcessorCount;  // one ring per reactor, one reactor per core
+int    bodyBytes = 8 * 1024;                    // TLS cost is per-byte, so a 2-byte &quot;ok&quot; would hide it
+
+const string certPath = &quot;cert.pem&quot;;   // any PEM pair
 const string keyPath  = &quot;key.pem&quot;;
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
 
 var config = new ServerConfig
 {
-    ReactorCount = Environment.ProcessorCount,
+    ReactorCount = reactors,
     Tcp = new TcpOptions
     {
-        Port = 8443,
+        Port = port,
     },
 };
 
@@ -594,21 +638,21 @@ var tlsOptions = new TlsOptions
     CertificatePath = certPath,
     KeyPath = keyPath,
 
-    // The only line that changes between the two runs above.
-    KernelTx = !false,
+    // The default. The kernel encrypts outbound records; see Playground/Tls/OpenSslPipes for the
+    // same server with this line flipped.
+    KernelTx = true,
 };
 
-int bodySize = 8 * 1024;
-byte[] body = new byte[bodySize];
+byte[] body = new byte[bodyBytes];
 &quot;ioxide-tls-pipes &quot;u8.CopyTo(body);
-for (int i = &quot;ioxide-tls-pipes &quot;u8.Length; i &lt; bodySize; i++)
+for (int i = &quot;ioxide-tls-pipes &quot;u8.Length; i &lt; bodyBytes; i++)
 {
     body[i] = (byte)(&#x27;a&#x27; + (i % 26));
 }
 
 byte[] response =
 [
-    .. Encoding.ASCII.GetBytes($&quot;HTTP/1.1 200 OK\r\nContent-Length: {bodySize}\r\n\r\n&quot;),
+    .. Encoding.ASCII.GetBytes($&quot;HTTP/1.1 200 OK\r\nContent-Length: {bodyBytes}\r\n\r\n&quot;),
     .. body,
 ];
 
@@ -668,7 +712,7 @@ for (int i = 0; i &lt; threads.Length; i++)
         }
         catch (Exception e)
         {
-            Console.Error.WriteLine($&quot;[tls-pipes] connection failed: {e.Message}&quot;);
+            Console.Error.WriteLine($&quot;[tls-ktls-pipes] connection failed: {e.Message}&quot;);
         }
         finally
         {
@@ -681,24 +725,22 @@ for (int i = 0; i &lt; threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($&quot;[tls-pipes] {config.ReactorCount} reactors on :{config.Tcp!.Port}, &quot;
-                + $&quot;{bodySize}-byte body, tx={(tlsOptions.KernelTx ? &quot;kernel&quot; : &quot;openssl&quot;)}&quot;);
+Console.WriteLine($&quot;[tls-ktls-pipes] {config.ReactorCount} reactors on :{config.Tcp!.Port}, &quot;
+                + $&quot;{bodyBytes}-byte body, tx={(tlsOptions.KernelTx ? &quot;kernel&quot; : &quot;openssl&quot;)}&quot;);
 
 foreach (Thread thread in threads)
 {
     thread.Join();
 }</code></pre>
-    <p class="ex-foot">Both backends run this handler <b>unchanged</b> - not similar, identical. <code>TlsConnectionDualPipe</code> composes rather than implements: it pairs <code>TcpConnectionPipeReader</code> or <code>TlsPumpPipeReader</code> with <code>TcpConnectionPipeWriter</code> or <code>TlsEncryptingPipeWriter</code>, chosen from the <em>session</em> rather than from configuration. Those differ, because a handshake that left a partial record cannot hand off to kTLS RX at all and that connection keeps the userspace reader whatever the config asked for.
-    Compare the two raw-ring samples, <label for="tab-tls" class="ex-jump">ktls &middot; raw</label> and <label for="tab-tlsossl" class="ex-jump">tls &middot; openssl only</label>: at that level the backend <em>is</em> visible, because kTLS writes plaintext and OpenSSL calls <code>WriteEncrypted</code>.</p>
+    <p class="ex-foot">The same kTLS server behind an <code>IDuplexPipe</code>, for the frameworks that serve from one. Now compare <label for="tab-tlsosslpipe" class="ex-jump">openssl &middot; pipes</label>: its serve loop is <b>byte-identical</b> to this one. Over a pipe the backend is invisible, because <code>TlsConnectionDualPipe</code> composes its halves from the session rather than from configuration.</p>
   </div>
   <div class="pane pane-tlsossl">
     <div class="pane-head">
-      <h3>TLS &middot; OpenSSL only</h3>
+      <h3>OpenSSL &middot; raw ring</h3>
       <span class="pane-pkg">ioxide</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide      -- TLS ships in the core package
-// NO &#x27;modprobe tls&#x27; - this path never touches the kernel TLS module.
-//   curl -k https://127.0.0.1:8443/
+//   curl -k https://127.0.0.1:8443/        # no modprobe needed
 
 using System.Text;
 using System.Runtime.InteropServices;
@@ -706,15 +748,23 @@ using ioxide;
 using ioxide.tls;
 using ioxide.utils;
 
-const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
+// ── Knobs ────────────────────────────────────────────────────────────────────────────────────
+
+ushort port      = 8443;                        // https://127.0.0.1:8443/
+int    reactors  = Environment.ProcessorCount;  // one ring per reactor, one reactor per core
+int    bodyBytes = 8 * 1024;                    // TLS cost is per-byte, so a 2-byte &quot;ok&quot; would hide it
+
+const string certPath = &quot;cert.pem&quot;;   // any PEM pair
 const string keyPath  = &quot;key.pem&quot;;
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
 
 var config = new ServerConfig
 {
-    ReactorCount = Environment.ProcessorCount,
+    ReactorCount = reactors,
     Tcp = new TcpOptions
     {
-        Port = 8443,
+        Port = port,
     },
 };
 
@@ -727,17 +777,15 @@ var tlsOptions = new TlsOptions
     KeyPath         = keyPath,
 };
 
-// A medium fixed response, built once. TLS cost is per-byte, so &quot;ok&quot; would hide it.
-int bodySize = 8 * 1024;
-byte[] body = new byte[bodySize];
+byte[] body = new byte[bodyBytes];
 ReadOnlySpan&lt;byte&gt; fill = &quot;ioxide-ktls-payload &quot;u8;
-for (int i = 0; i &lt; bodySize; i++)
+for (int i = 0; i &lt; bodyBytes; i++)
 {
     body[i] = fill[i % fill.Length];
 }
 byte[] response =
 [
-    .. Encoding.ASCII.GetBytes($&quot;HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {bodySize}\r\n\r\n&quot;),
+    .. Encoding.ASCII.GetBytes($&quot;HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {bodyBytes}\r\n\r\n&quot;),
     .. body,
 ];
 
@@ -816,7 +864,7 @@ for (int i = 0; i &lt; threads.Length; i++)
 }
 
 Console.WriteLine($&quot;[tls-openssl] {config.ReactorCount} reactors on :{config.Tcp!.Port}, &quot;
-                + $&quot;{bodySize}-byte body, cert {certPath}, no kernel TLS&quot;);
+                + $&quot;{bodyBytes}-byte body, cert {certPath}, no kernel TLS&quot;);
 
 foreach (Thread thread in threads)
 {
@@ -848,10 +896,145 @@ static bool Answer(TcpConnection conn, TlsSession tls, List&lt;byte&gt; carry, R
 
     return wrote;
 }</code></pre>
-    <p class="ex-foot"><code>KernelTx = false</code> is the whole difference: no TLS ULP on the socket, so OpenSSL encrypts and decrypts and nothing needs the <code>tls</code> kernel module. That also gives back everything kTLS gives up - TLS 1.2, any ciphersuite, session resumption - and removes the handshake-alignment problem entirely.
-    <b>It costs nothing measurable here.</b> Against the plaintext <code>Tcp/Raw</code> baseline, 4 reactors, <code>wrk -t4 -c64</code>: at a 64-byte response kTLS and OpenSSL both run 0.79&times; plaintext; at 64 KiB it is 0.35&times; for kTLS and 0.44&times; for OpenSSL. Which backend you pick matters far less than the cost of TLS itself. What kTLS keeps that this cannot is <code>sendfile</code> and NIC offload - neither of which this benchmark exercises.</p>
+    <p class="ex-foot"><code>KernelTx = false</code> and no TLS ULP is attached at all - OpenSSL encrypts and decrypts. That drops every constraint kTLS imposes: no kernel module, TLS 1.2 available, any ciphersuite, session resumption back, no handshake-alignment problem. What it gives up is <code>sendfile</code> and NIC offload. <b>It costs nothing measurable here</b> - against the plaintext baseline, 4 reactors, <code>wrk -t4 -c64</code>: 0.79&times; for both at a 64-byte response, 0.35&times; kTLS vs 0.44&times; OpenSSL at 64 KiB. Which backend you pick matters far less than the cost of TLS.</p>
   </div>
 
+  <div class="pane pane-tlsosslpipe">
+    <div class="pane-head">
+      <h3>OpenSSL &middot; pipes</h3>
+      <span class="pane-pkg">ioxide</span>
+    </div>
+<pre><code class="language-csharp">// dotnet add package ioxide      -- TLS ships in the core package
+//   curl -k https://127.0.0.1:8443/        # no modprobe needed
+
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Text;
+using ioxide;
+using ioxide.tls;
+
+// ── Knobs ────────────────────────────────────────────────────────────────────────────────────
+
+ushort port      = 8443;                        // https://127.0.0.1:8443/
+int    reactors  = Environment.ProcessorCount;  // one ring per reactor, one reactor per core
+int    bodyBytes = 8 * 1024;                    // TLS cost is per-byte, so a 2-byte &quot;ok&quot; would hide it
+
+const string certPath = &quot;cert.pem&quot;;   // any PEM pair
+const string keyPath  = &quot;key.pem&quot;;
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+
+var config = new ServerConfig
+{
+    ReactorCount = reactors,
+    Tcp = new TcpOptions
+    {
+        Port = port,
+    },
+};
+
+var tlsOptions = new TlsOptions
+{
+    CertificatePath = certPath,
+    KeyPath = keyPath,
+
+    // The whole difference from Playground/Tls/KtlsPipes. No TLS ULP on the socket, so OpenSSL
+    // encrypts and decrypts and nothing here needs the &#x27;tls&#x27; kernel module - which also gives back
+    // TLS 1.2, any ciphersuite and session resumption.
+    KernelTx = false,
+};
+
+byte[] body = new byte[bodyBytes];
+&quot;ioxide-tls-pipes &quot;u8.CopyTo(body);
+for (int i = &quot;ioxide-tls-pipes &quot;u8.Length; i &lt; bodyBytes; i++)
+{
+    body[i] = (byte)(&#x27;a&#x27; + (i % 26));
+}
+
+byte[] response =
+[
+    .. Encoding.ASCII.GetBytes($&quot;HTTP/1.1 200 OK\r\nContent-Length: {bodyBytes}\r\n\r\n&quot;),
+    .. body,
+];
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i &lt; threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    reactor.OnStart = r =&gt; TlsService.Start(r, tlsOptions);
+
+    reactor.TcpHandle = async (r, conn) =&gt;
+    {
+        TlsSession? tls = null;
+        try
+        {
+            tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
+
+            // From here down, nothing knows or cares which backend is in use.
+            await using var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
+
+            while (true)
+            {
+                ReadResult read = await pipe.Input.ReadAsync();
+
+                // Answer per REQUEST, not per read. TLS hands back RECORDS, so one request split
+                // across two records would otherwise draw two responses.
+                int answered = 0;
+                SequencePosition consumed = read.Buffer.Start;
+
+                var reader = new SequenceReader&lt;byte&gt;(read.Buffer);
+                while (reader.TryReadTo(out ReadOnlySequence&lt;byte&gt; _, &quot;\r\n\r\n&quot;u8, advancePastDelimiter: true))
+                {
+                    consumed = reader.Position;
+                    answered++;
+                }
+
+                // Consumed only whole requests; examined everything, so a partial head parks
+                // until more arrives instead of spinning on the same bytes.
+                pipe.Input.AdvanceTo(consumed, read.Buffer.End);
+
+                for (int n = 0; n &lt; answered; n++)
+                {
+                    pipe.Output.Write(response);
+                }
+
+                if (answered &gt; 0)
+                {
+                    await pipe.Output.FlushAsync();
+                }
+
+                if (read.IsCompleted || read.IsCanceled)
+                {
+                    return;
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($&quot;[tls-openssl-pipes] connection failed: {e.Message}&quot;);
+        }
+        finally
+        {
+            tls?.Dispose();
+            conn.DecRef();
+        }
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $&quot;reactor-{i}&quot; };
+    threads[i].Start();
+}
+
+Console.WriteLine($&quot;[tls-openssl-pipes] {config.ReactorCount} reactors on :{config.Tcp!.Port}, &quot;
+                + $&quot;{bodyBytes}-byte body, tx={(tlsOptions.KernelTx ? &quot;kernel&quot; : &quot;openssl&quot;)}&quot;);
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}</code></pre>
+    <p class="ex-foot">Diff this against <label for="tab-tlspipe" class="ex-jump">ktls &middot; pipes</label> and the only functional difference is <code>KernelTx</code>; the rest is the banner and the log tag. That is the point of the pipe seam - <code>TlsConnectionDualPipe</code> pairs <code>TcpConnectionPipeReader</code> or <code>TlsPumpPipeReader</code> with <code>TcpConnectionPipeWriter</code> or <code>TlsEncryptingPipeWriter</code>, chosen from the <em>session</em>. It has to be the session and not the config, because a handshake that left a partial record keeps the userspace reader whatever was asked for.</p>
+  </div>
   <div class="pane pane-h2">
     <div class="pane-head">
       <h3>HTTP/2 · nghttp2</h3>

--- a/docs/learn/tls.html
+++ b/docs/learn/tls.html
@@ -313,15 +313,47 @@ if (tls.NegotiatedAlpn == "h2")
     allocation-free and is not the bottleneck; the cost is <code>SslStream</code>'s own.</p>
 
     <h2>Which to use</h2>
+    <p>Three options, not two - and the middle one is new. It used to be that wanting TLS 1.2,
+    resumption or client certificates meant leaving the ring for <code>SslStream</code>. It no
+    longer does: <code>KernelTx = false</code> gives those on the ring-native path.</p>
     <ul>
-      <li><b>Maximum TLS throughput on Linux 6+</b> with the <code>tls</code> module available, and
-      TLS 1.3 / ALPN is enough &rarr; <b>kTLS</b> (<code>ioxide.tls</code>).</li>
-      <li><b>Portability, older clients, or full TLS features</b> (client certs, resumption,
-      TLS 1.2), or you just do not want a kernel-module dependency &rarr; <b>SslStream</b> over
-      <code>ConnectionStream</code>.</li>
+      <li><b>kTLS</b> (the default) &rarr; you are on Linux 6+ with the <code>tls</code> module, TLS
+      1.3 and ALPN are enough, and you want <code>sendfile</code> or a NIC that offloads TLS.
+      Sample: <a href="https://github.com/MDA2AV/ioxide/tree/main/Playground/Tls/Ktls">Tls/Ktls</a>.</li>
+      <li><b>OpenSSL both ways</b> (<code>KernelTx = false</code>) &rarr; no kernel module (so it runs
+      in a container that lacks it), TLS 1.2 available, any ciphersuite, resumption back, and no
+      handshake-alignment constraint. Costs nothing measurable here - see the table above. Sample:
+      <a href="https://github.com/MDA2AV/ioxide/tree/main/Playground/Tls/OpenSsl">Tls/OpenSsl</a>.</li>
+      <li><b>SslStream</b> over <code>ConnectionStream</code> &rarr; now only for what OpenSSL itself
+      cannot give you, or when you want the BCL's stack specifically. It is the slowest of the
+      three, because every byte is encrypted in userspace <em>and</em> copied through a
+      <code>Stream</code>.</li>
     </ul>
-    <p>Both ride a dedicated port via <a href="multiport.html">multi-port</a>, so you can even serve
-    plaintext on one port and either TLS path on another from the same reactors.</p>
+    <p>Serving from an <code>IDuplexPipe</code> makes the first two indistinguishable in your code:
+    <code>TlsConnectionDualPipe</code> picks its halves from the session, so the same handler runs
+    on either backend with no branch. That is what
+    <a href="https://github.com/MDA2AV/ioxide/tree/main/Playground/Tls/Pipes">Tls/Pipes</a>
+    demonstrates - one handler, two backends, one flag between them.</p>
+    <p>All of them ride a dedicated port via <a href="multiport.html">multi-port</a>, so you can
+    serve plaintext on one port and any TLS path on another from the same reactors.</p>
+
+    <h2>Kernel decryption, and why it is off</h2>
+    <p><code>TlsOptions.KernelRx</code> hands inbound records to the kernel as well, after which an
+    ordinary recv returns plaintext and the zero-copy reader serves TLS connections exactly as it
+    serves cleartext ones - no pump, no owned buffer. It is <b>experimental and off by default</b>,
+    for two reasons that are not going away on their own.</p>
+    <ul>
+      <li>The handoff must land on a record boundary. Whatever the handshake already pulled off the
+      socket is invisible to the kernel, so the record sequence it starts at has to account for it -
+      and a <em>partial</em> record left behind cannot be accounted for at all, because those bytes
+      are gone. That connection silently keeps the userspace reader.</li>
+      <li>A non-application-data record - a TLS 1.3 <code>KeyUpdate</code>, or an alert - is only
+      retrievable through <code>recvmsg</code> with a control message. The TCP hot path uses
+      <code>IORING_OP_RECV</code>, which carries none, so the kernel refuses the read and the
+      connection dies. Clients that never send one are unaffected.</li>
+    </ul>
+    <p>There is also a known race: roughly one first connection in twelve fails outright. Measured,
+    not fixed. Treat the flag as a research toggle rather than a deployment option.</p>
 
     <div class="next"><a href="files.html">Static files →</a></div>
   </main>

--- a/ioxide.slnx
+++ b/ioxide.slnx
@@ -46,8 +46,9 @@
 
   <Folder Name="/apps/playground/tls/">
     <Project Path="Playground/Tls/Ktls/Playground.Tls.Ktls.csproj" />
+    <Project Path="Playground/Tls/KtlsPipes/Playground.Tls.KtlsPipes.csproj" />
     <Project Path="Playground/Tls/OpenSsl/Playground.Tls.OpenSsl.csproj" />
-    <Project Path="Playground/Tls/Pipes/Playground.Tls.Pipes.csproj" />
+    <Project Path="Playground/Tls/OpenSslPipes/Playground.Tls.OpenSslPipes.csproj" />
     <Project Path="Playground/Tls/SslStream/Playground.Tls.SslStream.csproj" />
   </Folder>
 

--- a/scripts/gen-docs-tls-panes.py
+++ b/scripts/gen-docs-tls-panes.py
@@ -1,0 +1,125 @@
+"""Generate the docs' TLS panes from the Playground sources, so the two cannot drift.
+
+Same contract as gen-docs-proxy-panes.py: each pane is the sample's real Program.cs with the
+Playground.Shared indirection inlined, so what the page shows is a self-contained program.
+"""
+import html
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# pane slug -> (sample, title, packages, run lines, trailing note)
+PANES = {
+    "tls": (
+        "Tls/Ktls", "kTLS &middot; raw ring", "ioxide",
+        ["sudo modprobe tls        # kTLS needs the Linux 'tls' module + OpenSSL 3",
+         "curl -k https://127.0.0.1:8443/"],
+        "The default. The OpenSSL handshake runs over the ring, then <b>transmit</b> is handed to the "
+        "kernel - so <code>conn.Write</code> below is putting PLAINTEXT into the slab and the kernel "
+        "produces the records. Receive stays in userspace, which is the asymmetry the rest of the TLS "
+        "docs are about. Compare <label for=\"tab-tlsossl\" class=\"ex-jump\">openssl &middot; raw</label>: "
+        "same server, one <code>TlsOptions</code> line different, and <code>conn.Write</code> becomes "
+        "<code>tls.WriteEncrypted</code>."),
+    "tlsossl": (
+        "Tls/OpenSsl", "OpenSSL &middot; raw ring", "ioxide",
+        ["curl -k https://127.0.0.1:8443/        # no modprobe needed"],
+        "<code>KernelTx = false</code> and no TLS ULP is attached at all - OpenSSL encrypts and "
+        "decrypts. That drops every constraint kTLS imposes: no kernel module, TLS 1.2 available, any "
+        "ciphersuite, session resumption back, no handshake-alignment problem. What it gives up is "
+        "<code>sendfile</code> and NIC offload. "
+        "<b>It costs nothing measurable here</b> - against the plaintext baseline, 4 reactors, "
+        "<code>wrk -t4 -c64</code>: 0.79&times; for both at a 64-byte response, 0.35&times; kTLS vs "
+        "0.44&times; OpenSSL at 64 KiB. Which backend you pick matters far less than the cost of TLS."),
+    "tlspipe": (
+        "Tls/KtlsPipes", "kTLS &middot; pipes", "ioxide",
+        ["sudo modprobe tls", "curl -k https://127.0.0.1:8443/"],
+        "The same kTLS server behind an <code>IDuplexPipe</code>, for the frameworks that serve from "
+        "one. Now compare <label for=\"tab-tlsosslpipe\" class=\"ex-jump\">openssl &middot; pipes</label>: "
+        "its serve loop is <b>byte-identical</b> to this one. Over a pipe the backend is invisible, "
+        "because <code>TlsConnectionDualPipe</code> composes its halves from the session rather than "
+        "from configuration."),
+    "tlsosslpipe": (
+        "Tls/OpenSslPipes", "OpenSSL &middot; pipes", "ioxide",
+        ["curl -k https://127.0.0.1:8443/        # no modprobe needed"],
+        "Diff this against <label for=\"tab-tlspipe\" class=\"ex-jump\">ktls &middot; pipes</label> and "
+        "the only functional difference is <code>KernelTx</code>; the rest is the banner and the log "
+        "tag. That is the point of the pipe seam - <code>TlsConnectionDualPipe</code> pairs "
+        "<code>TcpConnectionPipeReader</code> or <code>TlsPumpPipeReader</code> with "
+        "<code>TcpConnectionPipeWriter</code> or <code>TlsEncryptingPipeWriter</code>, chosen from the "
+        "<em>session</em>. It has to be the session and not the config, because a handshake that left a "
+        "partial record keeps the userspace reader whatever was asked for."),
+}
+
+BANNER = re.compile(r"^// ─{5,}.*?^// ─{5,}\n\n", re.S | re.M)
+KNOBS = re.compile(r"^// ── Knobs ─+\n.*?^// ─{20,}\n\n", re.S | re.M)
+
+
+def inline(code: str) -> str:
+    """Strip the harness plumbing so the pane is a program you can paste and run."""
+    code = code.replace("using Playground.Shared;\n", "")
+
+    # The knob block is the sample's configuration; keep the literals, drop the harness override
+    # and the cert indirection that only exists because QuicCert generates one.
+    code = code.replace("\nEnv.Override(ref port, ref reactors, ref bodyBytes);\n", "")
+    code = code.replace("\nEnv.Override(ref port, ref reactors);\n", "")
+    code = re.sub(r"// Env\.Override exists only[^\n]*\n// when you copy this out[^\n]*\n", "", code)
+    code = re.sub(r"// Edit these\. That is the whole mechanism[^\n]*\n", "", code)
+
+    code = code.replace(
+        "// A real PEM pair, or null to generate a self-signed localhost cert on first run.\n"
+        "string? certOverride = null;\n"
+        "string? keyOverride  = null;\n",
+        'const string certPath = "cert.pem";   // any PEM pair\nconst string keyPath  = "key.pem";\n')
+    code = re.sub(r"\(string certPath, string keyPath\) = QuicCert\.Ensure\(certOverride, keyOverride\);\n", "", code)
+
+    code = BANNER.sub("", code)
+    assert "Env." not in code and "QuicCert" not in code, \
+        "harness plumbing survived: " + "; ".join(
+            l.strip() for l in code.splitlines() if "Env." in l or "QuicCert" in l)
+    return code.strip()
+
+
+def build(slug: str) -> str:
+    sample, title, packages, run, note = PANES[slug]
+    body = inline((ROOT / f"Playground/{sample}/Program.cs").read_text())
+
+    header = f"// dotnet add package {packages}      -- TLS ships in the core package\n"
+    header += "\n".join(f"//   {line}" for line in run)
+    code = html.escape(f"{header}\n\n{body}", quote=False).replace("'", "&#x27;").replace('"', "&quot;")
+
+    return (f'  <div class="pane pane-{slug}">\n'
+            f'    <div class="pane-head">\n'
+            f'      <h3>{title}</h3>\n'
+            f'      <span class="pane-pkg">{packages}</span>\n'
+            f'    </div>\n'
+            f'<pre><code class="language-csharp">{code}</code></pre>\n'
+            f'    <p class="ex-foot">{note}</p>\n'
+            f'  </div>\n')
+
+
+if __name__ == "__main__":
+    index = ROOT / "docs/index.html"
+    page = index.read_text()
+    changed = 0
+
+    for slug in PANES:
+        marker = f'  <div class="pane pane-{slug}">'
+        if marker not in page:
+            raise SystemExit(f"pane-{slug} is not in docs/index.html - add its tab first")
+
+        start = page.index(marker)
+        end = page.index("  </div>\n", page.index("</code></pre>", start)) + len("  </div>\n")
+        fresh = build(slug)
+        if page[start:end] != fresh:
+            page = page[:start] + fresh + page[end:]
+            changed += 1
+
+    if changed:
+        index.write_text(page)
+        print(f"rewrote {changed} of {len(PANES)} TLS panes in docs/index.html")
+    else:
+        print("docs/index.html is already up to date")
+
+    for slug, (sample, *_rest) in PANES.items():
+        print(f"  pane-{slug:12} <- Playground/{sample}/Program.cs")


### PR DESCRIPTION
#154 merged before this commit landed — the rest of that work is on `main`, this is the part left behind. **Docs only, one file.**

Two things `learn/tls.html` still got wrong after the backend table went in.

## `KernelRx` was documented nowhere

The flag shipped with no page explaining it, which is the worst combination: discoverable in intellisense, unexplained everywhere else. It has a section now saying plainly that it is **off by default**, and why:

- The handoff must land on a record boundary. Whatever the handshake already pulled off the socket is invisible to the kernel, so the record sequence has to account for it — and a *partial* record left behind cannot be accounted for at all. That connection silently keeps the userspace reader.
- A non-application-data record — a TLS 1.3 `KeyUpdate`, or an alert — is only retrievable through `recvmsg` with a control message. The TCP hot path uses `IORING_OP_RECV`, which carries none, so the kernel refuses the read and the connection dies.
- There is a known race: roughly **one first connection in twelve** fails outright. Measured, not fixed.

Labelled a research toggle rather than a deployment option, which is what it is.

## "Which to use" was sending people the wrong way

It still offered two options and routed anyone wanting **TLS 1.2, session resumption or client certificates** to `SslStream`. That stopped being true when `KernelTx` became a flag — those all work on the ring-native path now, and `SslStream` is the *slowest* of the three, because every byte is encrypted in userspace **and** copied through a `Stream`.

Rewritten as three options, each pointing at the sample that demonstrates it:

| | when |
|---|---|
| **kTLS** (default) | Linux 6+ with the `tls` module, TLS 1.3 + ALPN are enough, and you want `sendfile` or NIC offload |
| **OpenSSL both ways** (`KernelTx = false`) | no kernel module, TLS 1.2, any ciphersuite, resumption, no alignment constraint — and it costs nothing measurable on this rig |
| **SslStream** | only for what OpenSSL itself cannot give you |

Plus a note that over an `IDuplexPipe` the first two are indistinguishable in your code, since `TlsConnectionDualPipe` picks its halves from the session — which is what `Tls/Pipes` exists to show.

Tag balance verified; page rendered and read back.
