### PR TITLE
docs(examples): post-#156 staleness sweep; every example tells the current truth

### DIFF
--- a/Playground/Clients/Https/Program.cs
+++ b/Playground/Clients/Https/Program.cs
@@ -16,7 +16,7 @@ using Playground.Shared;
 //  every other I/O here, and the response resumes this handler inline on its own thread.
 //
 //  Unlike the server side, none of this needs kTLS - nothing is offloaded to the kernel, so it
-//  runs without 'modprobe tls'. Needs: ioxide, ioxide.tls, ioxide.httpclient
+//  runs without 'modprobe tls'. Needs: ioxide, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
 // ── Knobs ────────────────────────────────────────────────────────────────────────────────────

--- a/Playground/Dockerfile
+++ b/Playground/Dockerfile
@@ -3,11 +3,11 @@
 #   docker build -f Playground/Dockerfile --build-arg SAMPLE=Tcp/Raw -t playground-raw .
 #   docker run --rm -p 8080:8080 playground-raw
 #
-#   docker build -f Playground/Dockerfile --build-arg SAMPLE=Nghttp3 -t playground-h3 .
+#   docker build -f Playground/Dockerfile --build-arg SAMPLE=Http3/Nghttp3 -t playground-h3 .
 #   docker run --rm -p 8080:8080 -p 8443:8443/udp playground-h3
 #
-# SAMPLE is the directory path under Playground/: Tcp/Raw, Tcp/Pipe, Tcp/Hop, Tcp/TaskRun, Pg,
-# File, Proxy, Nghttp3, Nghttp3Buffered.
+# SAMPLE is the directory path under Playground/ - any directory that carries a csproj:
+# Tcp/Raw, Tcp/Pipe, Tls/OpenSsl, Http2/Nghttp2, Http3/Nghttp3, Clients/Pg, Proxy/H1ToH1, ...
 ARG SAMPLE=Tcp/Raw
 
 FROM mcr.microsoft.com/dotnet/sdk:11.0-preview AS build

--- a/Playground/Http2/SslStream/Program.cs
+++ b/Playground/Http2/SslStream/Program.cs
@@ -7,8 +7,8 @@ using ioxide.nghttp2;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  http2-sslstream - HTTP/2 over the BCL's SslStream instead of kTLS. Fully managed, portable,
-//  no kernel module, and slower - every byte is encrypted in userspace both ways.
+//  http2-sslstream - HTTP/2 over the BCL's SslStream instead of ioxide's own termination. Fully
+//  managed, portable, and slower - the bytes cross a Stream both ways.
 //
 //      dotnet run -c Release --project Playground/Http2/SslStream
 //      curl -k --http2 https://127.0.0.1:8443/

--- a/Playground/Http2/Tls/Program.cs
+++ b/Playground/Http2/Tls/Program.cs
@@ -20,7 +20,7 @@ using Playground.Shared;
 //  run two different protocol loops.
 //
 //  Note what Nghttp2Connection is handed: a TlsConnectionDualPipe. It never learns that TLS is
-//  involved - the pipe decrypts on the way in, and kTLS encrypts on the way out, so the protocol
+//  involved - the pipe decrypts on the way in and encrypts on the way out, so the protocol
 //  code is byte-for-byte the same as the h2c sample. Needs: ioxide, ioxide.nghttp2
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
@@ -104,22 +104,9 @@ for (int i = 0; i < threads.Length; i++)
             if (tls.NegotiatedAlpn == "h2")
             {
                 // The decrypt lives in the pipe, so the HTTP/2 code below is identical to the
-                // cleartext sample. Two implementations of the same seam:
-                //
-                //   default   TlsConnectionDualPipe          decrypts into a Pipe it owns, fed by
-                //                                            a pump task
-                //   INPLACE=1 TlsConnectionDualPipeInPlace   decrypts inside the recv buffer and
-                //                                            hands that memory out - no pump, no
-                //                                            Pipe, backpressure is the ring
-                //
-                // Both are handed to the same Nghttp2Connection, which is the point.
-                // The two share only IDuplexPipe, which is not disposable - hence the second
-                // declaration rather than one `await using`.
-                // One type, both worlds. Which halves it uses is decided by what the handshake
-                // achieved, not by anything chosen here - see TlsConnectionDualPipe.
-                var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
-
-                await using var owner = pipe;
+                // cleartext sample. Which halves the pipe uses is decided by what the handshake
+                // achieved, not by anything chosen here.
+                await using var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
 
                 await new Nghttp2Connection(pipe).RunBufferedAsync(_ => new Nghttp2Response
                 {
@@ -129,8 +116,7 @@ for (int i = 0; i < threads.Length; i++)
                 return;
             }
 
-            // Anything else: HTTP/1.1 on the same port, written as plaintext because kTLS is
-            // producing the records.
+            // Anything else: HTTP/1.1 on the same port.
             //
             // The carry is not incidental. TLS hands back RECORDS, not requests, so a request
             // split across two records decrypts twice - and answering on "plaintext arrived"

--- a/Playground/Proxy/H1ToH1/Program.cs
+++ b/Playground/Proxy/H1ToH1/Program.cs
@@ -13,16 +13,15 @@ using Playground.Shared;
 //  This is the shape every other sample in this folder varies. Read it first.
 //
 //      # a TLS origin to forward to
-//      PLAYGROUND_PORT=8444 dotnet run -c Release --project Playground/Tls/Ktls
+//      PLAYGROUND_PORT=8444 dotnet run -c Release --project Playground/Tls/OpenSsl
 //      dotnet run -c Release --project Playground/Proxy/H1ToH1
 //      curl -k https://127.0.0.1:8443/
 //
-//  Two different TLS stacks are in play and they are not symmetric. INBOUND is kTLS: the OpenSSL
-//  handshake runs over the ring, then the kernel takes over transmit, so everything this handler
-//  writes is PLAINTEXT and the kernel makes the records. OUTBOUND is userspace: the pool wraps
-//  each upstream connection in its own TlsClientStream. Neither shows up in the proxying code.
+//  Two TLS stacks are in play. INBOUND is ioxide's own termination, OpenSSL in both directions
+//  by default. OUTBOUND is the client pool's: each upstream connection wraps its own
+//  TlsClientStream. Neither shows up in the proxying code.
 //
-//  Needs the Linux 'tls' module (sudo modprobe tls). Needs: ioxide, ioxide.httpclient
+//  Needs: ioxide, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
 (string certPath, string keyPath) = QuicCert.Ensure(
@@ -91,8 +90,7 @@ for (int i = 0; i < threads.Length; i++)
 
         try
         {
-            // The handshake reads and writes through this same connection; after it, the socket
-            // carries kTLS records the kernel en/decrypts.
+            // The handshake reads and writes through this same connection.
             tls = await r.GetService<TlsService>().AcceptAsync(conn);
 
             // A request can ride in with the handshake's final flight - answer it before parking
@@ -157,8 +155,8 @@ foreach (Thread thread in threads)
     thread.Join();
 }
 
-// One request out, one response back. Everything written here is PLAINTEXT: after the handshake
-// kTLS owns transmit, so there is nothing left for us to wrap.
+// One request out, one response back. tls.Write encrypts correctly whichever backend the
+// session ended up with.
 static async ValueTask ProxyAsync(TcpConnection conn, TlsSession tls, HttpClientPool client, string path)
 {
     try

--- a/Playground/Proxy/H1ToH2/Program.cs
+++ b/Playground/Proxy/H1ToH2/Program.cs
@@ -18,12 +18,11 @@ using Playground.Shared;
 //      dotnet run -c Release --project Playground/Proxy/H1ToH2
 //      curl -k https://127.0.0.1:8443/
 //
-//  Two different TLS stacks are in play and they are not symmetric. INBOUND is kTLS: the OpenSSL
-//  handshake runs over the ring, then the kernel takes over transmit, so everything this handler
-//  writes is PLAINTEXT and the kernel makes the records. OUTBOUND is userspace: the pool wraps
-//  each upstream connection in its own TlsClientStream. Neither shows up in the proxying code.
+//  Two TLS stacks are in play. INBOUND is ioxide's own termination, OpenSSL in both directions
+//  by default. OUTBOUND is the client pool's: each upstream connection wraps its own
+//  TlsClientStream. Neither shows up in the proxying code.
 //
-//  Needs the Linux 'tls' module (sudo modprobe tls). Needs: ioxide, ioxide.httpclient
+//  Needs: ioxide, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
 (string certPath, string keyPath) = QuicCert.Ensure(
@@ -92,8 +91,7 @@ for (int i = 0; i < threads.Length; i++)
 
         try
         {
-            // The handshake reads and writes through this same connection; after it, the socket
-            // carries kTLS records the kernel en/decrypts.
+            // The handshake reads and writes through this same connection.
             tls = await r.GetService<TlsService>().AcceptAsync(conn);
 
             // A request can ride in with the handshake's final flight - answer it before parking
@@ -158,8 +156,8 @@ foreach (Thread thread in threads)
     thread.Join();
 }
 
-// One request out, one response back. Everything written here is PLAINTEXT: after the handshake
-// kTLS owns transmit, so there is nothing left for us to wrap.
+// One request out, one response back. tls.Write encrypts correctly whichever backend the
+// session ended up with.
 static async ValueTask ProxyAsync(TcpConnection conn, TlsSession tls, Http2ClientPool client, string path)
 {
     try

--- a/Playground/Proxy/H1ToH3/Program.cs
+++ b/Playground/Proxy/H1ToH3/Program.cs
@@ -19,12 +19,11 @@ using Playground.Shared;
 //      PLAYGROUND_UPSTREAM_PORT=8443 dotnet run -c Release --project Playground/Proxy/H1ToH3
 //      curl -k https://127.0.0.1:8443/
 //
-//  Two different TLS stacks are in play and they are not symmetric. INBOUND is kTLS: the OpenSSL
-//  handshake runs over the ring, then the kernel takes over transmit, so everything this handler
-//  writes is PLAINTEXT and the kernel makes the records. OUTBOUND is userspace: the pool wraps
-//  each upstream connection in its own TlsClientStream. Neither shows up in the proxying code.
+//  Two TLS stacks are in play. INBOUND is ioxide's own termination, OpenSSL in both directions
+//  by default. OUTBOUND is the client pool's: each upstream connection wraps its own
+//  TlsClientStream. Neither shows up in the proxying code.
 //
-//  Needs the Linux 'tls' module (sudo modprobe tls). Needs: ioxide, ioxide.httpclient
+//  Needs: ioxide, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
 (string certPath, string keyPath) = QuicCert.Ensure(
@@ -81,8 +80,7 @@ for (int i = 0; i < threads.Length; i++)
 
         try
         {
-            // The handshake reads and writes through this same connection; after it, the socket
-            // carries kTLS records the kernel en/decrypts.
+            // The handshake reads and writes through this same connection.
             tls = await r.GetService<TlsService>().AcceptAsync(conn);
 
             // A request can ride in with the handshake's final flight - answer it before parking
@@ -146,8 +144,8 @@ foreach (Thread thread in threads)
     thread.Join();
 }
 
-// One request out, one response back. Everything written here is PLAINTEXT: after the handshake
-// kTLS owns transmit, so there is nothing left for us to wrap.
+// One request out, one response back. tls.Write encrypts correctly whichever backend the
+// session ended up with.
 static async ValueTask ProxyAsync(TcpConnection conn, TlsSession tls, Http3ClientPool client, string path)
 {
     try

--- a/Playground/Proxy/H2ToH1/Program.cs
+++ b/Playground/Proxy/H2ToH1/Program.cs
@@ -15,11 +15,11 @@ using Playground.Shared;
 //  the handshake, before a single byte of HTTP exists.
 //
 //  Note what Nghttp2Connection is handed - a TlsConnectionDualPipe. It never learns that TLS is
-//  involved: the pipe decrypts on the way in and kTLS encrypts on the way out, so the HTTP/2 code
+//  involved: the pipe decrypts on the way in and encrypts on the way out, so the HTTP/2 code
 //  is byte-for-byte the h2c version.
 //
 //      # a TLS origin to forward to
-//      PLAYGROUND_PORT=8444 dotnet run -c Release --project Playground/Tls/Ktls
+//      PLAYGROUND_PORT=8444 dotnet run -c Release --project Playground/Tls/OpenSsl
 //      dotnet run -c Release --project Playground/Proxy/H2ToH1
 //      curl -k --http2 https://127.0.0.1:8443/
 //
@@ -30,7 +30,7 @@ using Playground.Shared;
 //  unbounded, with the whole acquire bounded by HttpClientOptions.AcquireTimeoutMs - a saturated
 //  origin surfaces as a 502 on that stream, not as an fd leak.
 //
-//  Needs the Linux 'tls' module (sudo modprobe tls). Needs: ioxide, ioxide.nghttp2, ioxide.httpclient
+//  Needs: ioxide, ioxide.nghttp2, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
 (string certPath, string keyPath) = QuicCert.Ensure(

--- a/Playground/Proxy/H2ToH2/Program.cs
+++ b/Playground/Proxy/H2ToH2/Program.cs
@@ -24,7 +24,7 @@ using Playground.Shared;
 //      dotnet run -c Release --project Playground/Proxy/H2ToH2
 //      curl -k --http2 https://127.0.0.1:8443/
 //
-//  Needs the Linux 'tls' module (sudo modprobe tls). Needs: ioxide, ioxide.nghttp2, ioxide.httpclient
+//  Needs: ioxide, ioxide.nghttp2, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
 (string certPath, string keyPath) = QuicCert.Ensure(

--- a/Playground/Proxy/H2ToH3/Program.cs
+++ b/Playground/Proxy/H2ToH3/Program.cs
@@ -10,8 +10,8 @@ using Playground.Shared;
 //  protocol-translating edge: the client half of a migration where the origin moved to h3 and the
 //  clients have not.
 //
-//  Both hops are TLS 1.3 and they get there completely differently. INBOUND is kTLS on a TCP
-//  socket: OpenSSL handshake over the ring, then the kernel owns transmit. OUTBOUND is QUIC,
+//  Both hops are encrypted and get there completely differently. INBOUND is TLS on a TCP
+//  socket, terminated here - OpenSSL both ways by default. OUTBOUND is QUIC,
 //  where TLS is inside the transport and the crypto handshake IS the connection handshake - so
 //  the upstream pool takes no TLS options at all, only the ServerName the certificate must match.
 //
@@ -23,7 +23,7 @@ using Playground.Shared;
 //      PLAYGROUND_UPSTREAM_PORT=8443 dotnet run -c Release --project Playground/Proxy/H2ToH3
 //      curl -k --http2 https://127.0.0.1:8443/
 //
-//  Needs the Linux 'tls' module (sudo modprobe tls). Needs: ioxide, ioxide.nghttp2, ioxide.httpclient
+//  Needs: ioxide, ioxide.nghttp2, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
 (string certPath, string keyPath) = QuicCert.Ensure(

--- a/Playground/Proxy/H3ToH2/Program.cs
+++ b/Playground/Proxy/H3ToH2/Program.cs
@@ -5,16 +5,17 @@ using ioxide.ngtcp2;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  proxy h3->h2 - an HTTP/3 front door for an HTTP/2 (h2c) upstream. The shape of Proxy.H3ToH1
+//  proxy h3->h2 - an HTTP/3 front door for an HTTP/2 upstream. The shape of Proxy.H3ToH1
 //  with the upstream pool swapped: requests multiplex onto a single HTTP/2 connection instead of
 //  taking keep-alive h1 connections, so concurrent h3 requests share one upstream socket. Both
 //  hops still live on one reactor thread, and the frontend is QUIC-only (Tcp = null).
 //
-//  h2c is cleartext HTTP/2 with prior knowledge - the upstream must already speak it, e.g.:
+//  The upstream speaks h2 over TLS - chosen by ALPN, certificate verified (the playground's own
+//  self-signed cert is trusted by default). The Http2/Tls sample makes a ready origin:
 //
-//      docker run --rm -p 8081:8081 nginx ...        # nginx.conf: listen 8081; http2 on;
+//      PLAYGROUND_PORT=8444 dotnet run -c Release --project Playground/Http2/Tls
 //      dotnet run -c Release --project Playground/Proxy/H3ToH2
-//      curl --http3-only -ks https://127.0.0.1:8443/index.html
+//      curl --http3-only -ks https://127.0.0.1:8443/
 //
 //  Needs: ioxide.ngtcp2, ioxide.nghttp3, ioxide.httpclient
 // ─────────────────────────────────────────────────────────────────────────────────────────────

--- a/Playground/README.md
+++ b/Playground/README.md
@@ -17,11 +17,11 @@ Run any of them with `dotnet run -c Release --project Playground/<Group>/<Name>`
 | [`Tcp.TaskRun`](Tcp/TaskRun/Program.cs) | 84 | Awaiting ordinary thread-pool work and still resuming on the reactor. | `ioxide` |
 | [`Tcp.Incremental`](Tcp/Incremental/Program.cs) | 95 | `Tcp.Raw` with the per-connection buffer-ring mode - one config block is the whole diff. Kernel 6.12+. | `ioxide` |
 | [`Tcp.Big`](Tcp/Big/Program.cs) | 101 | The write path under a 100 KB body: `SEND_ZC`, slab overflow (`grow` vs `seg`), checksum-able output. | `ioxide` |
-| [`Tls.Ktls`](Tls/Ktls/Program.cs) | 172 | OpenSSL handshake on the ring, then **kernel TLS** transmit - the handler writes plaintext. | `ioxide` |
-| [`Tls.OpenSsl`](Tls/OpenSsl/Program.cs) | 194 | The same server with kernel TLS **off**: OpenSSL both ways, no `modprobe tls`, and TLS 1.2 / any suite / resumption come back. | `ioxide` |
+| [`Tls.Ktls`](Tls/Ktls/Program.cs) | 172 | The **kernel TLS** opt-in: after the handshake the kernel owns transmit and the handler writes plaintext. `modprobe tls`. | `ioxide` |
+| [`Tls.OpenSsl`](Tls/OpenSsl/Program.cs) | 194 | **The default**: OpenSSL both ways - no kernel module, and TLS 1.2 / any suite / resumption. | `ioxide` |
 | [`Tls.KtlsPipes`](Tls/KtlsPipes/Program.cs) | 163 | kTLS served through an `IDuplexPipe`. | `ioxide` |
 | [`Tls.OpenSslPipes`](Tls/OpenSslPipes/Program.cs) | 164 | The same, with OpenSSL. Its serve loop is byte-identical to `Tls.KtlsPipes` - over a pipe the backend is invisible. | `ioxide` |
-| [`Tls.SslStream`](Tls/SslStream/Program.cs) | 100 | The BCL `SslStream` over `TcpConnectionStream` - portable userspace TLS, the kTLS comparison point. | `ioxide` |
+| [`Tls.SslStream`](Tls/SslStream/Program.cs) | 100 | The BCL `SslStream` over `TcpConnectionStream` - portable userspace TLS, the comparison point. | `ioxide` |
 | [`Http2.Nghttp2`](Http2/Nghttp2/Program.cs) | 66 | HTTP/2 (h2c, prior knowledge) with nghttp2 doing framing, HPACK and flow control. | `ioxide.nghttp2` |
 | [`Http2.Managed`](Http2/Managed/Program.cs) | 66 | The same server with **zero native code** - framing, HPACK and flow control in C#. Drop-in for the above. | `ioxide.http2` |
 | [`Http2.Tls`](Http2/Tls/Program.cs) | 132 | h2 **and** http/1.1 on one port, chosen by ALPN. The HTTP/2 code is unchanged - only the pipe differs. | `ioxide.nghttp2` |
@@ -29,12 +29,12 @@ Run any of them with `dotnet run -c Release --project Playground/<Group>/<Name>`
 | [`Http3.Nghttp3`](Http3/Nghttp3/Program.cs) | 169 | HTTP/3 with **streamed** dispatch, and a `SIGTERM` GOAWAY drain. | `ioxide.ngtcp2`, `ioxide.nghttp3` |
 | [`Http3.Buffered`](Http3/Buffered/Program.cs) | 146 | The same server with **buffered** dispatch - one method call is the whole difference. | `ioxide.ngtcp2`, `ioxide.nghttp3` |
 | [`Quic.Alpn`](Quic/Alpn/Program.cs) | 111 | One QUIC listener, two protocols by ALPN: h3, or raw stream echo over the dual pipe. QUIC-only - `Tcp = null`. | `ioxide.ngtcp2`, `ioxide.nghttp3` |
-| [`Proxy.H1ToH1`](Proxy/H1ToH1/Program.cs) | 207 | TLS both hops, and the one to read first - kTLS in, `TlsClientContext` out. Everything else here is this with one type changed. | `ioxide.httpclient` |
+| [`Proxy.H1ToH1`](Proxy/H1ToH1/Program.cs) | 207 | TLS both hops, and the one to read first - ioxide TLS in, `TlsClientContext` out. Everything else here is this with one type changed. | `ioxide.httpclient` |
 | [`Proxy.H1ToH2`](Proxy/H1ToH2/Program.cs) | 208 | The same frontend, h2 upstream chosen by ALPN: `PoolSize` 1 carries every concurrent request. | `ioxide.httpclient` |
 | [`Proxy.H1ToH3`](Proxy/H1ToH3/Program.cs) | 196 | h1 in, h3 out. The upstream takes no TLS options at all - QUIC has no cleartext mode, and no `Quic` config is needed to be a client. | `ioxide.httpclient` |
 | [`Proxy.H2ToH1`](Proxy/H2ToH1/Program.cs) | 171 | The classic edge: h2 over TLS in (browsers refuse h2c), h1 origin behind. The one combination whose pool must size for concurrency. | `ioxide.nghttp2`, `ioxide.httpclient` |
 | [`Proxy.H2ToH2`](Proxy/H2ToH2/Program.cs) | 164 | h2 both sides - two sockets per reactor whatever the load. Two HPACK tables that cannot be spliced, and now two keys. | `ioxide.nghttp2`, `ioxide.httpclient` |
-| [`Proxy.H2ToH3`](Proxy/H2ToH3/Program.cs) | 150 | The protocol-translating edge: kTLS on TCP in, QUIC out, encrypted end to end by two completely different mechanisms. | `ioxide.nghttp2`, `ioxide.httpclient` |
+| [`Proxy.H2ToH3`](Proxy/H2ToH3/Program.cs) | 150 | The protocol-translating edge: TLS on TCP in, QUIC out, encrypted end to end by two completely different mechanisms. | `ioxide.nghttp2`, `ioxide.httpclient` |
 | [`Proxy.H3ToH1`](Proxy/H3ToH1/Program.cs) | 129 | HTTP/3 front door, TLS h1 upstream. `Tcp = null`, so every TCP socket the process owns is an outbound TLS one. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
 | [`Proxy.H3ToH2`](Proxy/H3ToH2/Program.cs) | 127 | The same proxy with the upstream pool swapped: requests multiplex onto one h2-over-TLS connection. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
 | [`Proxy.H3ToH3`](Proxy/H3ToH3/Program.cs) | 111 | The one that needed no TLS wiring at either end - QUIC has no cleartext mode, so both hops are TLS 1.3 by construction. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |
@@ -142,12 +142,13 @@ Nine samples, one per frontend x upstream combination: the frontend protocol is 
 pool type (`HttpClientPool`, `Http2ClientPool`, `Http3ClientPool`). Nothing else differs, which
 is the point.
 
-**Every hop is TLS.** Facing, that is kTLS for the h1 and h2 frontends (`modprobe tls`) and QUIC's
-own TLS 1.3 for the h3 ones; upstream, a `TlsClientContext` for h1 and h2 and again QUIC for h3.
-The h2 frontends offer only `h2` in ALPN, which is what makes them reachable from a browser at all.
+**Every hop is TLS.** Facing, that is ioxide's own termination for the h1 and h2 frontends -
+OpenSSL both ways by default, no kernel module - and QUIC's own TLS 1.3 for the h3 ones;
+upstream, a `TlsClientContext` for h1 and h2 and again QUIC for h3. The h2 frontends offer only
+`h2` in ALPN, which is what makes them reachable from a browser at all.
 
-Each needs a **TLS** origin to forward to on `PLAYGROUND_UPSTREAM_PORT` - `Tls.Ktls` for an h1
-upstream, `Http2.Tls` for h2, `Http3.Nghttp3` for h3. They verify its certificate against the same
+Each needs a **TLS** origin to forward to on `PLAYGROUND_UPSTREAM_PORT` - `Tls/OpenSsl` for an h1
+upstream, `Http2/Tls` for h2, `Http3/Nghttp3` for h3. They verify its certificate against the same
 self-signed cert they serve, so they work against each other out of the box. With nothing listening
 they answer `502` once the acquire timeout elapses, and a certificate that does not verify arrives
 the same way.
@@ -155,7 +156,7 @@ the same way.
 ## Docker
 
 `Playground/Dockerfile` builds one image per sample, selected with `--build-arg SAMPLE=<path>` from
-the repo root - `Tcp/Raw`, `Clients.Pg`, `Http3.Nghttp3` and so on, matching the directory layout. Publish
+the repo root - `Tcp/Raw`, `Clients/Pg`, `Http3/Nghttp3` and so on, matching the directory layout. Publish
 `8080/tcp`, and `8443/udp` as well for the HTTP/3 samples.
 
 io_uring pins memory, so a container running many reactors may need `--ulimit memlock=-1:-1`.

--- a/Playground/Tls/Ktls/Program.cs
+++ b/Playground/Tls/Ktls/Program.cs
@@ -16,7 +16,7 @@ using Playground.Shared;
 //
 //  PLAYGROUND_TLS_CERT/_KEY point at a real PEM pair; otherwise a self-signed localhost cert is
 //  generated. PLAYGROUND_BODY sizes the response (default 8 KB - a representative JSON/HTML-ish
-//  payload, since TLS overhead only shows against real bodies). Needs: ioxide.tls
+//  payload, since TLS overhead only shows against real bodies). Needs: ioxide
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
 // ── Knobs ────────────────────────────────────────────────────────────────────────────────────
@@ -153,7 +153,8 @@ for (int i = 0; i < threads.Length; i++)
 }
 
 Console.WriteLine($"[tls-ktls] {config.ReactorCount} reactors on :{config.Tcp!.Port}, "
-                + $"{bodyBytes}-byte body, cert {certPath}");
+                + $"{bodyBytes}-byte body, rx={(kernelRx ? "kernel (experimental)" : "openssl")}, "
+                + $"cert {certPath}");
 
 foreach (Thread thread in threads)
 {

--- a/Playground/Tls/KtlsPipes/Program.cs
+++ b/Playground/Tls/KtlsPipes/Program.cs
@@ -31,8 +31,8 @@ using Playground.Shared;
 //  userspace reader whatever the config said. TlsSession reports what actually happened.
 //
 //  Compare the raw-ring pair, Playground/Tls/Ktls and Playground/Tls/OpenSsl. Those two DO differ
-//  in the handler, because at that level the backend is visible: kTLS writes plaintext, OpenSSL
-//  calls WriteEncrypted. Over a pipe it is not. Needs: ioxide
+//  in the handler, because at that level the backend is visible: kTLS writes plaintext straight
+//  to the connection, OpenSSL goes through TlsSession.Write. Over a pipe it is not. Needs: ioxide
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
 // ── Knobs ────────────────────────────────────────────────────────────────────────────────────
@@ -49,6 +49,13 @@ Env.Override(ref port, ref reactors, ref bodyBytes);
 // A real PEM pair, or null to generate a self-signed localhost cert on first run.
 string? certOverride = null;
 string? keyOverride  = null;
+
+// Hand INBOUND decryption to the kernel too. Off by default and experimental: about one first
+// connection in twelve fails outright, and a client sending a TLS 1.3 KeyUpdate loses the
+// connection. Transmit stays kernel-side either way - that is the point of this sample.
+bool kernelRx = false;
+
+Env.OverrideKtls(ref kernelRx);
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
 (string certPath, string keyPath) = QuicCert.Ensure(certOverride, keyOverride);
@@ -67,10 +74,12 @@ var tlsOptions = new TlsOptions
     CertificatePath = certPath,
     KeyPath = keyPath,
 
-    // NOT the default - TLS is OpenSSL both ways unless you ask for this. The kernel encrypts
-    // outbound records while receive stays in OpenSSL, so this is the mixed mode: kTLS TX,
-    // userspace RX. See Playground/Tls/OpenSslPipes for the same server without this line.
+    // NOT the default - TLS is OpenSSL both ways unless you ask for this. As shipped this is the
+    // mixed mode, kernel TX with OpenSSL RX; Playground/Tls/OpenSslPipes is the same server
+    // without this line.
     KernelTx = true,
+
+    KernelRx = kernelRx,
 };
 
 byte[] body = new byte[bodyBytes];
@@ -156,7 +165,8 @@ for (int i = 0; i < threads.Length; i++)
 }
 
 Console.WriteLine($"[tls-ktls-pipes] {config.ReactorCount} reactors on :{config.Tcp!.Port}, "
-                + $"{bodyBytes}-byte body, tx={(tlsOptions.KernelTx ? "kernel" : "openssl")}");
+                + $"{bodyBytes}-byte body, tx={(tlsOptions.KernelTx ? "kernel" : "openssl")}, "
+                + $"rx={(kernelRx ? "kernel (experimental)" : "openssl")}");
 
 foreach (Thread thread in threads)
 {

--- a/Playground/Tls/OpenSsl/Program.cs
+++ b/Playground/Tls/OpenSsl/Program.cs
@@ -135,7 +135,7 @@ for (int i = 0; i < threads.Length; i++)
 
                 if (Answer(conn, tls, carry, response))
                 {
-                    await conn.FlushAsync();   // plaintext: the kernel encrypts on send
+                    await conn.FlushAsync();
                 }
 
                 if (snapshot.IsClosed || tls.Closed) return;

--- a/docs/index.html
+++ b/docs/index.html
@@ -270,7 +270,7 @@ foreach (Thread thread in threads)
 {
     thread.Join();
 }</code></pre>
-    <p class="ex-foot">The third TLS backend, and the portable one: the BCL's <code>SslStream</code> over <code>TcpConnectionStream</code>. Fully managed, full-featured - client certificates, resumption, TLS 1.2 - and the slowest of the three, because every byte is encrypted in userspace <em>and</em> copied through a <code>Stream</code>. Reach for it when you need something OpenSSL itself cannot give you; otherwise <label for="tab-tlsossl" class="ex-jump">openssl &middot; raw</label> gets you the same features on the ring.</p>
+    <p class="ex-foot">The third TLS backend, and the portable one: the BCL's <code>SslStream</code> over <code>TcpConnectionStream</code>. Fully managed, full-featured, and the slowest of the three, because the bytes are copied through a <code>Stream</code> both ways. Reach for it for <b>client certificates</b> - the ring-native path does not do mTLS - or anything else OpenSSL-on-the-ring does not expose; for TLS 1.2 and resumption the default already has you covered: <label for="tab-tlsossl" class="ex-jump">openssl &middot; raw</label>.</p>
   </div>
   <div class="pane pane-big">
     <div class="pane-head">
@@ -637,7 +637,7 @@ internal sealed class StreamDuplexPipe(Stream stream) : IDuplexPipe
     public PipeReader Input { get; } = PipeReader.Create(stream, new StreamPipeReaderOptions(leaveOpen: true));
     public PipeWriter Output { get; } = PipeWriter.Create(stream, new StreamPipeWriterOptions(leaveOpen: true));
 }</code></pre>
-    <p class="ex-foot">HTTP/2 over the BCL's <code>SslStream</code>, and the point is the ten-line <code>Stream</code>-to-<code>IDuplexPipe</code> adapter at the bottom. <code>Nghttp2Connection</code> takes a pipe, so the same HTTP/2 code runs over the ring directly, over kTLS, or over <code>SslStream</code> - the transport is a constructor argument, not a branch inside the protocol.</p>
+    <p class="ex-foot">HTTP/2 over the BCL's <code>SslStream</code>, and the point is the ten-line <code>Stream</code>-to-<code>IDuplexPipe</code> adapter at the bottom. <code>Nghttp2Connection</code> takes a pipe, so the same HTTP/2 code runs over the ring directly, over ioxide's TLS, or over <code>SslStream</code> - the transport is a constructor argument, not a branch inside the protocol.</p>
   </div>
   <div class="pane pane-h3buf">
     <div class="pane-head">
@@ -1132,17 +1132,12 @@ for (int id = 0; id &lt; threads.Length; id++)
                 while (TryParseRequest(ref buffer, out _))   // framing is your code
                 {
                     consumed = buffer.Start;
+                    ok.Span.CopyTo(writer.GetSpan(ok.Length));   // one response per request
+                    writer.Advance(ok.Length);
                     respond = true;
                 }
 
-                if (respond)
-                {
-                    ok.Span.CopyTo(writer.GetSpan(ok.Length));
-                    writer.Advance(ok.Length);
-                    wrote = true;
-                }
-
-                if (wrote) await writer.FlushAsync();
+                if (respond) await writer.FlushAsync();
 
                 reader.AdvanceTo(consumed, buffer.End);   // partial tail is kept
 
@@ -1502,7 +1497,8 @@ for (int i = 0; i &lt; threads.Length; i++)
 }
 
 Console.WriteLine($&quot;[tls-ktls] {config.ReactorCount} reactors on :{config.Tcp!.Port}, &quot;
-                + $&quot;{bodyBytes}-byte body, cert {certPath}&quot;);
+                + $&quot;{bodyBytes}-byte body, rx={(kernelRx ? &quot;kernel (experimental)&quot; : &quot;openssl&quot;)}, &quot;
+                + $&quot;cert {certPath}&quot;);
 
 foreach (Thread thread in threads)
 {
@@ -1535,7 +1531,7 @@ static bool Answer(TcpConnection conn, List&lt;byte&gt; carry, ReadOnlyMemory&lt
 
     return wrote;
 }</code></pre>
-    <p class="ex-foot"><b>Opt-in</b> - note the explicit <code>KernelTx = true</code>. TLS is OpenSSL in both directions unless you ask for this, and that line is what makes the <code>conn.Write</code> below legal: it puts PLAINTEXT into the slab and the kernel turns it into records. Without it the same call would put <b>cleartext on the wire</b>, which is why every other sample goes through <code>TlsSession.Write</code> - correct in either mode. Receive stays in userspace either way. Compare <label for="tab-tlsossl" class="ex-jump">openssl &middot; raw</label>.</p>
+    <p class="ex-foot"><b>Opt-in</b> - note the explicit <code>KernelTx = true</code>. TLS is OpenSSL in both directions unless you ask for this, and that line is what makes the <code>conn.Write</code> below legal: it puts PLAINTEXT into the slab and the kernel turns it into records. Without it the same call would put <b>cleartext on the wire</b>, which is why every other sample goes through <code>TlsSession.Write</code> - correct in either mode. Receive follows the <code>kernelRx</code> knob: userspace by default, kernel-decrypted when you flip it (experimental). Compare <label for="tab-tlsossl" class="ex-jump">openssl &middot; raw</label>.</p>
   </div>
 
   <div class="pane pane-tlspipe">
@@ -1562,6 +1558,11 @@ int    bodyBytes = 8 * 1024;                    // TLS cost is per-byte, so a 2-
 
 const string certPath = &quot;cert.pem&quot;;   // any PEM pair
 const string keyPath  = &quot;key.pem&quot;;
+
+// Hand INBOUND decryption to the kernel too. Off by default and experimental: about one first
+// connection in twelve fails outright, and a client sending a TLS 1.3 KeyUpdate loses the
+// connection. Transmit stays kernel-side either way - that is the point of this sample.
+bool kernelRx = false;
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
 
@@ -1579,10 +1580,12 @@ var tlsOptions = new TlsOptions
     CertificatePath = certPath,
     KeyPath = keyPath,
 
-    // NOT the default - TLS is OpenSSL both ways unless you ask for this. The kernel encrypts
-    // outbound records while receive stays in OpenSSL, so this is the mixed mode: kTLS TX,
-    // userspace RX. See Playground/Tls/OpenSslPipes for the same server without this line.
+    // NOT the default - TLS is OpenSSL both ways unless you ask for this. As shipped this is the
+    // mixed mode, kernel TX with OpenSSL RX; Playground/Tls/OpenSslPipes is the same server
+    // without this line.
     KernelTx = true,
+
+    KernelRx = kernelRx,
 };
 
 byte[] body = new byte[bodyBytes];
@@ -1668,7 +1671,8 @@ for (int i = 0; i &lt; threads.Length; i++)
 }
 
 Console.WriteLine($&quot;[tls-ktls-pipes] {config.ReactorCount} reactors on :{config.Tcp!.Port}, &quot;
-                + $&quot;{bodyBytes}-byte body, tx={(tlsOptions.KernelTx ? &quot;kernel&quot; : &quot;openssl&quot;)}&quot;);
+                + $&quot;{bodyBytes}-byte body, tx={(tlsOptions.KernelTx ? &quot;kernel&quot; : &quot;openssl&quot;)}, &quot;
+                + $&quot;rx={(kernelRx ? &quot;kernel (experimental)&quot; : &quot;openssl&quot;)}&quot;);
 
 foreach (Thread thread in threads)
 {
@@ -1782,7 +1786,7 @@ for (int i = 0; i &lt; threads.Length; i++)
 
                 if (Answer(conn, tls, carry, response))
                 {
-                    await conn.FlushAsync();   // plaintext: the kernel encrypts on send
+                    await conn.FlushAsync();
                 }
 
                 if (snapshot.IsClosed || tls.Closed) return;
@@ -2195,22 +2199,9 @@ for (int i = 0; i &lt; threads.Length; i++)
             if (tls.NegotiatedAlpn == &quot;h2&quot;)
             {
                 // The decrypt lives in the pipe, so the HTTP/2 code below is identical to the
-                // cleartext sample. Two implementations of the same seam:
-                //
-                //   default   TlsConnectionDualPipe          decrypts into a Pipe it owns, fed by
-                //                                            a pump task
-                //   INPLACE=1 TlsConnectionDualPipeInPlace   decrypts inside the recv buffer and
-                //                                            hands that memory out - no pump, no
-                //                                            Pipe, backpressure is the ring
-                //
-                // Both are handed to the same Nghttp2Connection, which is the point.
-                // The two share only IDuplexPipe, which is not disposable - hence the second
-                // declaration rather than one `await using`.
-                // One type, both worlds. Which halves it uses is decided by what the handshake
-                // achieved, not by anything chosen here - see TlsConnectionDualPipe.
-                var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
-
-                await using var owner = pipe;
+                // cleartext sample. Which halves the pipe uses is decided by what the handshake
+                // achieved, not by anything chosen here.
+                await using var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
 
                 await new Nghttp2Connection(pipe).RunBufferedAsync(_ =&gt; new Nghttp2Response
                 {
@@ -2220,8 +2211,7 @@ for (int i = 0; i &lt; threads.Length; i++)
                 return;
             }
 
-            // Anything else: HTTP/1.1 on the same port, written as plaintext because kTLS is
-            // producing the records.
+            // Anything else: HTTP/1.1 on the same port.
             //
             // The carry is not incidental. TLS hands back RECORDS, not requests, so a request
             // split across two records decrypts twice - and answering on &quot;plaintext arrived&quot;
@@ -2660,8 +2650,7 @@ for (int i = 0; i &lt; threads.Length; i++)
 
         try
         {
-            // The handshake reads and writes through this same connection; after it, the socket
-            // carries kTLS records the kernel en/decrypts.
+            // The handshake reads and writes through this same connection.
             tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
 
             // A request can ride in with the handshake&#x27;s final flight - answer it before parking
@@ -2726,8 +2715,8 @@ foreach (Thread thread in threads)
     thread.Join();
 }
 
-// One request out, one response back. Everything written here is PLAINTEXT: after the handshake
-// kTLS owns transmit, so there is nothing left for us to wrap.
+// One request out, one response back. tls.Write encrypts correctly whichever backend the
+// session ended up with.
 static async ValueTask ProxyAsync(TcpConnection conn, TlsSession tls, HttpClientPool client, string path)
 {
     try
@@ -2856,8 +2845,7 @@ for (int i = 0; i &lt; threads.Length; i++)
 
         try
         {
-            // The handshake reads and writes through this same connection; after it, the socket
-            // carries kTLS records the kernel en/decrypts.
+            // The handshake reads and writes through this same connection.
             tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
 
             // A request can ride in with the handshake&#x27;s final flight - answer it before parking
@@ -2922,8 +2910,8 @@ foreach (Thread thread in threads)
     thread.Join();
 }
 
-// One request out, one response back. Everything written here is PLAINTEXT: after the handshake
-// kTLS owns transmit, so there is nothing left for us to wrap.
+// One request out, one response back. tls.Write encrypts correctly whichever backend the
+// session ended up with.
 static async ValueTask ProxyAsync(TcpConnection conn, TlsSession tls, Http2ClientPool client, string path)
 {
     try
@@ -3041,8 +3029,7 @@ for (int i = 0; i &lt; threads.Length; i++)
 
         try
         {
-            // The handshake reads and writes through this same connection; after it, the socket
-            // carries kTLS records the kernel en/decrypts.
+            // The handshake reads and writes through this same connection.
             tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
 
             // A request can ride in with the handshake&#x27;s final flight - answer it before parking
@@ -3106,8 +3093,8 @@ foreach (Thread thread in threads)
     thread.Join();
 }
 
-// One request out, one response back. Everything written here is PLAINTEXT: after the handshake
-// kTLS owns transmit, so there is nothing left for us to wrap.
+// One request out, one response back. tls.Write encrypts correctly whichever backend the
+// session ended up with.
 static async ValueTask ProxyAsync(TcpConnection conn, TlsSession tls, Http3ClientPool client, string path)
 {
     try
@@ -3842,7 +3829,7 @@ foreach (Thread thread in threads)
 {
     thread.Join();
 }</code></pre>
-    <p class="ex-foot">The same program as <b>h3 &rarr; h1</b> with the pool swapped - which is the whole point of the matrix. Concurrent h3 requests fan into one h2c upstream connection instead of taking a keep-alive connection each.</p>
+    <p class="ex-foot">The same program as <b>h3 &rarr; h1</b> with the pool swapped - which is the whole point of the matrix. Concurrent h3 requests fan into one h2-over-TLS upstream connection instead of taking a keep-alive connection each.</p>
   </div>
   <div class="pane pane-pxh3toh3">
     <div class="pane-head">

--- a/docs/learn/dev-core.html
+++ b/docs/learn/dev-core.html
@@ -411,7 +411,7 @@ internal void Clear()
       <code>Stream</code> (so <code>SslStream</code> and other BCL code can ride a connection - see
       <a href="dev-tls.html">TLS internals</a>), and a duplex pipe pairing.</li>
     </ul>
-<p class="src"><b>ConnectionStream.cs</b> · the Stream write bridge - stage into the slab, then chain onto the connection's flush source (no async state machine, so an SslStream write still resumes inline)</p>
+<p class="src"><b>TcpConnectionStream.cs</b> · the Stream write bridge - stage into the slab, then chain onto the connection's flush source (no async state machine, so an SslStream write still resumes inline)</p>
 <pre><code class="language-csharp">public override ValueTask WriteAsync(ReadOnlyMemory&lt;byte&gt; buffer, CancellationToken cancellationToken = default)
 {
     Span&lt;byte&gt; destination = _conn.GetSpan(1);   // full slab when empty
@@ -434,7 +434,7 @@ internal void Clear()
     _pendingFlush.UnsafeOnCompleted(_onFlushDone);
     return new ValueTask(this, _writeCore.Version);
 }</code></pre>
-<p>One subtlety: a <code>ConnectionStream</code> is <em>both</em> an
+<p>One subtlety: a <code>TcpConnectionStream</code> is <em>both</em> an
 <code>IValueTaskSource&lt;int&gt;</code> (read) and an <code>IValueTaskSource</code> (write) at once -
 the returned value task's static type (<code>ValueTask&lt;int&gt;</code> vs <code>ValueTask</code>)
 routes each <code>GetResult</code>/<code>OnCompleted</code> to the right backing core, so read and

--- a/docs/learn/dev-tls.html
+++ b/docs/learn/dev-tls.html
@@ -41,17 +41,21 @@
 
   <main class="doc">
     <h1>TLS internals</h1>
-    <p class="lead"><code>ioxide.tls</code> terminates TLS 1.3 with a deliberate split: the handshake
-    and inbound records go through OpenSSL in userspace, while outbound bulk is offloaded to the kernel
-    (kTLS) so responses are encrypted inline on the io_uring send - zero-copy, no managed crypto.
-    Requests are small and responses big, so the kernel does the heavy direction.</p>
+    <p class="lead"><code>ioxide.tls</code> terminates TLS with OpenSSL in both directions by
+    default: the handshake runs over memory BIOs, inbound records decrypt in userspace, and
+    responses are encrypted before they reach the write slab. Kernel TLS is a per-direction
+    opt-in (<code>TlsOptions.KernelTx</code> / <code>KernelRx</code>) for the deployments where
+    <code>sendfile</code> or NIC offload pays for its constraints.</p>
 
     <h2>TlsService &middot; <span class="dim">TlsService.cs</span></h2>
     <p>Per-reactor TLS termination, holding one <code>SSL_CTX</code> shared across that reactor's
-    connections (created in <code>OnStart</code>). The context is TLS 1.3 only, one suite
-    (<code>TLS_AES_128_GCM_SHA256</code> - kTLS needs a known key layout), with session tickets
-    disabled (they would advance the server's record sequence after the handshake and break the kTLS
-    handoff, which programs sequence 0).</p>
+    connections (created in <code>OnStart</code>). By default the context keeps OpenSSL's own
+    posture - TLS 1.2 and 1.3, any ciphersuite, session tickets on. Only when
+    <code>KernelTx</code> opts into kTLS is it pinned to TLS 1.3 with
+    <code>TLS_AES_128_GCM_SHA256</code> and tickets disabled: the kernel needs a known key layout,
+    and a ticket would advance the record sequence after the handshake and break the handoff.
+    Asking for <code>KernelRx</code> without <code>KernelTx</code> is refused at
+    <code>Start</code> - RX shares the ULP the TX handoff installs.</p>
 
     <h3>The handshake</h3>
     <p><code>AcceptAsync</code> drives a standard memory-BIO server handshake as an ordinary reactor
@@ -80,14 +84,16 @@
 }</code></pre>
 
     <h3>Per-session secret via ex_data (no global map)</h3>
-    <p>kTLS keys are derived from the TLS 1.3 server traffic secret, which OpenSSL surfaces through a
-    keylog callback. The callback is a static function pointer with no instance, so to find the right
-    session it reads a <code>GCHandle</code> to the <code>TlsSession</code> stored on the
-    <code>SSL</code> via <code>SSL_set_ex_data</code> / <code>SSL_get_ex_data</code> (the index
-    allocated once with <code>CRYPTO_get_ex_new_index</code>). The callback parses
-    <code>SERVER_TRAFFIC_SECRET_0</code> and stores it on that session directly - no process-global,
-    recycled-pointer-keyed map, so two reactors that get the same recycled <code>SSL</code> address
-    can't collide. The handle is freed on <code>TlsSession.Dispose</code>.</p>
+    <p>kTLS keys are derived from the TLS 1.3 traffic secrets (server for TX, client for RX), which
+    OpenSSL surfaces through a keylog callback. The callback is a static function pointer with no
+    instance, so to find the right session it reads a <code>GCHandle</code> to the
+    <code>TlsSession</code> stored on the <code>SSL</code> via <code>SSL_set_ex_data</code> /
+    <code>SSL_get_ex_data</code> (the index allocated once with
+    <code>CRYPTO_get_ex_new_index</code>), and stores the secret on that session directly - no
+    process-global, recycled-pointer-keyed map, so two reactors that get the same recycled
+    <code>SSL</code> address can't collide. On every path that does not program the kernel the
+    secrets are zeroed at the handoff decision, and again on <code>TlsSession.Dispose</code>,
+    which also frees the handle.</p>
 <p class="src"><b>TlsService.cs</b> · one ex_data index, allocated once; each SSL* carries a GCHandle to its session</p>
 <pre><code class="language-csharp">private static readonly int SslSessionIndex =
     OpenSsl.CRYPTO_get_ex_new_index(OpenSsl.CRYPTO_EX_INDEX_SSL, 0, 0, 0, 0, 0);
@@ -101,7 +107,12 @@ session.AttachHandle(handle);</code></pre>
 private static void KeylogCallback(nint ssl, nint line)
 {
     string? text = Marshal.PtrToStringUTF8(line);
-    if (text == null || !text.StartsWith("SERVER_TRAFFIC_SECRET_0 ", StringComparison.Ordinal))
+    if (text == null)
+        return;
+
+    bool server = text.StartsWith("SERVER_TRAFFIC_SECRET_0 ", StringComparison.Ordinal);
+    bool client = text.StartsWith("CLIENT_TRAFFIC_SECRET_0 ", StringComparison.Ordinal);
+    if (!server &amp;&amp; !client)
         return;
 
     nint data = OpenSsl.SSL_get_ex_data(ssl, SslSessionIndex);
@@ -121,30 +132,36 @@ private static void KeylogCallback(nint ssl, nint line)
     hard-coded. The callback finds it in the client's offer list and points <code>*out</code> into the
     client buffer.</p>
 
-    <h3>The kTLS handoff</h3>
-    <p>Once the handshake is done and all server flights are flushed, <code>Ktls.EnableTx</code>
-    programs the TX keys into the socket and <code>conn.SendOpFlags = 0</code> clears
-    <code>MSG_WAITALL</code> (kTLS rejects it; the reactor's partial-send loop preserves correctness).
-    From the next write on, the handler writes <em>plaintext</em> through <code>conn.Write</code> /
-    <code>FlushAsync</code> and the kernel produces the records on the io_uring send path. Faults are
-    surfaced (a missing kernel <code>tls</code> module shows up as a logged handshake failure rather
-    than a silent drop).</p>
+    <h3>The kTLS handoff (opt-in)</h3>
+    <p>With <code>KernelTx</code> on, once the handshake is done and all server flights are
+    flushed, <code>Ktls.EnableTx</code> programs the TX keys into the socket and
+    <code>conn.SendOpFlags = 0</code> clears <code>MSG_WAITALL</code> (kTLS rejects it; the
+    reactor's partial-send loop preserves correctness). From the next write on the kernel produces
+    the records - which is what makes the kTLS samples' bare <code>conn.Write</code> legal there
+    and nowhere else. <code>TlsSession.Write</code> is correct in either mode, which is why every
+    other sample goes through it. With <code>KernelRx</code> also on, the RX keys are programmed
+    at the same moment, with the record sequence advanced past whatever the handshake already
+    consumed - and a connection whose handshake left a partial record behind silently keeps the
+    userspace reader, because those bytes are gone for the kernel.</p>
 <p class="src"><b>TlsService.cs</b> · the handoff - program TX keys, then drop MSG_WAITALL</p>
-<pre><code class="language-csharp">Ktls.EnableTx(conn.ClientFd, secret);
-conn.SendOpFlags = 0;                    // clear MSG_WAITALL - kTLS rejects it (EOPNOTSUPP)
-session.MarkTxEnabled(conn.ClientFd);
-// from here the handler writes plaintext; the kernel makes the records on the io_uring send</code></pre>
+<pre><code class="language-csharp">if (_kernelTx)
+{
+    Ktls.EnableTx(conn.ClientFd, secret);
+    conn.SendOpFlags = 0;                // clear MSG_WAITALL - kTLS rejects it (EOPNOTSUPP)
+    session.MarkTxEnabled(conn.ClientFd);
+}</code></pre>
 
     <h2>TlsSession &middot; <span class="dim">TlsSession.cs</span></h2>
-    <p>The receive half after the handoff (one per connection, reactor-thread only). Inbound bytes are
-    still TLS records, decrypted in userspace: <code>Decrypt(ciphertext, length)</code> feeds the read
-    BIO and drains <code>SSL_read</code> into a reusable plaintext buffer, returning the span (valid
-    until the next call). The buffer is bounded per-decrypt (a defensive cap; in practice one decrypt
-    processes one recv-buffer-sized slice and decryption never expands). <code>SSL_ERROR_ZERO_RETURN</code>
-    sets <code>Closed</code> (the peer's close_notify). On a clean server-side teardown,
-    <code>Dispose</code> sends a close_notify alert over kTLS (best-effort) so the peer can tell
-    end-of-stream from a truncation, then <code>SSL_free</code>s (which frees both BIOs) and releases
-    the ex_data handle.</p>
+    <p>The per-connection TLS state after the handshake (reactor-thread only).
+    <code>Decrypt(ciphertext, length)</code> feeds the read BIO and drains <code>SSL_read</code>
+    into a reusable plaintext buffer, returning the span (valid until the next call); under kTLS RX
+    it is a pass-through, since recv already delivered plaintext. <code>Write</code> is the
+    mode-aware outbound: plaintext straight to the slab under kTLS TX, encrypted through the write
+    BIO otherwise. <code>SSL_ERROR_ZERO_RETURN</code> sets <code>Closed</code> (the peer's
+    close_notify). On a clean server-side teardown, <code>Dispose</code> sends close_notify in
+    whichever mode applies - a kTLS control send, or <code>SSL_shutdown</code>'s record delivered
+    with a best-effort raw send - zeroes any remaining secrets, then <code>SSL_free</code>s (which
+    frees both BIOs) and releases the ex_data handle.</p>
 
     <h2>Ktls &middot; <span class="dim">Ktls.cs</span></h2>
     <p>The kernel-TLS transmit offload. <code>EnableTx</code> derives the record key (16B) and IV (12B)
@@ -154,6 +171,8 @@ session.MarkTxEnabled(conn.ClientFd);
     <code>setsockopt(SOL_TLS, TLS_TX, &amp;cryptoInfo)</code> installs the keys. All key material -
     the derived key/iv, the crypto-info struct, and the captured secret - is zeroed in a
     <code>finally</code> with <code>CryptographicOperations.ZeroMemory</code> once programmed.
+    <code>EnableRx</code> is the same dance for the receive keys, taking the record sequence the
+    handshake already consumed (the sequence is part of the AEAD nonce, so it cannot be guessed).
     <code>SendCloseNotify</code> sends a <code>{warning, close_notify}</code> alert as a control
     message (<code>sendmsg</code> with a <code>SOL_TLS / TLS_SET_RECORD_TYPE = alert</code> cmsg),
     best-effort.</p>
@@ -195,17 +214,21 @@ session.MarkTxEnabled(conn.ClientFd);
     <p>The minimal OpenSSL 3 P/Invoke surface (via <code>[LibraryImport]</code> source-gen): context
     setup (<code>SSL_CTX_new</code>, protocol/ciphersuite/ticket controls, cert/key file loads, the
     keylog and ALPN callback setters), the per-connection objects (<code>SSL_new</code>/<code>_free</code>,
-    <code>SSL_set_bio</code>/<code>_accept_state</code>/<code>_accept</code>/<code>_read</code>/<code>_get_error</code>),
+    <code>SSL_set_bio</code>/<code>_accept_state</code>/<code>_accept</code>/<code>_read</code>/<code>_write</code>/<code>_shutdown</code>/<code>_get_error</code>),
     the ex_data accessors, and the memory BIOs (<code>BIO_new</code>/<code>_s_mem</code>/<code>_read</code>/<code>_write</code>/<code>_ctrl_pending</code>).
     <code>LastError</code> formats the first queued error and drains the rest so the next report isn't
     stale.</p>
 
     <h2>TlsOptions &middot; <span class="dim">TlsOptions.cs</span></h2>
-    <p>The PEM certificate-chain path, the private-key path, and the ALPN protocol to advertise.</p>
+    <p>The PEM certificate-chain path, the private-key path, the ALPN protocols to advertise
+    (most preferred first), and the two kernel-offload opt-ins: <code>KernelTx</code> (kTLS
+    transmit - constrains the context to TLS 1.3, one suite, no tickets) and <code>KernelRx</code>
+    (experimental kernel receive; requires <code>KernelTx</code>).</p>
 
-    <p class="lead" style="margin-top:2rem">An alternative, fully-managed path exists with no kTLS or
-    native dependency: a BCL <code>SslStream</code> over <code>ConnectionStream</code> (everything
-    encrypted in userspace, ~0.65x kTLS throughput) - see the <code>tls-sslstream</code> example.</p>
+    <p class="lead" style="margin-top:2rem">An alternative, fully-managed path exists with no
+    native dependency: a BCL <code>SslStream</code> over <code>TcpConnectionStream</code> (~0.65x
+    the ring-native path, but the only one that does client certificates) - see the
+    <code>tls-sslstream</code> example.</p>
 
     <div class="next"><a href="dev-file.html">ioxide.file internals →</a></div>
   </main>

--- a/docs/learn/multiport.html
+++ b/docs/learn/multiport.html
@@ -68,10 +68,12 @@
     on the connection before your handler runs:</p>
 <pre><code class="language-csharp">reactor.TcpHandle = async (r, conn) =&gt;
 {
+    TlsSession? tls = null;
     if (conn.ListenerPort == 8443)
-        await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);   // terminate TLS on this door
+        tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);   // terminate TLS on this door
 
-    // from here both ports look identical - plaintext in, plaintext out
+    // one loop serves both doors: with a session, reads decrypt through tls.Decrypt and
+    // responses go out through tls.Write; without one the same calls are conn reads and writes
 };</code></pre>
     <p>The engine never learns what a port <em>means</em>. <code>ListenerPort</code> is just a
     number you branch on - terminate TLS on one, serve metrics on another, accept the PROXY

--- a/docs/learn/overview.html
+++ b/docs/learn/overview.html
@@ -125,8 +125,8 @@ foreach (var t in threads) t.Join();</code></pre>
       knowledge, or h2 over TLS chosen by <a href="tls.html">ALPN</a>.</li>
       <li><code>ioxide.nghttp3</code> / <code>ioxide.http3</code> - HTTP/3, over
       <a href="quic-h3.html">QUIC</a> from <code>ioxide.ngtcp2</code>.</li>
-      <li><a href="tls.html">TLS</a> - kernel TLS, plus a portable SslStream path. In the core
-      package; no reference to add.</li>
+      <li><a href="tls.html">TLS</a> - OpenSSL on the ring, kernel TLS as an opt-in, plus a
+      portable SslStream path. In the core package; no reference to add.</li>
     </ul>
 
     <h2>Where to go next</h2>

--- a/docs/learn/postgres.html
+++ b/docs/learn/postgres.html
@@ -66,14 +66,17 @@ var result = await pool.QueryAsync("SELECT 42");
 
 // result.Value: "42" · result.Rows: 1 · result.CommandTag: "SELECT 1"</code></pre>
 
-    <p>One <code>PgConnection</code> is one conversation - one query in flight. The pool is the
-    concurrency: <code>QueryAsync</code> rents a connection, runs the query, returns it; when all
-    are busy, requests queue and resume inline as connections free up. For multi-statement work
-    (transactions), <code>RentAsync</code>/<code>Return</code> directly.</p>
+    <p>One <code>PgConnection</code> is one ordered conversation, and commands <em>pipeline</em>
+    onto it - many in flight at once, answered in order. <code>QueryAsync</code> picks the next
+    connection round-robin; the pool is parallelism, not exclusive checkout, and there is no
+    rent/return surface. That also means a transaction must not be split across
+    <code>QueryAsync</code> calls - other handlers' queries interleave on the same connection.
+    Keep it in one SQL string (<code>BEGIN; …; COMMIT</code>), which travels as one simple-query
+    message and runs as one unit.</p>
 
     <p>Warmup is concurrent and non-blocking: <code>Start</code> fires <code>PoolSize</code>
-    ring-native connects; a request that arrives first simply waits in the rent queue until the
-    first connection lands. Total server-side connections = <code>PoolSize × ReactorCount</code>.</p>
+    ring-native connects; a request that arrives first simply queues until the first connection
+    lands. Total server-side connections = <code>PoolSize × ReactorCount</code>.</p>
 
     <h2>Failure semantics</h2>
     <table>

--- a/docs/learn/quic-h3.html
+++ b/docs/learn/quic-h3.html
@@ -129,7 +129,7 @@
 
 var config = new ServerConfig
 {
-    // Tcp defaults still bind :8080 - there is no TCP opt-out yet.
+    Tcp = null,                        // QUIC-only: no TCP listener at all
     Quic = new QuicOptions
     {
         Port = 8443,                   // UDP port, bound automatically on every reactor

--- a/docs/learn/tls.html
+++ b/docs/learn/tls.html
@@ -45,7 +45,7 @@
     them. <b><code>ioxide.tls</code></b> is the native path: the handshake runs over the ring,
     OpenSSL does the record crypto in both directions by default, and kernel TLS transmit offload
     is one flag away for the deployments that can use it. <b>SslStream</b> over
-    <code>ConnectionStream</code> is the portable path: fully managed, full-featured, and a bit
+    <code>TcpConnectionStream</code> is the portable path: fully managed, full-featured, and a bit
     slower. Both terminate on a <a href="multiport.html">dedicated port</a> and need nothing from
     the core engine beyond what is already public - and both ship <b>inside the <code>ioxide</code>
     package</b>. The namespace is still <code>ioxide.tls</code>, but there is no separate
@@ -55,7 +55,7 @@
     hand-off work is in <a href="dev-tls.html">ioxide.tls internals</a>.</div>
 
     <table>
-      <tr><th></th><th><code>ioxide.tls</code></th><th>SslStream + <code>ConnectionStream</code></th></tr>
+      <tr><th></th><th><code>ioxide.tls</code></th><th>SslStream + <code>TcpConnectionStream</code></th></tr>
       <tr><td>crypto</td><td>OpenSSL; kernel TX offload opt-in</td><td>fully managed</td></tr>
       <tr><td>copies</td><td>one staged copy; zero-copy send under kTLS TX</td><td>buffered both ways</td></tr>
       <tr><td>TLS versions</td><td>1.2 and 1.3 (1.3 only under kTLS)</td><td>1.2 and 1.3</td></tr>
@@ -193,7 +193,7 @@ if (tls.NegotiatedAlpn == "h2")
     return;
 }
 
-// http/1.1 on the same port, written as plaintext - kTLS owns transmit from here.
+// http/1.1 on the same port - tls.Write encrypts correctly in either backend.
 </code></pre>
     <p><code>TlsConnectionDualPipe</code> is what makes the branch cheap. It is an
     <code>IDuplexPipe</code> whose reader decrypts on the way in and whose writer delegates to the
@@ -277,20 +277,22 @@ if (tls.NegotiatedAlpn == "h2")
     <p>The remainder of this section is about kTLS specifically.
     The cost is dominated by the <em>inherent</em> work of encrypting each response - which the
     kernel does, on the existing send path, with no userspace copy - plus the small fixed cost of
-    decrypting each request. There is no managed-crypto tax and no extra copy on the send side,
-    which is exactly why it beats a userspace TLS stack: those copy plaintext into a TLS library
-    before encrypting; kTLS skips that copy entirely. The remaining gap to plaintext is the AES-GCM
-    work itself, which no TLS implementation avoids.</p>
+    decrypting each request. Skipping the userspace copy does <em>not</em> make it faster than
+    OpenSSL on the ring: the table above has OpenSSL level or ahead at every size, because the
+    crypto dominates and the kernel path gives up batching the userspace one keeps. What the
+    kernel path uniquely enables is <code>sendfile</code> and NIC offload - which loopback numbers
+    cannot show. The remaining gap to plaintext is the AES-GCM work itself, which no TLS
+    implementation avoids.</p>
 
-    <h2>SslStream over ConnectionStream</h2>
+    <h2>SslStream over TcpConnectionStream</h2>
     <p>When you want TLS without the kernel module, or you need TLS 1.2 clients, client
     certificates, or session resumption, use the BCL's <code>SslStream</code> over a
-    <code>ConnectionStream</code>. <code>ConnectionStream</code> is a general-purpose
+    <code>TcpConnectionStream</code>. <code>TcpConnectionStream</code> is a general-purpose
     <code>Stream</code> over a connection (in the core engine), so this path needs nothing from
     <code>ioxide.tls</code> at all:</p>
 <pre><code class="language-csharp">reactor.TcpHandle = async (r, conn) =&gt;
 {
-    var ssl = new SslStream(new ConnectionStream(conn), leaveInnerStreamOpen: false);
+    var ssl = new SslStream(new TcpConnectionStream(conn), leaveInnerStreamOpen: false);
     await ssl.AuthenticateAsServerAsync(new SslServerAuthenticationOptions
     {
         ServerCertificate    = cert,
@@ -308,7 +310,7 @@ if (tls.NegotiatedAlpn == "h2")
     ssl.Dispose();
     conn.DecRef();
 };</code></pre>
-    <p><b>It stays on the reactor.</b> <code>ConnectionStream</code> is built on the same
+    <p><b>It stays on the reactor.</b> <code>TcpConnectionStream</code> is built on the same
     <code>RunContinuationsAsynchronously = false</code> value-task sources as the rest of the
     engine, and <code>SslStream</code> uses <code>ConfigureAwait(false)</code> and does its crypto
     inline - so for request/response traffic the whole thing resumes inline on the reactor thread,
@@ -319,13 +321,14 @@ if (tls.NegotiatedAlpn == "h2")
     <p><b>The trade-off is throughput.</b> <code>SslStream</code> buffers and copies on both sides
     and does all crypto in managed code, so it runs around 0.65&times; the throughput of kTLS on
     the same workload. In return you get TLS 1.2 and 1.3, client certificates, resumption, and zero
-    native dependencies - portable to any OS. The <code>ConnectionStream</code> bridge itself is
+    native dependencies - portable to any OS. The <code>TcpConnectionStream</code> bridge itself is
     allocation-free and is not the bottleneck; the cost is <code>SslStream</code>'s own.</p>
 
     <h2>Which to use</h2>
-    <p>Three options, not two - and the middle one is new. It used to be that wanting TLS 1.2,
-    resumption or client certificates meant leaving the ring for <code>SslStream</code>. It no
-    longer does: <code>KernelTx = false</code> gives those on the ring-native path.</p>
+    <p>Three options, not two - and the middle one is new. It used to be that wanting TLS 1.2 or
+    resumption meant leaving the ring for <code>SslStream</code>. It no longer does: the default
+    gives both on the ring-native path. Client certificates remain the exception - the ring-native
+    path does not do mTLS, so that still means <code>SslStream</code>.</p>
     <ul>
       <li><b>kTLS</b> (<code>KernelTx = true</code>) &rarr; you are on Linux 6+ with the
       <code>tls</code> module, TLS 1.3 and ALPN are enough, and you want <code>sendfile</code> or a
@@ -335,7 +338,7 @@ if (tls.NegotiatedAlpn == "h2")
       that lacks one; TLS 1.2 available, any ciphersuite, resumption back, and no
       handshake-alignment constraint. Costs nothing measurable here - see the table above. Sample:
       <a href="https://github.com/MDA2AV/ioxide/tree/main/Playground/Tls/OpenSsl">Tls/OpenSsl</a>.</li>
-      <li><b>SslStream</b> over <code>ConnectionStream</code> &rarr; now only for what OpenSSL itself
+      <li><b>SslStream</b> over <code>TcpConnectionStream</code> &rarr; now only for what OpenSSL itself
       cannot give you, or when you want the BCL's stack specifically. It is the slowest of the
       three, because every byte is encrypted in userspace <em>and</em> copied through a
       <code>Stream</code>.</li>

--- a/scripts/gen-docs-panes.py
+++ b/scripts/gen-docs-panes.py
@@ -19,8 +19,9 @@ PANES = {
         "directions unless you ask for this, and that line is what makes the <code>conn.Write</code> "
         "below legal: it puts PLAINTEXT into the slab and the kernel turns it into records. Without "
         "it the same call would put <b>cleartext on the wire</b>, which is why every other sample "
-        "goes through <code>TlsSession.Write</code> - correct in either mode. Receive stays in "
-        "userspace either way. Compare "
+        "goes through <code>TlsSession.Write</code> - correct in either mode. Receive follows the "
+        "<code>kernelRx</code> knob: userspace by default, kernel-decrypted when you flip it "
+        "(experimental). Compare "
         "<label for=\"tab-tlsossl\" class=\"ex-jump\">openssl &middot; raw</label>."),
     "tlsossl": (
         "Tls/OpenSsl", "OpenSSL &middot; raw ring", "ioxide",
@@ -57,12 +58,11 @@ PANES = {
         "Tls/SslStream", "TLS &middot; SslStream", "ioxide",
         ["curl -k https://127.0.0.1:8443/"],
         "The third TLS backend, and the portable one: the BCL's <code>SslStream</code> over "
-        "<code>TcpConnectionStream</code>. Fully managed, full-featured - client certificates, "
-        "resumption, TLS 1.2 - and the slowest of the three, because every byte is encrypted in "
-        "userspace <em>and</em> copied through a <code>Stream</code>. Reach for it when you need "
-        "something OpenSSL itself cannot give you; otherwise "
-        "<label for=\"tab-tlsossl\" class=\"ex-jump\">openssl &middot; raw</label> gets you the same "
-        "features on the ring."),
+        "<code>TcpConnectionStream</code>. Fully managed, full-featured, and the slowest of the "
+        "three, because the bytes are copied through a <code>Stream</code> both ways. Reach for it "
+        "for <b>client certificates</b> - the ring-native path does not do mTLS - or anything else "
+        "OpenSSL-on-the-ring does not expose; for TLS 1.2 and resumption the default already has "
+        "you covered: <label for=\"tab-tlsossl\" class=\"ex-jump\">openssl &middot; raw</label>."),
     "big": (
         "Tcp/Big", "TCP &middot; large responses", "ioxide",
         ["curl -s http://127.0.0.1:8080/ | wc -c"],
@@ -102,8 +102,8 @@ PANES = {
         "HTTP/2 over the BCL's <code>SslStream</code>, and the point is the ten-line "
         "<code>Stream</code>-to-<code>IDuplexPipe</code> adapter at the bottom. "
         "<code>Nghttp2Connection</code> takes a pipe, so the same HTTP/2 code runs over the ring "
-        "directly, over kTLS, or over <code>SslStream</code> - the transport is a constructor "
-        "argument, not a branch inside the protocol."),
+        "directly, over ioxide's TLS, or over <code>SslStream</code> - the transport is a "
+        "constructor argument, not a branch inside the protocol."),
     "h3buf": (
         "Http3/Buffered", "HTTP/3 &middot; buffered dispatch", "ioxide + ioxide.ngtcp2 + ioxide.nghttp3",
         ["curl --http3-only -k https://127.0.0.1:8443/"],

--- a/scripts/gen-docs-proxy-panes.py
+++ b/scripts/gen-docs-proxy-panes.py
@@ -84,8 +84,8 @@ NOTES = {
     "H3ToH1": "QUIC-only frontend: <code>Tcp = null</code>, so every TCP socket this process owns is "
               "outbound. The h3 server and the h1 client share the reactor and nothing else.",
     "H3ToH2": "The same program as <b>h3 &rarr; h1</b> with the pool swapped - which is the whole point "
-              "of the matrix. Concurrent h3 requests fan into one h2c upstream connection instead of "
-              "taking a keep-alive connection each.",
+              "of the matrix. Concurrent h3 requests fan into one h2-over-TLS upstream connection "
+              "instead of taking a keep-alive connection each.",
     "H3ToH3": "QUIC on both sides, and the upstream connections share the serving socket: one fd, both "
               "directions. Nothing else in this set collapses that far.",
 }


### PR DESCRIPTION
A max-effort staleness audit of the Playground and the site (87 confirmed findings, 0 refuted, folded to 15 root causes), fixed in one pass — plus the new standing rule applied along the way: sample comments are for users (knob meaning, caveats), not internals.

**The dangerous tier — examples that taught the cleartext trap.** Five proxy samples, the TLS learn page's ALPN example, multiport's shared-loop example, the Http2/Tls comments and the whole dev-tls internals page still said kTLS owns transmit and handlers write plaintext. Post-#156 that puts cleartext on the wire. Everything now routes through `TlsSession.Write` and says so; dev-tls.html describes the shipped architecture (OpenSSL both ways, per-direction opt-in, gated constraints, close_notify both modes, both secrets captured and zeroed).

**The broken-workflow tier.** The landing pipes pane didn't compile (undeclared `wrote`) and answered once per batch — now compiles and answers per request. Docs named `ConnectionStream` (shipped: `TcpConnectionStream`), samples said `Needs: ioxide.tls` (folded into core), postgres.html documented a `RentAsync`/`Return` API that never shipped instead of the pipelined reality, the Dockerfile/README advertised pre-reorg sample paths, H3ToH2's header demonstrated an h2c origin its TLS-only client can never dial, and quic-h3.html denied the `Tcp = null` opt-out it ships.

**Truth fixes.** tls.html no longer claims kTLS beats userspace (its own table disproves it) or ring-native client certificates (SslStream is the mTLS path); the kTLS pane note no longer denies the `kernelRx` knob printed beside it.

**New:** `Tls/KtlsPipes` gains the same tri-state `kernelRx` knob as the raw sample (verified serving with `rx=kernel`), and both kTLS banners report the rx mode.

Verified: solution builds clean, both generators re-run (15 panes rewrote), `Http2/Tls` serves 200 on both ALPN branches, `KtlsPipes` serves six-for-six with kernel RX.