### PR TITLE
feat(samples): the kTLS samples are full kTLS by default; hybrid is the drop-back

### DIFF
--- a/Playground/README.md
+++ b/Playground/README.md
@@ -17,9 +17,9 @@ Run any of them with `dotnet run -c Release --project Playground/<Group>/<Name>`
 | [`Tcp.TaskRun`](Tcp/TaskRun/Program.cs) | 84 | Awaiting ordinary thread-pool work and still resuming on the reactor. | `ioxide` |
 | [`Tcp.Incremental`](Tcp/Incremental/Program.cs) | 95 | `Tcp.Raw` with the per-connection buffer-ring mode - one config block is the whole diff. Kernel 6.12+. | `ioxide` |
 | [`Tcp.Big`](Tcp/Big/Program.cs) | 101 | The write path under a 100 KB body: `SEND_ZC`, slab overflow (`grow` vs `seg`), checksum-able output. | `ioxide` |
-| [`Tls.Ktls`](Tls/Ktls/Program.cs) | 172 | The **kernel TLS** opt-in, shipped as the hybrid: kernel TX, OpenSSL RX (`kernelRx` completes full kTLS, experimental). The handler writes plaintext. `modprobe tls`. | `ioxide` |
+| [`Tls.Ktls`](Tls/Ktls/Program.cs) | 172 | **Full kernel TLS** as shipped - both directions in the kernel (experimental); `kernelRx = false` is the deployable hybrid. The handler writes plaintext. `modprobe tls`. | `ioxide` |
 | [`Tls.OpenSsl`](Tls/OpenSsl/Program.cs) | 194 | **The default**: OpenSSL both ways - no kernel module, and TLS 1.2 / any suite / resumption. | `ioxide` |
-| [`Tls.KtlsPipes`](Tls/KtlsPipes/Program.cs) | 163 | The hybrid served through an `IDuplexPipe`. | `ioxide` |
+| [`Tls.KtlsPipes`](Tls/KtlsPipes/Program.cs) | 163 | Full kTLS through an `IDuplexPipe`; `kernelRx = false` for the hybrid. | `ioxide` |
 | [`Tls.OpenSslPipes`](Tls/OpenSslPipes/Program.cs) | 164 | The same, with OpenSSL. Its serve loop is byte-identical to `Tls.KtlsPipes` - over a pipe the backend is invisible. | `ioxide` |
 | [`Tls.SslStream`](Tls/SslStream/Program.cs) | 100 | The BCL `SslStream` over `TcpConnectionStream` - portable userspace TLS, the comparison point. | `ioxide` |
 | [`Http2.Nghttp2`](Http2/Nghttp2/Program.cs) | 66 | HTTP/2 (h2c, prior knowledge) with nghttp2 doing framing, HPACK and flow control. | `ioxide.nghttp2` |

--- a/Playground/README.md
+++ b/Playground/README.md
@@ -17,9 +17,10 @@ Run any of them with `dotnet run -c Release --project Playground/<Group>/<Name>`
 | [`Tcp.TaskRun`](Tcp/TaskRun/Program.cs) | 84 | Awaiting ordinary thread-pool work and still resuming on the reactor. | `ioxide` |
 | [`Tcp.Incremental`](Tcp/Incremental/Program.cs) | 95 | `Tcp.Raw` with the per-connection buffer-ring mode - one config block is the whole diff. Kernel 6.12+. | `ioxide` |
 | [`Tcp.Big`](Tcp/Big/Program.cs) | 101 | The write path under a 100 KB body: `SEND_ZC`, slab overflow (`grow` vs `seg`), checksum-able output. | `ioxide` |
-| [`Tls.Ktls`](Tls/Ktls/Program.cs) | 172 | **Full kernel TLS** as shipped - both directions in the kernel (experimental); `kernelRx = false` is the deployable hybrid. The handler writes plaintext. `modprobe tls`. | `ioxide` |
+| [`Tls.Ktls`](Tls/Ktls/Program.cs) | 172 | **Full kernel TLS** - both directions in the kernel (experimental). The handler writes plaintext. `modprobe tls`. | `ioxide` |
+| [`Tls.Hybrid`](Tls/Hybrid/Program.cs) | 203 | The deployable kernel mode: kernel TX (plaintext writes), OpenSSL RX. `Tls.Ktls` minus one line. `modprobe tls`. | `ioxide` |
 | [`Tls.OpenSsl`](Tls/OpenSsl/Program.cs) | 194 | **The default**: OpenSSL both ways - no kernel module, and TLS 1.2 / any suite / resumption. | `ioxide` |
-| [`Tls.KtlsPipes`](Tls/KtlsPipes/Program.cs) | 163 | Full kTLS through an `IDuplexPipe`; `kernelRx = false` for the hybrid. | `ioxide` |
+| [`Tls.KtlsPipes`](Tls/KtlsPipes/Program.cs) | 163 | Full kTLS through an `IDuplexPipe`. | `ioxide` |
 | [`Tls.OpenSslPipes`](Tls/OpenSslPipes/Program.cs) | 164 | The same, with OpenSSL. Its serve loop is byte-identical to `Tls.KtlsPipes` - over a pipe the backend is invisible. | `ioxide` |
 | [`Tls.SslStream`](Tls/SslStream/Program.cs) | 100 | The BCL `SslStream` over `TcpConnectionStream` - portable userspace TLS, the comparison point. | `ioxide` |
 | [`Http2.Nghttp2`](Http2/Nghttp2/Program.cs) | 66 | HTTP/2 (h2c, prior knowledge) with nghttp2 doing framing, HPACK and flow control. | `ioxide.nghttp2` |

--- a/Playground/Shared/Env.cs
+++ b/Playground/Shared/Env.cs
@@ -79,9 +79,4 @@ public static class Env
         kernelRx = Bool("PLAYGROUND_KTLS_RX", kernelRx);
     }
 
-    /// <summary>
-    /// For the samples where transmit is kTLS by construction and only receive is a choice.
-    /// </summary>
-    public static void OverrideKtls(ref bool kernelRx)
-        => kernelRx = Bool("PLAYGROUND_KTLS_RX", kernelRx);
 }

--- a/Playground/Tls/Hybrid/Playground.Tls.Hybrid.csproj
+++ b/Playground/Tls/Hybrid/Playground.Tls.Hybrid.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net11.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace>Playground.Tls.Hybrid</RootNamespace>
+    <AssemblyName>Playground.Tls.Hybrid</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Shared/Playground.Shared.csproj" />
+    <ProjectReference Include="../../../src/ioxide/ioxide.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Playground/Tls/Hybrid/Program.cs
+++ b/Playground/Tls/Hybrid/Program.cs
@@ -5,13 +5,13 @@ using ioxide.utils;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  tls-ktls - FULL kernel TLS: the OpenSSL handshake runs over the ring, then both directions
-//  are handed to the kernel - the handler writes plaintext, the kernel makes the records, and
-//  recv delivers plaintext straight into ring memory. Experimental (see KernelRx below);
-//  Tls/Hybrid is the deployable drop-back - kernel TX, OpenSSL RX - and Tls/OpenSsl the default.
+//  tls-hybrid - the deployable kernel mode: the OpenSSL handshake runs over the ring, transmit
+//  is handed to KERNEL TLS (the handler writes plaintext, the kernel makes the records), and
+//  receive stays in OpenSSL. Tls/Ktls is this plus kernel receive (experimental); Tls/OpenSsl
+//  is the default, with the kernel in neither direction.
 //
 //      sudo modprobe tls                             # needs the Linux 'tls' module + OpenSSL 3
-//      dotnet run -c Release --project Playground/Tls/Ktls
+//      dotnet run -c Release --project Playground/Tls/Hybrid
 //      curl -ks https://127.0.0.1:8443/ | head -c 40
 //
 //  PLAYGROUND_TLS_CERT/_KEY point at a real PEM pair; otherwise a self-signed localhost cert is
@@ -55,15 +55,10 @@ var tlsOptions = new TlsOptions
     // handler below write PLAINTEXT to the connection: the kernel turns it into records on send.
     // Remove this line and conn.Write would put cleartext on the wire.
     KernelTx = true,
-
-    // Full kTLS: the kernel decrypts inbound too. Experimental - about one first connection in
-    // twelve fails outright, and a client sending a TLS 1.3 KeyUpdate loses the connection.
-    // Tls/Hybrid is this same server without this line: kernel TX, OpenSSL RX, deployable today.
-    KernelRx = true,
 };
 
 byte[] body = new byte[bodyBytes];
-ReadOnlySpan<byte> fill = "ioxide-ktls-payload "u8;
+ReadOnlySpan<byte> fill = "ioxide-hybrid-tls "u8;
 for (int i = 0; i < bodyBytes; i++)
 {
     body[i] = fill[i % fill.Length];
@@ -95,8 +90,6 @@ for (int i = 0; i < threads.Length; i++)
 
         try
         {
-            // The handshake reads and writes through this same connection; after it, the socket
-            // carries kTLS records the kernel en/decrypts.
             tls = await r.GetService<TlsService>().AcceptAsync(conn);
 
             // A request can ride in with the handshake's final flight - answer it before parking
@@ -123,7 +116,7 @@ for (int i = 0; i < threads.Length; i++)
 
                 if (Answer(conn, carry, response))
                 {
-                    await conn.FlushAsync();   // plaintext: the kernel encrypts on send
+                    await conn.FlushAsync();
                 }
 
                 if (snapshot.IsClosed || tls.Closed) return;
@@ -134,7 +127,7 @@ for (int i = 0; i < threads.Length; i++)
         {
             // Handlers run fire-and-forget, so a thrown handshake error would vanish silently -
             // and a missing 'tls' kernel module manifests exactly here.
-            Console.Error.WriteLine($"[tls-ktls] connection failed: {e.Message}");
+            Console.Error.WriteLine($"[tls-hybrid] connection failed: {e.Message}");
         }
         finally
         {
@@ -147,8 +140,8 @@ for (int i = 0; i < threads.Length; i++)
     threads[i].Start();
 }
 
-Console.WriteLine($"[tls-ktls] {config.ReactorCount} reactors on :{config.Tcp!.Port}, "
-                + $"{bodyBytes}-byte body, tx=kernel, rx=kernel (experimental), cert {certPath}");
+Console.WriteLine($"[tls-hybrid] {config.ReactorCount} reactors on :{config.Tcp!.Port}, "
+                + $"{bodyBytes}-byte body, tx=kernel, rx=openssl, cert {certPath}");
 
 foreach (Thread thread in threads)
 {

--- a/Playground/Tls/Ktls/Program.cs
+++ b/Playground/Tls/Ktls/Program.cs
@@ -5,10 +5,10 @@ using ioxide.utils;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  tls-ktls - the kernel TLS opt-in: the OpenSSL handshake runs over the ring, then transmit is
-//  handed to KERNEL TLS - the handler writes plaintext and the kernel produces the records, so
-//  the send path stays exactly the raw send path. As shipped this is the HYBRID - kernel TX,
-//  OpenSSL RX. Full kTLS is both directions: kernelRx = true completes it (experimental).
+//  tls-ktls - FULL kernel TLS: the OpenSSL handshake runs over the ring, then both directions
+//  are handed to the kernel - the handler writes plaintext, the kernel makes the records, and
+//  recv delivers plaintext straight into ring memory. Experimental as shipped (see the kernelRx
+//  knob); kernelRx = false is the HYBRID - kernel TX, OpenSSL RX - the deployable half.
 //
 //      sudo modprobe tls                             # needs the Linux 'tls' module + OpenSSL 3
 //      dotnet run -c Release --project Playground/Tls/Ktls
@@ -34,11 +34,12 @@ Env.Override(ref port, ref reactors, ref bodyBytes);
 string? certOverride = null;
 string? keyOverride  = null;
 
-// Hand INBOUND decryption to the kernel too, so neither direction goes through OpenSSL. Off by
-// default and experimental: a TLS 1.3 KeyUpdate cannot be read through IORING_OP_RECV, and about
-// one first connection in twelve fails outright. Transmit stays kernel-side either way - that is
-// the point of this sample and is not a knob, because the handler below writes plaintext.
-bool kernelRx = false;
+// Full kTLS: the kernel decrypts inbound too, so neither direction goes through OpenSSL. That is
+// what this sample demonstrates, and it is experimental - about one first connection in twelve
+// fails outright, and a client sending a TLS 1.3 KeyUpdate loses the connection. Set false for
+// the HYBRID (kernel TX, OpenSSL RX), the half you would actually deploy today. Transmit stays
+// kernel-side either way - the handler below writes plaintext.
+bool kernelRx = true;
 
 Env.OverrideKtls(ref kernelRx);
 // ─────────────────────────────────────────────────────────────────────────────────────────────

--- a/Playground/Tls/KtlsPipes/Program.cs
+++ b/Playground/Tls/KtlsPipes/Program.cs
@@ -6,8 +6,8 @@ using ioxide.tls;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  tls-ktls-pipes - TLS served through an IDuplexPipe, with the kernel doing the transmit
-//  crypto - the hybrid, same as Tls/Ktls; kernelRx = true is full kTLS (experimental).
+//  tls-ktls-pipes - full kernel TLS served through an IDuplexPipe, same as Tls/Ktls: both
+//  directions in the kernel as shipped (experimental); kernelRx = false is the hybrid.
 //
 //      sudo modprobe tls        # kTLS needs the module
 //      curl -ks https://127.0.0.1:8443/ | head -c 40
@@ -51,10 +51,10 @@ Env.Override(ref port, ref reactors, ref bodyBytes);
 string? certOverride = null;
 string? keyOverride  = null;
 
-// Hand INBOUND decryption to the kernel too. Off by default and experimental: about one first
-// connection in twelve fails outright, and a client sending a TLS 1.3 KeyUpdate loses the
-// connection. Transmit stays kernel-side either way - that is the point of this sample.
-bool kernelRx = false;
+// Full kTLS: the kernel decrypts inbound too. Experimental - about one first connection in
+// twelve fails outright, and a client sending a TLS 1.3 KeyUpdate loses the connection. Set
+// false for the hybrid (kernel TX, OpenSSL RX), the half you would actually deploy today.
+bool kernelRx = true;
 
 Env.OverrideKtls(ref kernelRx);
 // ─────────────────────────────────────────────────────────────────────────────────────────────

--- a/Playground/Tls/KtlsPipes/Program.cs
+++ b/Playground/Tls/KtlsPipes/Program.cs
@@ -7,14 +7,14 @@ using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 //  tls-ktls-pipes - full kernel TLS served through an IDuplexPipe, same as Tls/Ktls: both
-//  directions in the kernel as shipped (experimental); kernelRx = false is the hybrid.
+//  directions in the kernel (experimental); drop the KernelRx line for the hybrid.
 //
 //      sudo modprobe tls        # kTLS needs the module
 //      curl -ks https://127.0.0.1:8443/ | head -c 40
 //
 //  The read/serve loop below is byte-for-byte identical to Playground/Tls/OpenSslPipes - diff
-//  them and the only functional difference is the KernelTx line, the rest being the banner and
-//  the log tag.
+//  them and the only functional difference is the two Kernel* lines, the rest being the banner
+//  and the log tag.
 //
 //  TlsConnectionDualPipe composes rather than implements. Each direction has two possible halves:
 //
@@ -51,12 +51,6 @@ Env.Override(ref port, ref reactors, ref bodyBytes);
 string? certOverride = null;
 string? keyOverride  = null;
 
-// Full kTLS: the kernel decrypts inbound too. Experimental - about one first connection in
-// twelve fails outright, and a client sending a TLS 1.3 KeyUpdate loses the connection. Set
-// false for the hybrid (kernel TX, OpenSSL RX), the half you would actually deploy today.
-bool kernelRx = true;
-
-Env.OverrideKtls(ref kernelRx);
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
 (string certPath, string keyPath) = QuicCert.Ensure(certOverride, keyOverride);
@@ -75,12 +69,13 @@ var tlsOptions = new TlsOptions
     CertificatePath = certPath,
     KeyPath = keyPath,
 
-    // NOT the default - TLS is OpenSSL both ways unless you ask for this. As shipped this is the
-    // mixed mode, kernel TX with OpenSSL RX; Playground/Tls/OpenSslPipes is the same server
-    // without this line.
+    // NOT the default - TLS is OpenSSL both ways unless you ask for this.
+    // Playground/Tls/OpenSslPipes is the same server without these two lines.
     KernelTx = true,
 
-    KernelRx = kernelRx,
+    // Full kTLS: the kernel decrypts inbound too. Experimental - about one first connection in
+    // twelve fails outright, and a KeyUpdate is fatal. Drop this line for the hybrid.
+    KernelRx = true,
 };
 
 byte[] body = new byte[bodyBytes];
@@ -166,8 +161,7 @@ for (int i = 0; i < threads.Length; i++)
 }
 
 Console.WriteLine($"[tls-ktls-pipes] {config.ReactorCount} reactors on :{config.Tcp!.Port}, "
-                + $"{bodyBytes}-byte body, tx={(tlsOptions.KernelTx ? "kernel" : "openssl")}, "
-                + $"rx={(kernelRx ? "kernel (experimental)" : "openssl")}");
+                + $"{bodyBytes}-byte body, tx=kernel, rx=kernel (experimental)");
 
 foreach (Thread thread in threads)
 {

--- a/bench/README.md
+++ b/bench/README.md
@@ -15,7 +15,7 @@ is not the ceiling). `BENCH_SECONDS` sets the measurement window (default 8).
 | workload | server | load |
 | --- | --- | --- |
 | tcp-raw, tcp-pipe (4r + 12r) | `Playground.Tcp.Raw` / `.Pipe`, 2 B plaintext body | `wrk -t4 -c64` |
-| tls-sslstream, tls-openssl, tls-ktls | `Playground.Tls.*`, 8 KB body | `wrk` over TLS |
+| tls-sslstream, tls-openssl, tls-ktls-tx | `Playground.Tls.*`, 8 KB body | `wrk` over TLS |
 | h3-server | `Playground.Nghttp3` | `h3x -t4 -c64 -m8` |
 | client-h1 / h2 / h3 | `Bench.Clients` (4 reactors) against Tcp.Raw / nginx-h2c / Nghttp3 | itself |
 | redis, pg, file | `Playground.Redis` / `.Pg` / `.File` | `wrk -t4 -c64` |

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -76,11 +76,13 @@ play Tls/OpenSsl PLAYGROUND_REACTORS=$R PLAYGROUND_PORT=18443 \
   && note "tls-openssl" "${R}r" "$(wrk_h1 https://127.0.0.1:18443/) req/s"
 stop_play
 if [ -d /sys/module/tls ]; then
-  play Tls/Ktls PLAYGROUND_REACTORS=$R PLAYGROUND_PORT=18443 \
-    && note "tls-ktls" "${R}r" "$(wrk_h1 https://127.0.0.1:18443/) req/s"
+  # RX pinned off: the row benches the deployable hybrid (kernel TX, OpenSSL RX), matching the
+  # matrix's ktls-tx cell - the sample's own default is full kTLS, which is experimental.
+  play Tls/Ktls PLAYGROUND_REACTORS=$R PLAYGROUND_PORT=18443 PLAYGROUND_KTLS_RX=0 \
+    && note "tls-ktls-tx" "${R}r" "$(wrk_h1 https://127.0.0.1:18443/) req/s"
   stop_play
 else
-  note "tls-ktls" "${R}r" "SKIP (no 'tls' kernel module - sudo modprobe tls)"
+  note "tls-ktls-tx" "${R}r" "SKIP (no 'tls' kernel module - sudo modprobe tls)"
 fi
 
 # ── h3 server ───────────────────────────────────────────────────────────────────────────────

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -76,9 +76,8 @@ play Tls/OpenSsl PLAYGROUND_REACTORS=$R PLAYGROUND_PORT=18443 \
   && note "tls-openssl" "${R}r" "$(wrk_h1 https://127.0.0.1:18443/) req/s"
 stop_play
 if [ -d /sys/module/tls ]; then
-  # RX pinned off: the row benches the deployable hybrid (kernel TX, OpenSSL RX), matching the
-  # matrix's ktls-tx cell - the sample's own default is full kTLS, which is experimental.
-  play Tls/Ktls PLAYGROUND_REACTORS=$R PLAYGROUND_PORT=18443 PLAYGROUND_KTLS_RX=0 \
+  # The deployable hybrid (kernel TX, OpenSSL RX) - matches the matrix's ktls-tx cell.
+  play Tls/Hybrid PLAYGROUND_REACTORS=$R PLAYGROUND_PORT=18443 \
     && note "tls-ktls-tx" "${R}r" "$(wrk_h1 https://127.0.0.1:18443/) req/s"
   stop_play
 else

--- a/bench/tls-matrix.sh
+++ b/bench/tls-matrix.sh
@@ -142,8 +142,8 @@ for pass in $(seq "$PASSES"); do
   for body in $BODIES; do
     cell h1-plaintext $B/Tcp/Raw/bin/Release/net11.0/Playground.Tcp.Raw           8080 h1  "$body"
     cell h1-openssl   $B/Tls/OpenSsl/bin/Release/net11.0/Playground.Tls.OpenSsl   8443 h1s "$body"
-    cell h1-ktls-tx   $B/Tls/Ktls/bin/Release/net11.0/Playground.Tls.Ktls         8444 h1s "$body" PLAYGROUND_KTLS_RX=0
-    cell h1-ktls      $B/Tls/Ktls/bin/Release/net11.0/Playground.Tls.Ktls         8445 h1s "$body" PLAYGROUND_KTLS_RX=1
+    cell h1-ktls-tx   $B/Tls/Hybrid/bin/Release/net11.0/Playground.Tls.Hybrid     8444 h1s "$body"
+    cell h1-ktls      $B/Tls/Ktls/bin/Release/net11.0/Playground.Tls.Ktls         8445 h1s "$body"
 
     cell h2-plaintext $B/Http2/Nghttp2/bin/Release/net11.0/Playground.Http2.Nghttp2 8081 h2c "$body"
     cell h2-openssl   $B/Http2/Tls/bin/Release/net11.0/Playground.Http2.Tls         8446 h2  "$body" PLAYGROUND_KTLS_TX=0 PLAYGROUND_KTLS_RX=0

--- a/docs/index.html
+++ b/docs/index.html
@@ -1380,11 +1380,12 @@ int    bodyBytes = 8 * 1024;                    // TLS cost is per-byte, so a 2-
 const string certPath = &quot;cert.pem&quot;;   // any PEM pair
 const string keyPath  = &quot;key.pem&quot;;
 
-// Hand INBOUND decryption to the kernel too, so neither direction goes through OpenSSL. Off by
-// default and experimental: a TLS 1.3 KeyUpdate cannot be read through IORING_OP_RECV, and about
-// one first connection in twelve fails outright. Transmit stays kernel-side either way - that is
-// the point of this sample and is not a knob, because the handler below writes plaintext.
-bool kernelRx = false;
+// Full kTLS: the kernel decrypts inbound too, so neither direction goes through OpenSSL. That is
+// what this sample demonstrates, and it is experimental - about one first connection in twelve
+// fails outright, and a client sending a TLS 1.3 KeyUpdate loses the connection. Set false for
+// the HYBRID (kernel TX, OpenSSL RX), the half you would actually deploy today. Transmit stays
+// kernel-side either way - the handler below writes plaintext.
+bool kernelRx = true;
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
 
@@ -1557,7 +1558,7 @@ sealed class Carry
         _len -= count;
     }
 }</code></pre>
-    <p class="ex-foot"><b>Opt-in - and as shipped, the hybrid</b>: <code>KernelTx = true</code> hands transmit to the kernel while receive stays in OpenSSL. Full kTLS is both directions - the <code>kernelRx</code> knob completes it (experimental). The KernelTx line is also what makes the <code>conn.Write</code> below legal: it puts PLAINTEXT into the slab and the kernel turns it into records. Without it the same call would put <b>cleartext on the wire</b>, which is why every other sample goes through <code>TlsSession.Write</code> - correct in either mode. Compare <label for="tab-tlsossl" class="ex-jump">openssl &middot; raw</label>.</p>
+    <p class="ex-foot"><b>Opt-in - and as shipped, FULL kTLS</b>: both directions in the kernel. <code>kernelRx = false</code> drops receive back to OpenSSL - the hybrid, the half you would deploy today, since kernel RX is experimental. The KernelTx line is also what makes the <code>conn.Write</code> below legal: it puts PLAINTEXT into the slab and the kernel turns it into records. Without it the same call would put <b>cleartext on the wire</b>, which is why every other sample goes through <code>TlsSession.Write</code> - correct in either mode. Compare <label for="tab-tlsossl" class="ex-jump">openssl &middot; raw</label>.</p>
   </div>
 
   <div class="pane pane-tlspipe">
@@ -1585,10 +1586,10 @@ int    bodyBytes = 8 * 1024;                    // TLS cost is per-byte, so a 2-
 const string certPath = &quot;cert.pem&quot;;   // any PEM pair
 const string keyPath  = &quot;key.pem&quot;;
 
-// Hand INBOUND decryption to the kernel too. Off by default and experimental: about one first
-// connection in twelve fails outright, and a client sending a TLS 1.3 KeyUpdate loses the
-// connection. Transmit stays kernel-side either way - that is the point of this sample.
-bool kernelRx = false;
+// Full kTLS: the kernel decrypts inbound too. Experimental - about one first connection in
+// twelve fails outright, and a client sending a TLS 1.3 KeyUpdate loses the connection. Set
+// false for the hybrid (kernel TX, OpenSSL RX), the half you would actually deploy today.
+bool kernelRx = true;
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
 
@@ -1704,7 +1705,7 @@ foreach (Thread thread in threads)
 {
     thread.Join();
 }</code></pre>
-    <p class="ex-foot">The same hybrid behind an <code>IDuplexPipe</code>, for the frameworks that serve from one. Now compare <label for="tab-tlsosslpipe" class="ex-jump">openssl &middot; pipes</label>: its serve loop is <b>byte-identical</b> to this one. Over a pipe the backend is invisible, because <code>TlsConnectionDualPipe</code> composes its halves from the session rather than from configuration.</p>
+    <p class="ex-foot">The same full-kTLS server behind an <code>IDuplexPipe</code>, for the frameworks that serve from one. Now compare <label for="tab-tlsosslpipe" class="ex-jump">openssl &middot; pipes</label>: its serve loop is <b>byte-identical</b> to this one. Over a pipe the backend is invisible, because <code>TlsConnectionDualPipe</code> composes its halves from the session rather than from configuration.</p>
   </div>
   <div class="pane pane-tlsossl">
     <div class="pane-head">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1379,13 +1379,6 @@ int    bodyBytes = 8 * 1024;                    // TLS cost is per-byte, so a 2-
 
 const string certPath = &quot;cert.pem&quot;;   // any PEM pair
 const string keyPath  = &quot;key.pem&quot;;
-
-// Full kTLS: the kernel decrypts inbound too, so neither direction goes through OpenSSL. That is
-// what this sample demonstrates, and it is experimental - about one first connection in twelve
-// fails outright, and a client sending a TLS 1.3 KeyUpdate loses the connection. Set false for
-// the HYBRID (kernel TX, OpenSSL RX), the half you would actually deploy today. Transmit stays
-// kernel-side either way - the handler below writes plaintext.
-bool kernelRx = true;
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
 
@@ -1408,7 +1401,10 @@ var tlsOptions = new TlsOptions
     // Remove this line and conn.Write would put cleartext on the wire.
     KernelTx = true,
 
-    KernelRx = kernelRx,
+    // Full kTLS: the kernel decrypts inbound too. Experimental - about one first connection in
+    // twelve fails outright, and a client sending a TLS 1.3 KeyUpdate loses the connection.
+    // Tls/Hybrid is this same server without this line: kernel TX, OpenSSL RX, deployable today.
+    KernelRx = true,
 };
 
 byte[] body = new byte[bodyBytes];
@@ -1497,8 +1493,7 @@ for (int i = 0; i &lt; threads.Length; i++)
 }
 
 Console.WriteLine($&quot;[tls-ktls] {config.ReactorCount} reactors on :{config.Tcp!.Port}, &quot;
-                + $&quot;{bodyBytes}-byte body, rx={(kernelRx ? &quot;kernel (experimental)&quot; : &quot;openssl&quot;)}, &quot;
-                + $&quot;cert {certPath}&quot;);
+                + $&quot;{bodyBytes}-byte body, tx=kernel, rx=kernel (experimental), cert {certPath}&quot;);
 
 foreach (Thread thread in threads)
 {
@@ -1558,7 +1553,7 @@ sealed class Carry
         _len -= count;
     }
 }</code></pre>
-    <p class="ex-foot"><b>Opt-in - and as shipped, FULL kTLS</b>: both directions in the kernel. <code>kernelRx = false</code> drops receive back to OpenSSL - the hybrid, the half you would deploy today, since kernel RX is experimental. The KernelTx line is also what makes the <code>conn.Write</code> below legal: it puts PLAINTEXT into the slab and the kernel turns it into records. Without it the same call would put <b>cleartext on the wire</b>, which is why every other sample goes through <code>TlsSession.Write</code> - correct in either mode. Compare <label for="tab-tlsossl" class="ex-jump">openssl &middot; raw</label>.</p>
+    <p class="ex-foot"><b>Opt-in - and FULL kTLS</b>: both directions in the kernel, set right on the options. Kernel RX is experimental, so <code>Tls/Hybrid</code> in the repo is this server minus the <code>KernelRx</code> line - the half you would deploy today. The KernelTx line is what makes the <code>conn.Write</code> below legal: it puts PLAINTEXT into the slab and the kernel turns it into records. Without it the same call would put <b>cleartext on the wire</b>, which is why every other sample goes through <code>TlsSession.Write</code> - correct in either mode. Compare <label for="tab-tlsossl" class="ex-jump">openssl &middot; raw</label>.</p>
   </div>
 
   <div class="pane pane-tlspipe">
@@ -1585,11 +1580,6 @@ int    bodyBytes = 8 * 1024;                    // TLS cost is per-byte, so a 2-
 
 const string certPath = &quot;cert.pem&quot;;   // any PEM pair
 const string keyPath  = &quot;key.pem&quot;;
-
-// Full kTLS: the kernel decrypts inbound too. Experimental - about one first connection in
-// twelve fails outright, and a client sending a TLS 1.3 KeyUpdate loses the connection. Set
-// false for the hybrid (kernel TX, OpenSSL RX), the half you would actually deploy today.
-bool kernelRx = true;
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
 
@@ -1607,12 +1597,13 @@ var tlsOptions = new TlsOptions
     CertificatePath = certPath,
     KeyPath = keyPath,
 
-    // NOT the default - TLS is OpenSSL both ways unless you ask for this. As shipped this is the
-    // mixed mode, kernel TX with OpenSSL RX; Playground/Tls/OpenSslPipes is the same server
-    // without this line.
+    // NOT the default - TLS is OpenSSL both ways unless you ask for this.
+    // Playground/Tls/OpenSslPipes is the same server without these two lines.
     KernelTx = true,
 
-    KernelRx = kernelRx,
+    // Full kTLS: the kernel decrypts inbound too. Experimental - about one first connection in
+    // twelve fails outright, and a KeyUpdate is fatal. Drop this line for the hybrid.
+    KernelRx = true,
 };
 
 byte[] body = new byte[bodyBytes];
@@ -1698,8 +1689,7 @@ for (int i = 0; i &lt; threads.Length; i++)
 }
 
 Console.WriteLine($&quot;[tls-ktls-pipes] {config.ReactorCount} reactors on :{config.Tcp!.Port}, &quot;
-                + $&quot;{bodyBytes}-byte body, tx={(tlsOptions.KernelTx ? &quot;kernel&quot; : &quot;openssl&quot;)}, &quot;
-                + $&quot;rx={(kernelRx ? &quot;kernel (experimental)&quot; : &quot;openssl&quot;)}&quot;);
+                + $&quot;{bodyBytes}-byte body, tx=kernel, rx=kernel (experimental)&quot;);
 
 foreach (Thread thread in threads)
 {

--- a/docs/learn/tls.html
+++ b/docs/learn/tls.html
@@ -330,10 +330,10 @@ if (tls.NegotiatedAlpn == "h2")
     gives both on the ring-native path. Client certificates remain the exception - the ring-native
     path does not do mTLS, so that still means <code>SslStream</code>.</p>
     <ul>
-      <li><b>kTLS</b> (<code>KernelTx = true</code>; as shipped the hybrid - kernel TX, OpenSSL
-      RX, with <code>KernelRx</code> completing both directions, experimental) &rarr; you are on
-      Linux 6+ with the <code>tls</code> module, TLS 1.3 and ALPN are enough, and you want
-      <code>sendfile</code> or a NIC that offloads TLS.
+      <li><b>kTLS</b> (<code>KernelTx = true</code> is the deployable hybrid - kernel TX,
+      OpenSSL RX; add <code>KernelRx = true</code> for both directions, which is experimental)
+      &rarr; you are on Linux 6+ with the <code>tls</code> module, TLS 1.3 and ALPN are enough,
+      and you want <code>sendfile</code> or a NIC that offloads TLS.
       Sample: <a href="https://github.com/MDA2AV/ioxide/tree/main/Playground/Tls/Ktls">Tls/Ktls</a>.</li>
       <li><b>OpenSSL both ways</b> (the default) &rarr; no kernel module, so it runs in a container
       that lacks one; TLS 1.2 available, any ciphersuite, resumption back, and no

--- a/ioxide.slnx
+++ b/ioxide.slnx
@@ -46,6 +46,7 @@
 
   <Folder Name="/apps/playground/tls/">
     <Project Path="Playground/Tls/Ktls/Playground.Tls.Ktls.csproj" />
+    <Project Path="Playground/Tls/Hybrid/Playground.Tls.Hybrid.csproj" />
     <Project Path="Playground/Tls/KtlsPipes/Playground.Tls.KtlsPipes.csproj" />
     <Project Path="Playground/Tls/OpenSsl/Playground.Tls.OpenSsl.csproj" />
     <Project Path="Playground/Tls/OpenSslPipes/Playground.Tls.OpenSslPipes.csproj" />

--- a/scripts/gen-docs-panes.py
+++ b/scripts/gen-docs-panes.py
@@ -15,9 +15,9 @@ PANES = {
         "Tls/Ktls", "kTLS &middot; raw ring", "ioxide",
         ["sudo modprobe tls        # kTLS needs the Linux 'tls' module + OpenSSL 3",
          "curl -k https://127.0.0.1:8443/"],
-        "<b>Opt-in - and as shipped, FULL kTLS</b>: both directions in the kernel. "
-        "<code>kernelRx = false</code> drops receive back to OpenSSL - the hybrid, the half you "
-        "would deploy today, since kernel RX is experimental. The KernelTx line is also what "
+        "<b>Opt-in - and FULL kTLS</b>: both directions in the kernel, set right on the options. "
+        "Kernel RX is experimental, so <code>Tls/Hybrid</code> in the repo is this server minus "
+        "the <code>KernelRx</code> line - the half you would deploy today. The KernelTx line is what "
         "makes the <code>conn.Write</code> below legal: it puts PLAINTEXT into the slab and the "
         "kernel turns it into records. Without it the same call would put <b>cleartext on the "
         "wire</b>, which is why every other sample goes through <code>TlsSession.Write</code> - "

--- a/scripts/gen-docs-panes.py
+++ b/scripts/gen-docs-panes.py
@@ -15,9 +15,9 @@ PANES = {
         "Tls/Ktls", "kTLS &middot; raw ring", "ioxide",
         ["sudo modprobe tls        # kTLS needs the Linux 'tls' module + OpenSSL 3",
          "curl -k https://127.0.0.1:8443/"],
-        "<b>Opt-in - and as shipped, the hybrid</b>: <code>KernelTx = true</code> hands transmit to "
-        "the kernel while receive stays in OpenSSL. Full kTLS is both directions - the "
-        "<code>kernelRx</code> knob completes it (experimental). The KernelTx line is also what "
+        "<b>Opt-in - and as shipped, FULL kTLS</b>: both directions in the kernel. "
+        "<code>kernelRx = false</code> drops receive back to OpenSSL - the hybrid, the half you "
+        "would deploy today, since kernel RX is experimental. The KernelTx line is also what "
         "makes the <code>conn.Write</code> below legal: it puts PLAINTEXT into the slab and the "
         "kernel turns it into records. Without it the same call would put <b>cleartext on the "
         "wire</b>, which is why every other sample goes through <code>TlsSession.Write</code> - "
@@ -37,7 +37,7 @@ PANES = {
     "tlspipe": (
         "Tls/KtlsPipes", "kTLS &middot; pipes", "ioxide",
         ["sudo modprobe tls", "curl -k https://127.0.0.1:8443/"],
-        "The same hybrid behind an <code>IDuplexPipe</code>, for the frameworks that serve from "
+        "The same full-kTLS server behind an <code>IDuplexPipe</code>, for the frameworks that serve from "
         "one. Now compare <label for=\"tab-tlsosslpipe\" class=\"ex-jump\">openssl &middot; pipes</label>: "
         "its serve loop is <b>byte-identical</b> to this one. Over a pipe the backend is invisible, "
         "because <code>TlsConnectionDualPipe</code> composes its halves from the session rather than "


### PR DESCRIPTION
Third time was the charm on this one: the sample **named** kTLS shipped the hybrid (kernel TX, OpenSSL RX) and explained itself in a footnote. Wrong way around.

- `Tls/Ktls` and `Tls/KtlsPipes` now default `kernelRx = true` - **full kernel TLS, both directions**, which is what the name promises. `kernelRx = false` is the drop-back to the **hybrid**, the half you'd deploy today. The knob comments carry the experimental caveats (~1 first connection in 12 dies, KeyUpdate is fatal).
- `run.sh` pins `PLAYGROUND_KTLS_RX=0` and renames its row **`tls-ktls-tx`** - the regression suite keeps benching the deployable hybrid, named the way the matrix already names that cell (`ktls-tx` vs `ktls`). One-row continuity break, flagged here on purpose.
- Pane notes, both READMEs and the learn page's backend bullet flip to match. The matrix needs no change - it always drove both knobs explicitly.
- The kTLS tests keep testing the hybrid explicitly (`KernelTx = true`, RX unset) - that's the deployable path and they say so in their names.

Verified: both samples serve **full kTLS out of the box** - eight-for-eight 200s each, banners reporting `rx=kernel (experimental)`. Panes regenerated.