### PR TITLE
docs(tls): honest mode taxonomy (hybrid vs full kTLS); retire the List<byte> carry

### DIFF
--- a/Playground/Http2/Tls/Program.cs
+++ b/Playground/Http2/Tls/Program.cs
@@ -1,5 +1,4 @@
 using System.IO.Pipelines;
-using System.Runtime.InteropServices;
 using System.Text;
 using ioxide;
 using ioxide.nghttp2;
@@ -121,21 +120,21 @@ for (int i = 0; i < threads.Length; i++)
             // The carry is not incidental. TLS hands back RECORDS, not requests, so a request
             // split across two records decrypts twice - and answering on "plaintext arrived"
             // would answer twice to one request. Framing is ours; ioxide does not parse HTTP.
-            var carry = new List<byte>();
+            var carry = new Carry();
 
             // The client's first request usually rides in with its Finished flight, so the
             // handshake already decrypted it and it is sitting in the session, not in any recv
             // buffer. Miss this and that request is dropped and the loop parks on bytes that
             // already arrived - which is exactly what happened here before.
-            carry.AddRange(tls.DrainPlaintext());
+            carry.Append(tls.DrainPlaintext());
 
             while (true)
             {
                 bool wrote = false;
                 int end;
-                while ((end = CollectionsMarshal.AsSpan(carry).IndexOf("\r\n\r\n"u8)) >= 0)
+                while ((end = carry.Span.IndexOf("\r\n\r\n"u8)) >= 0)
                 {
-                    carry.RemoveRange(0, end + 4);
+                    carry.Consume(end + 4);
                     // Correct whichever backend the session ended up with.
                     tls.Write(conn, http11Response);
                     wrote = true;
@@ -154,7 +153,7 @@ for (int i = 0; i < threads.Length; i++)
                     {
                         if (item.HasBuffer)
                         {
-                            carry.AddRange(tls.Decrypt(item.Ptr, item.Len));
+                            carry.Append(tls.Decrypt(item.Ptr, item.Len));
                             conn.ReturnBuffer(in item);
                         }
                     }
@@ -189,3 +188,29 @@ foreach (Thread thread in threads)
     thread.Join();
 }
 
+// Decrypted-but-unframed bytes: append at the end, consume from the front. A List<byte> pressed
+// into this job needs CollectionsMarshal to be searched and RemoveRange to be consumed; a plain
+// array does both directly.
+sealed class Carry
+{
+    private byte[] _buf = new byte[8 * 1024];
+    private int _len;
+
+    public ReadOnlySpan<byte> Span => _buf.AsSpan(0, _len);
+
+    public void Append(ReadOnlySpan<byte> bytes)
+    {
+        if (_buf.Length - _len < bytes.Length)
+        {
+            Array.Resize(ref _buf, Math.Max(_buf.Length * 2, _len + bytes.Length));
+        }
+        bytes.CopyTo(_buf.AsSpan(_len));
+        _len += bytes.Length;
+    }
+
+    public void Consume(int count)
+    {
+        _buf.AsSpan(count, _len - count).CopyTo(_buf);
+        _len -= count;
+    }
+}

--- a/Playground/README.md
+++ b/Playground/README.md
@@ -17,9 +17,9 @@ Run any of them with `dotnet run -c Release --project Playground/<Group>/<Name>`
 | [`Tcp.TaskRun`](Tcp/TaskRun/Program.cs) | 84 | Awaiting ordinary thread-pool work and still resuming on the reactor. | `ioxide` |
 | [`Tcp.Incremental`](Tcp/Incremental/Program.cs) | 95 | `Tcp.Raw` with the per-connection buffer-ring mode - one config block is the whole diff. Kernel 6.12+. | `ioxide` |
 | [`Tcp.Big`](Tcp/Big/Program.cs) | 101 | The write path under a 100 KB body: `SEND_ZC`, slab overflow (`grow` vs `seg`), checksum-able output. | `ioxide` |
-| [`Tls.Ktls`](Tls/Ktls/Program.cs) | 172 | The **kernel TLS** opt-in: after the handshake the kernel owns transmit and the handler writes plaintext. `modprobe tls`. | `ioxide` |
+| [`Tls.Ktls`](Tls/Ktls/Program.cs) | 172 | The **kernel TLS** opt-in, shipped as the hybrid: kernel TX, OpenSSL RX (`kernelRx` completes full kTLS, experimental). The handler writes plaintext. `modprobe tls`. | `ioxide` |
 | [`Tls.OpenSsl`](Tls/OpenSsl/Program.cs) | 194 | **The default**: OpenSSL both ways - no kernel module, and TLS 1.2 / any suite / resumption. | `ioxide` |
-| [`Tls.KtlsPipes`](Tls/KtlsPipes/Program.cs) | 163 | kTLS served through an `IDuplexPipe`. | `ioxide` |
+| [`Tls.KtlsPipes`](Tls/KtlsPipes/Program.cs) | 163 | The hybrid served through an `IDuplexPipe`. | `ioxide` |
 | [`Tls.OpenSslPipes`](Tls/OpenSslPipes/Program.cs) | 164 | The same, with OpenSSL. Its serve loop is byte-identical to `Tls.KtlsPipes` - over a pipe the backend is invisible. | `ioxide` |
 | [`Tls.SslStream`](Tls/SslStream/Program.cs) | 100 | The BCL `SslStream` over `TcpConnectionStream` - portable userspace TLS, the comparison point. | `ioxide` |
 | [`Http2.Nghttp2`](Http2/Nghttp2/Program.cs) | 66 | HTTP/2 (h2c, prior knowledge) with nghttp2 doing framing, HPACK and flow control. | `ioxide.nghttp2` |

--- a/Playground/Tls/Ktls/Program.cs
+++ b/Playground/Tls/Ktls/Program.cs
@@ -1,14 +1,14 @@
 using System.Text;
-using System.Runtime.InteropServices;
 using ioxide;
 using ioxide.tls;
 using ioxide.utils;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  tls-ktls - TLS via ioxide.tls: the OpenSSL handshake runs over the ring, then transmit is
+//  tls-ktls - the kernel TLS opt-in: the OpenSSL handshake runs over the ring, then transmit is
 //  handed to KERNEL TLS - the handler writes plaintext and the kernel produces the records, so
-//  the send path stays exactly the raw send path.
+//  the send path stays exactly the raw send path. As shipped this is the HYBRID - kernel TX,
+//  OpenSSL RX. Full kTLS is both directions: kernelRx = true completes it (experimental).
 //
 //      sudo modprobe tls                             # needs the Linux 'tls' module + OpenSSL 3
 //      dotnet run -c Release --project Playground/Tls/Ktls
@@ -96,7 +96,7 @@ for (int i = 0; i < threads.Length; i++)
         // request across two records and each decrypts on its own, so answering per decrypt
         // answers twice. The carry is what turns "some plaintext arrived" into "a request
         // arrived", exactly as the plaintext samples do - ioxide does not parse HTTP for you.
-        var carry = new List<byte>();
+        var carry = new Carry();
 
         try
         {
@@ -106,7 +106,7 @@ for (int i = 0; i < threads.Length; i++)
 
             // A request can ride in with the handshake's final flight - answer it before parking
             // in ReadAsync, or the client waits on a response we never send.
-            carry.AddRange(tls.DrainPlaintext());
+            carry.Append(tls.DrainPlaintext());
             if (Answer(conn, carry, response))
             {
                 await conn.FlushAsync();
@@ -163,19 +163,19 @@ foreach (Thread thread in threads)
 
 // Decrypt takes a raw pointer (the buffer belongs to the ring); the pointer work stays out of the
 // async handler, which cannot contain unsafe code.
-static unsafe void Decrypt(TlsSession tls, in SpscRecvRing.Item item, List<byte> carry)
-    => carry.AddRange(tls.Decrypt(item.Ptr, item.Len));
+static unsafe void Decrypt(TlsSession tls, in SpscRecvRing.Item item, Carry carry)
+    => carry.Append(tls.Decrypt(item.Ptr, item.Len));
 
 // One response per COMPLETE request in the carry, and none for a partial one. Returns whether
 // anything was written, so the caller flushes once for the batch rather than once per request.
-static bool Answer(TcpConnection conn, List<byte> carry, ReadOnlyMemory<byte> response)
+static bool Answer(TcpConnection conn, Carry carry, ReadOnlyMemory<byte> response)
 {
     bool wrote = false;
     int end;
 
-    while ((end = CollectionsMarshal.AsSpan(carry).IndexOf("\r\n\r\n"u8)) >= 0)
+    while ((end = carry.Span.IndexOf("\r\n\r\n"u8)) >= 0)
     {
-        carry.RemoveRange(0, end + 4);
+        carry.Consume(end + 4);
 
         // PLAINTEXT into the slab - safe only because KernelTx = true above. TlsSession.Write
         // is the call that is correct either way, and is what every other sample uses; this one
@@ -186,4 +186,31 @@ static bool Answer(TcpConnection conn, List<byte> carry, ReadOnlyMemory<byte> re
     }
 
     return wrote;
+}
+
+// Decrypted-but-unframed bytes: append at the end, consume from the front. A List<byte> pressed
+// into this job needs CollectionsMarshal to be searched and RemoveRange to be consumed; a plain
+// array does both directly.
+sealed class Carry
+{
+    private byte[] _buf = new byte[8 * 1024];
+    private int _len;
+
+    public ReadOnlySpan<byte> Span => _buf.AsSpan(0, _len);
+
+    public void Append(ReadOnlySpan<byte> bytes)
+    {
+        if (_buf.Length - _len < bytes.Length)
+        {
+            Array.Resize(ref _buf, Math.Max(_buf.Length * 2, _len + bytes.Length));
+        }
+        bytes.CopyTo(_buf.AsSpan(_len));
+        _len += bytes.Length;
+    }
+
+    public void Consume(int count)
+    {
+        _buf.AsSpan(count, _len - count).CopyTo(_buf);
+        _len -= count;
+    }
 }

--- a/Playground/Tls/KtlsPipes/Program.cs
+++ b/Playground/Tls/KtlsPipes/Program.cs
@@ -6,7 +6,8 @@ using ioxide.tls;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  tls-ktls-pipes - TLS served through an IDuplexPipe, with kernel TLS doing the crypto.
+//  tls-ktls-pipes - TLS served through an IDuplexPipe, with the kernel doing the transmit
+//  crypto - the hybrid, same as Tls/Ktls; kernelRx = true is full kTLS (experimental).
 //
 //      sudo modprobe tls        # kTLS needs the module
 //      curl -ks https://127.0.0.1:8443/ | head -c 40

--- a/Playground/Tls/OpenSsl/Program.cs
+++ b/Playground/Tls/OpenSsl/Program.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Runtime.InteropServices;
 using ioxide;
 using ioxide.tls;
 using ioxide.utils;
@@ -102,7 +101,7 @@ for (int i = 0; i < threads.Length; i++)
         // request across two records and each decrypts on its own, so answering per decrypt
         // answers twice. The carry is what turns "some plaintext arrived" into "a request
         // arrived", exactly as the plaintext samples do - ioxide does not parse HTTP for you.
-        var carry = new List<byte>();
+        var carry = new Carry();
 
         try
         {
@@ -113,7 +112,7 @@ for (int i = 0; i < threads.Length; i++)
 
             // A request can ride in with the handshake's final flight - answer it before parking
             // in ReadAsync, or the client waits on a response we never send.
-            carry.AddRange(tls.DrainPlaintext());
+            carry.Append(tls.DrainPlaintext());
             if (Answer(conn, tls, carry, response))
             {
                 await conn.FlushAsync();
@@ -169,19 +168,19 @@ foreach (Thread thread in threads)
 
 // Decrypt takes a raw pointer (the buffer belongs to the ring); the pointer work stays out of the
 // async handler, which cannot contain unsafe code.
-static unsafe void Decrypt(TlsSession tls, in SpscRecvRing.Item item, List<byte> carry)
-    => carry.AddRange(tls.Decrypt(item.Ptr, item.Len));
+static unsafe void Decrypt(TlsSession tls, in SpscRecvRing.Item item, Carry carry)
+    => carry.Append(tls.Decrypt(item.Ptr, item.Len));
 
 // One response per COMPLETE request in the carry, and none for a partial one. Returns whether
 // anything was written, so the caller flushes once for the batch rather than once per request.
-static bool Answer(TcpConnection conn, TlsSession tls, List<byte> carry, ReadOnlyMemory<byte> response)
+static bool Answer(TcpConnection conn, TlsSession tls, Carry carry, ReadOnlyMemory<byte> response)
 {
     bool wrote = false;
     int end;
 
-    while ((end = CollectionsMarshal.AsSpan(carry).IndexOf("\r\n\r\n"u8)) >= 0)
+    while ((end = carry.Span.IndexOf("\r\n\r\n"u8)) >= 0)
     {
-        carry.RemoveRange(0, end + 4);
+        carry.Consume(end + 4);
 
         // The one line that differs from Tls/Ktls. There, kTLS is producing the records so the
         // handler writes plaintext; here OpenSSL has to encrypt before anything reaches the slab.
@@ -191,4 +190,31 @@ static bool Answer(TcpConnection conn, TlsSession tls, List<byte> carry, ReadOnl
     }
 
     return wrote;
+}
+
+// Decrypted-but-unframed bytes: append at the end, consume from the front. A List<byte> pressed
+// into this job needs CollectionsMarshal to be searched and RemoveRange to be consumed; a plain
+// array does both directly.
+sealed class Carry
+{
+    private byte[] _buf = new byte[8 * 1024];
+    private int _len;
+
+    public ReadOnlySpan<byte> Span => _buf.AsSpan(0, _len);
+
+    public void Append(ReadOnlySpan<byte> bytes)
+    {
+        if (_buf.Length - _len < bytes.Length)
+        {
+            Array.Resize(ref _buf, Math.Max(_buf.Length * 2, _len + bytes.Length));
+        }
+        bytes.CopyTo(_buf.AsSpan(_len));
+        _len += bytes.Length;
+    }
+
+    public void Consume(int count)
+    {
+        _buf.AsSpan(count, _len - count).CopyTo(_buf);
+        _len -= count;
+    }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1366,7 +1366,6 @@ foreach (Thread t in threads) t.Join();</code></pre>
 //   curl -k https://127.0.0.1:8443/
 
 using System.Text;
-using System.Runtime.InteropServices;
 using ioxide;
 using ioxide.tls;
 using ioxide.utils;
@@ -1440,7 +1439,7 @@ for (int i = 0; i &lt; threads.Length; i++)
         // request across two records and each decrypts on its own, so answering per decrypt
         // answers twice. The carry is what turns &quot;some plaintext arrived&quot; into &quot;a request
         // arrived&quot;, exactly as the plaintext samples do - ioxide does not parse HTTP for you.
-        var carry = new List&lt;byte&gt;();
+        var carry = new Carry();
 
         try
         {
@@ -1450,7 +1449,7 @@ for (int i = 0; i &lt; threads.Length; i++)
 
             // A request can ride in with the handshake&#x27;s final flight - answer it before parking
             // in ReadAsync, or the client waits on a response we never send.
-            carry.AddRange(tls.DrainPlaintext());
+            carry.Append(tls.DrainPlaintext());
             if (Answer(conn, carry, response))
             {
                 await conn.FlushAsync();
@@ -1507,19 +1506,19 @@ foreach (Thread thread in threads)
 
 // Decrypt takes a raw pointer (the buffer belongs to the ring); the pointer work stays out of the
 // async handler, which cannot contain unsafe code.
-static unsafe void Decrypt(TlsSession tls, in SpscRecvRing.Item item, List&lt;byte&gt; carry)
-    =&gt; carry.AddRange(tls.Decrypt(item.Ptr, item.Len));
+static unsafe void Decrypt(TlsSession tls, in SpscRecvRing.Item item, Carry carry)
+    =&gt; carry.Append(tls.Decrypt(item.Ptr, item.Len));
 
 // One response per COMPLETE request in the carry, and none for a partial one. Returns whether
 // anything was written, so the caller flushes once for the batch rather than once per request.
-static bool Answer(TcpConnection conn, List&lt;byte&gt; carry, ReadOnlyMemory&lt;byte&gt; response)
+static bool Answer(TcpConnection conn, Carry carry, ReadOnlyMemory&lt;byte&gt; response)
 {
     bool wrote = false;
     int end;
 
-    while ((end = CollectionsMarshal.AsSpan(carry).IndexOf(&quot;\r\n\r\n&quot;u8)) &gt;= 0)
+    while ((end = carry.Span.IndexOf(&quot;\r\n\r\n&quot;u8)) &gt;= 0)
     {
-        carry.RemoveRange(0, end + 4);
+        carry.Consume(end + 4);
 
         // PLAINTEXT into the slab - safe only because KernelTx = true above. TlsSession.Write
         // is the call that is correct either way, and is what every other sample uses; this one
@@ -1530,8 +1529,35 @@ static bool Answer(TcpConnection conn, List&lt;byte&gt; carry, ReadOnlyMemory&lt
     }
 
     return wrote;
+}
+
+// Decrypted-but-unframed bytes: append at the end, consume from the front. A List&lt;byte&gt; pressed
+// into this job needs CollectionsMarshal to be searched and RemoveRange to be consumed; a plain
+// array does both directly.
+sealed class Carry
+{
+    private byte[] _buf = new byte[8 * 1024];
+    private int _len;
+
+    public ReadOnlySpan&lt;byte&gt; Span =&gt; _buf.AsSpan(0, _len);
+
+    public void Append(ReadOnlySpan&lt;byte&gt; bytes)
+    {
+        if (_buf.Length - _len &lt; bytes.Length)
+        {
+            Array.Resize(ref _buf, Math.Max(_buf.Length * 2, _len + bytes.Length));
+        }
+        bytes.CopyTo(_buf.AsSpan(_len));
+        _len += bytes.Length;
+    }
+
+    public void Consume(int count)
+    {
+        _buf.AsSpan(count, _len - count).CopyTo(_buf);
+        _len -= count;
+    }
 }</code></pre>
-    <p class="ex-foot"><b>Opt-in</b> - note the explicit <code>KernelTx = true</code>. TLS is OpenSSL in both directions unless you ask for this, and that line is what makes the <code>conn.Write</code> below legal: it puts PLAINTEXT into the slab and the kernel turns it into records. Without it the same call would put <b>cleartext on the wire</b>, which is why every other sample goes through <code>TlsSession.Write</code> - correct in either mode. Receive follows the <code>kernelRx</code> knob: userspace by default, kernel-decrypted when you flip it (experimental). Compare <label for="tab-tlsossl" class="ex-jump">openssl &middot; raw</label>.</p>
+    <p class="ex-foot"><b>Opt-in - and as shipped, the hybrid</b>: <code>KernelTx = true</code> hands transmit to the kernel while receive stays in OpenSSL. Full kTLS is both directions - the <code>kernelRx</code> knob completes it (experimental). The KernelTx line is also what makes the <code>conn.Write</code> below legal: it puts PLAINTEXT into the slab and the kernel turns it into records. Without it the same call would put <b>cleartext on the wire</b>, which is why every other sample goes through <code>TlsSession.Write</code> - correct in either mode. Compare <label for="tab-tlsossl" class="ex-jump">openssl &middot; raw</label>.</p>
   </div>
 
   <div class="pane pane-tlspipe">
@@ -1678,7 +1704,7 @@ foreach (Thread thread in threads)
 {
     thread.Join();
 }</code></pre>
-    <p class="ex-foot">The same kTLS server behind an <code>IDuplexPipe</code>, for the frameworks that serve from one. Now compare <label for="tab-tlsosslpipe" class="ex-jump">openssl &middot; pipes</label>: its serve loop is <b>byte-identical</b> to this one. Over a pipe the backend is invisible, because <code>TlsConnectionDualPipe</code> composes its halves from the session rather than from configuration.</p>
+    <p class="ex-foot">The same hybrid behind an <code>IDuplexPipe</code>, for the frameworks that serve from one. Now compare <label for="tab-tlsosslpipe" class="ex-jump">openssl &middot; pipes</label>: its serve loop is <b>byte-identical</b> to this one. Over a pipe the backend is invisible, because <code>TlsConnectionDualPipe</code> composes its halves from the session rather than from configuration.</p>
   </div>
   <div class="pane pane-tlsossl">
     <div class="pane-head">
@@ -1689,7 +1715,6 @@ foreach (Thread thread in threads)
 //   curl -k https://127.0.0.1:8443/        # no modprobe needed
 
 using System.Text;
-using System.Runtime.InteropServices;
 using ioxide;
 using ioxide.tls;
 using ioxide.utils;
@@ -1753,7 +1778,7 @@ for (int i = 0; i &lt; threads.Length; i++)
         // request across two records and each decrypts on its own, so answering per decrypt
         // answers twice. The carry is what turns &quot;some plaintext arrived&quot; into &quot;a request
         // arrived&quot;, exactly as the plaintext samples do - ioxide does not parse HTTP for you.
-        var carry = new List&lt;byte&gt;();
+        var carry = new Carry();
 
         try
         {
@@ -1764,7 +1789,7 @@ for (int i = 0; i &lt; threads.Length; i++)
 
             // A request can ride in with the handshake&#x27;s final flight - answer it before parking
             // in ReadAsync, or the client waits on a response we never send.
-            carry.AddRange(tls.DrainPlaintext());
+            carry.Append(tls.DrainPlaintext());
             if (Answer(conn, tls, carry, response))
             {
                 await conn.FlushAsync();
@@ -1820,19 +1845,19 @@ foreach (Thread thread in threads)
 
 // Decrypt takes a raw pointer (the buffer belongs to the ring); the pointer work stays out of the
 // async handler, which cannot contain unsafe code.
-static unsafe void Decrypt(TlsSession tls, in SpscRecvRing.Item item, List&lt;byte&gt; carry)
-    =&gt; carry.AddRange(tls.Decrypt(item.Ptr, item.Len));
+static unsafe void Decrypt(TlsSession tls, in SpscRecvRing.Item item, Carry carry)
+    =&gt; carry.Append(tls.Decrypt(item.Ptr, item.Len));
 
 // One response per COMPLETE request in the carry, and none for a partial one. Returns whether
 // anything was written, so the caller flushes once for the batch rather than once per request.
-static bool Answer(TcpConnection conn, TlsSession tls, List&lt;byte&gt; carry, ReadOnlyMemory&lt;byte&gt; response)
+static bool Answer(TcpConnection conn, TlsSession tls, Carry carry, ReadOnlyMemory&lt;byte&gt; response)
 {
     bool wrote = false;
     int end;
 
-    while ((end = CollectionsMarshal.AsSpan(carry).IndexOf(&quot;\r\n\r\n&quot;u8)) &gt;= 0)
+    while ((end = carry.Span.IndexOf(&quot;\r\n\r\n&quot;u8)) &gt;= 0)
     {
-        carry.RemoveRange(0, end + 4);
+        carry.Consume(end + 4);
 
         // The one line that differs from Tls/Ktls. There, kTLS is producing the records so the
         // handler writes plaintext; here OpenSSL has to encrypt before anything reaches the slab.
@@ -1842,6 +1867,33 @@ static bool Answer(TcpConnection conn, TlsSession tls, List&lt;byte&gt; carry, R
     }
 
     return wrote;
+}
+
+// Decrypted-but-unframed bytes: append at the end, consume from the front. A List&lt;byte&gt; pressed
+// into this job needs CollectionsMarshal to be searched and RemoveRange to be consumed; a plain
+// array does both directly.
+sealed class Carry
+{
+    private byte[] _buf = new byte[8 * 1024];
+    private int _len;
+
+    public ReadOnlySpan&lt;byte&gt; Span =&gt; _buf.AsSpan(0, _len);
+
+    public void Append(ReadOnlySpan&lt;byte&gt; bytes)
+    {
+        if (_buf.Length - _len &lt; bytes.Length)
+        {
+            Array.Resize(ref _buf, Math.Max(_buf.Length * 2, _len + bytes.Length));
+        }
+        bytes.CopyTo(_buf.AsSpan(_len));
+        _len += bytes.Length;
+    }
+
+    public void Consume(int count)
+    {
+        _buf.AsSpan(count, _len - count).CopyTo(_buf);
+        _len -= count;
+    }
 }</code></pre>
     <p class="ex-foot"><b>The default.</b> No TLS ULP is attached at all - OpenSSL encrypts and decrypts, and the response goes through <code>TlsSession.Write</code>, which is correct whichever backend the session ended up with. That drops every constraint kTLS imposes: no kernel module, TLS 1.2, any ciphersuite, session resumption back, no handshake-alignment problem. What it gives up is <code>sendfile</code> and NIC offload. <b>It costs nothing measurable here</b> - against the plaintext baseline, 4 reactors, <code>wrk -t4 -c64</code>: 0.79&times; for both at a 64-byte response, 0.35&times; kTLS vs 0.44&times; OpenSSL at 64 KiB. Which backend you pick matters far less than the cost of TLS.</p>
   </div>
@@ -2121,7 +2173,6 @@ foreach (Thread t in threads) t.Join();
 //   curl -k --http2 https://127.0.0.1:8443/
 
 using System.IO.Pipelines;
-using System.Runtime.InteropServices;
 using System.Text;
 using ioxide;
 using ioxide.nghttp2;
@@ -2216,21 +2267,21 @@ for (int i = 0; i &lt; threads.Length; i++)
             // The carry is not incidental. TLS hands back RECORDS, not requests, so a request
             // split across two records decrypts twice - and answering on &quot;plaintext arrived&quot;
             // would answer twice to one request. Framing is ours; ioxide does not parse HTTP.
-            var carry = new List&lt;byte&gt;();
+            var carry = new Carry();
 
             // The client&#x27;s first request usually rides in with its Finished flight, so the
             // handshake already decrypted it and it is sitting in the session, not in any recv
             // buffer. Miss this and that request is dropped and the loop parks on bytes that
             // already arrived - which is exactly what happened here before.
-            carry.AddRange(tls.DrainPlaintext());
+            carry.Append(tls.DrainPlaintext());
 
             while (true)
             {
                 bool wrote = false;
                 int end;
-                while ((end = CollectionsMarshal.AsSpan(carry).IndexOf(&quot;\r\n\r\n&quot;u8)) &gt;= 0)
+                while ((end = carry.Span.IndexOf(&quot;\r\n\r\n&quot;u8)) &gt;= 0)
                 {
-                    carry.RemoveRange(0, end + 4);
+                    carry.Consume(end + 4);
                     // Correct whichever backend the session ended up with.
                     tls.Write(conn, http11Response);
                     wrote = true;
@@ -2249,7 +2300,7 @@ for (int i = 0; i &lt; threads.Length; i++)
                     {
                         if (item.HasBuffer)
                         {
-                            carry.AddRange(tls.Decrypt(item.Ptr, item.Len));
+                            carry.Append(tls.Decrypt(item.Ptr, item.Len));
                             conn.ReturnBuffer(in item);
                         }
                     }
@@ -2282,6 +2333,33 @@ Console.WriteLine($&quot;[http2-tls] {config.ReactorCount} reactors on :{config.
 foreach (Thread thread in threads)
 {
     thread.Join();
+}
+
+// Decrypted-but-unframed bytes: append at the end, consume from the front. A List&lt;byte&gt; pressed
+// into this job needs CollectionsMarshal to be searched and RemoveRange to be consumed; a plain
+// array does both directly.
+sealed class Carry
+{
+    private byte[] _buf = new byte[8 * 1024];
+    private int _len;
+
+    public ReadOnlySpan&lt;byte&gt; Span =&gt; _buf.AsSpan(0, _len);
+
+    public void Append(ReadOnlySpan&lt;byte&gt; bytes)
+    {
+        if (_buf.Length - _len &lt; bytes.Length)
+        {
+            Array.Resize(ref _buf, Math.Max(_buf.Length * 2, _len + bytes.Length));
+        }
+        bytes.CopyTo(_buf.AsSpan(_len));
+        _len += bytes.Length;
+    }
+
+    public void Consume(int count)
+    {
+        _buf.AsSpan(count, _len - count).CopyTo(_buf);
+        _len -= count;
+    }
 }</code></pre>
     <p class="ex-foot">How a browser actually reaches h2: over TLS, with the protocol chosen during the handshake. <code>Alpn = ["h2", "http/1.1"]</code> is an ordered preference, not a weighting - the server takes the first entry the client also offered, and this sample then branches on what was agreed, so one port serves both. That is why the h2c samples are the exception rather than the rule. TLS here is <b>OpenSSL both ways by default</b>; the <code>kernelTx</code>/<code>kernelRx</code> knobs at the top are what move either direction into the kernel.</p>
   </div>

--- a/docs/learn/tls.html
+++ b/docs/learn/tls.html
@@ -330,9 +330,10 @@ if (tls.NegotiatedAlpn == "h2")
     gives both on the ring-native path. Client certificates remain the exception - the ring-native
     path does not do mTLS, so that still means <code>SslStream</code>.</p>
     <ul>
-      <li><b>kTLS</b> (<code>KernelTx = true</code>) &rarr; you are on Linux 6+ with the
-      <code>tls</code> module, TLS 1.3 and ALPN are enough, and you want <code>sendfile</code> or a
-      NIC that offloads TLS.
+      <li><b>kTLS</b> (<code>KernelTx = true</code>; as shipped the hybrid - kernel TX, OpenSSL
+      RX, with <code>KernelRx</code> completing both directions, experimental) &rarr; you are on
+      Linux 6+ with the <code>tls</code> module, TLS 1.3 and ALPN are enough, and you want
+      <code>sendfile</code> or a NIC that offloads TLS.
       Sample: <a href="https://github.com/MDA2AV/ioxide/tree/main/Playground/Tls/Ktls">Tls/Ktls</a>.</li>
       <li><b>OpenSSL both ways</b> (the default) &rarr; no kernel module, so it runs in a container
       that lacks one; TLS 1.2 available, any ciphersuite, resumption back, and no

--- a/scripts/gen-docs-panes.py
+++ b/scripts/gen-docs-panes.py
@@ -15,13 +15,13 @@ PANES = {
         "Tls/Ktls", "kTLS &middot; raw ring", "ioxide",
         ["sudo modprobe tls        # kTLS needs the Linux 'tls' module + OpenSSL 3",
          "curl -k https://127.0.0.1:8443/"],
-        "<b>Opt-in</b> - note the explicit <code>KernelTx = true</code>. TLS is OpenSSL in both "
-        "directions unless you ask for this, and that line is what makes the <code>conn.Write</code> "
-        "below legal: it puts PLAINTEXT into the slab and the kernel turns it into records. Without "
-        "it the same call would put <b>cleartext on the wire</b>, which is why every other sample "
-        "goes through <code>TlsSession.Write</code> - correct in either mode. Receive follows the "
-        "<code>kernelRx</code> knob: userspace by default, kernel-decrypted when you flip it "
-        "(experimental). Compare "
+        "<b>Opt-in - and as shipped, the hybrid</b>: <code>KernelTx = true</code> hands transmit to "
+        "the kernel while receive stays in OpenSSL. Full kTLS is both directions - the "
+        "<code>kernelRx</code> knob completes it (experimental). The KernelTx line is also what "
+        "makes the <code>conn.Write</code> below legal: it puts PLAINTEXT into the slab and the "
+        "kernel turns it into records. Without it the same call would put <b>cleartext on the "
+        "wire</b>, which is why every other sample goes through <code>TlsSession.Write</code> - "
+        "correct in either mode. Compare "
         "<label for=\"tab-tlsossl\" class=\"ex-jump\">openssl &middot; raw</label>."),
     "tlsossl": (
         "Tls/OpenSsl", "OpenSSL &middot; raw ring", "ioxide",
@@ -37,7 +37,7 @@ PANES = {
     "tlspipe": (
         "Tls/KtlsPipes", "kTLS &middot; pipes", "ioxide",
         ["sudo modprobe tls", "curl -k https://127.0.0.1:8443/"],
-        "The same kTLS server behind an <code>IDuplexPipe</code>, for the frameworks that serve from "
+        "The same hybrid behind an <code>IDuplexPipe</code>, for the frameworks that serve from "
         "one. Now compare <label for=\"tab-tlsosslpipe\" class=\"ex-jump\">openssl &middot; pipes</label>: "
         "its serve loop is <b>byte-identical</b> to this one. Over a pipe the backend is invisible, "
         "because <code>TlsConnectionDualPipe</code> composes its halves from the session rather than "


### PR DESCRIPTION
Two things the site examples got called out on.

**Taxonomy.** Full kTLS is kernel in both directions. What the kTLS samples ship by default (`KernelTx = true`, `kernelRx = false`) is the **hybrid** - kernel TX, OpenSSL RX - and the site labeled it plain "kTLS" without saying so. The pane note, both kTLS sample headers, the Playground README rows and the learn page's backend bullet now name the shipped default the hybrid, with `kernelRx` as what completes full kTLS (experimental). The bench matrix already used this taxonomy (`ktls-tx` vs `ktls`).

**The carry.** Three samples framed requests by accumulating decrypted plaintext in a `List<byte>` - searched via `CollectionsMarshal.AsSpan`, consumed via `RemoveRange`. Replaced in each with a 15-line `Carry` class (append at the end, consume from the front, plain arrays), duplicated per sample on purpose like everything else in the Playground. The stray `using System.Runtime.InteropServices` went with it.

Verified: all three samples build and serve (openssl, ktls, both ALPN branches of `Http2/Tls`), and a two-requests-in-one-TCP-segment pipeline draws exactly two responses through the new framing. Panes regenerated (4 rewrote).