### PR TITLE
feat(samples): hybrid pane on the site; Tls/MultiPort - plaintext and TLS, one loop

### DIFF
--- a/Playground/README.md
+++ b/Playground/README.md
@@ -22,6 +22,7 @@ Run any of them with `dotnet run -c Release --project Playground/<Group>/<Name>`
 | [`Tls.OpenSsl`](Tls/OpenSsl/Program.cs) | 194 | **The default**: OpenSSL both ways - no kernel module, and TLS 1.2 / any suite / resumption. | `ioxide` |
 | [`Tls.KtlsPipes`](Tls/KtlsPipes/Program.cs) | 163 | Full kTLS through an `IDuplexPipe`. | `ioxide` |
 | [`Tls.OpenSslPipes`](Tls/OpenSslPipes/Program.cs) | 164 | The same, with OpenSSL. Its serve loop is byte-identical to `Tls.KtlsPipes` - over a pipe the backend is invisible. | `ioxide` |
+| [`Tls.MultiPort`](Tls/MultiPort/Program.cs) | 160 | Plaintext on `:8080`, TLS on `:8081`, ONE pipe serve loop for both doors - multi-port made concrete. | `ioxide` |
 | [`Tls.SslStream`](Tls/SslStream/Program.cs) | 100 | The BCL `SslStream` over `TcpConnectionStream` - portable userspace TLS, the comparison point. | `ioxide` |
 | [`Http2.Nghttp2`](Http2/Nghttp2/Program.cs) | 66 | HTTP/2 (h2c, prior knowledge) with nghttp2 doing framing, HPACK and flow control. | `ioxide.nghttp2` |
 | [`Http2.Managed`](Http2/Managed/Program.cs) | 66 | The same server with **zero native code** - framing, HPACK and flow control in C#. Drop-in for the above. | `ioxide.http2` |

--- a/Playground/Tls/MultiPort/Playground.Tls.MultiPort.csproj
+++ b/Playground/Tls/MultiPort/Playground.Tls.MultiPort.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net11.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace>Playground.Tls.MultiPort</RootNamespace>
+    <AssemblyName>Playground.Tls.MultiPort</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Shared/Playground.Shared.csproj" />
+    <ProjectReference Include="../../../src/ioxide/ioxide.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Playground/Tls/MultiPort/Program.cs
+++ b/Playground/Tls/MultiPort/Program.cs
@@ -1,0 +1,160 @@
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Text;
+using ioxide;
+using ioxide.tls;
+using Playground.Shared;
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+//  tls-multiport - one server, two doors: plaintext on :8080, TLS on :8081, and ONE serve loop
+//  for both. The TLS door terminates with the default backend (OpenSSL both ways, no kernel
+//  module) and serves through a TlsConnectionDualPipe; the plaintext door pairs the connection's
+//  own pipe halves. The loop reads an IDuplexPipe and cannot tell which door it got - that is
+//  the point.
+//
+//      dotnet run -c Release --project Playground/Tls/MultiPort
+//      curl  http://127.0.0.1:8080/
+//      curl -ks https://127.0.0.1:8081/
+//
+//  A self-signed localhost cert is generated on first run. Needs: ioxide
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+// ── Knobs ────────────────────────────────────────────────────────────────────────────────────
+// Edit these. That is the whole mechanism - there is no config file and nothing else to find.
+// Env.Override exists only so bench/run.sh can drive the sample from outside; delete that line
+// when you copy this out and the literals above it are the entire configuration.
+
+ushort port     = 8080;                        // http://127.0.0.1:8080/  - the plaintext door
+ushort tlsPort  = 8081;                        // https://127.0.0.1:8081/ - the TLS door
+int    reactors = Environment.ProcessorCount;  // one ring per reactor, one reactor per core
+
+Env.Override(ref port, ref reactors);
+
+// A real PEM pair, or null to generate a self-signed localhost cert on first run.
+string? certOverride = null;
+string? keyOverride  = null;
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(certOverride, keyOverride);
+
+var config = new ServerConfig
+{
+    ReactorCount = reactors,
+    Tcp = new TcpOptions
+    {
+        Port = port,
+        ExtraPorts = [tlsPort],   // every reactor listens on both; ListenerPort says which one accepted
+    },
+};
+
+// Default backend: OpenSSL in both directions. Only connections on the TLS door go near this.
+var tlsOptions = new TlsOptions
+{
+    CertificatePath = certPath,
+    KeyPath         = keyPath,
+};
+
+const string bodyText = "multiport-ok\n";
+byte[] response = Encoding.ASCII.GetBytes(
+    $"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {bodyText.Length}\r\n\r\n{bodyText}");
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i < threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    reactor.OnStart = r => TlsService.Start(r, tlsOptions);
+
+    reactor.TcpHandle = async (r, conn) =>
+    {
+        TlsSession? tls = null;
+        try
+        {
+            // Which door? This branch is the entire difference between the two.
+            if (conn.ListenerPort == tlsPort)
+            {
+                tls = await r.GetService<TlsService>().AcceptAsync(conn);
+                await using var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
+                await ServeAsync(pipe, response);
+            }
+            else
+            {
+                var pipe = new PlainPipe(new TcpConnectionPipeReader(conn), new TcpConnectionPipeWriter(conn));
+                try
+                {
+                    await ServeAsync(pipe, response);
+                }
+                finally
+                {
+                    pipe.Input.Complete();
+                    pipe.Output.Complete();
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"[tls-multiport] connection failed: {e.Message}");
+        }
+        finally
+        {
+            tls?.Dispose();
+            conn.DecRef();
+        }
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $"reactor-{i}" };
+    threads[i].Start();
+}
+
+Console.WriteLine($"[tls-multiport] {config.ReactorCount} reactors, "
+                + $"plaintext :{config.Tcp!.Port}, tls :{tlsPort} (openssl both ways), cert {certPath}");
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}
+
+// One loop for both doors. It reads an IDuplexPipe and nothing else - whether the bytes were
+// decrypted on the way in, or will be encrypted on the way out, is not visible from here.
+static async Task ServeAsync(IDuplexPipe pipe, ReadOnlyMemory<byte> response)
+{
+    while (true)
+    {
+        ReadResult read = await pipe.Input.ReadAsync();
+
+        // Answer per REQUEST, not per read - a request split across reads must not draw two
+        // responses, and two requests in one read must not draw one.
+        int answered = 0;
+        SequencePosition consumed = read.Buffer.Start;
+
+        var reader = new SequenceReader<byte>(read.Buffer);
+        while (reader.TryReadTo(out ReadOnlySequence<byte> _, "\r\n\r\n"u8, advancePastDelimiter: true))
+        {
+            consumed = reader.Position;
+            answered++;
+        }
+
+        // Consumed only whole requests; examined everything, so a partial head parks until more
+        // arrives instead of spinning on the same bytes.
+        pipe.Input.AdvanceTo(consumed, read.Buffer.End);
+
+        for (int n = 0; n < answered; n++)
+        {
+            pipe.Output.Write(response.Span);
+        }
+
+        if (answered > 0)
+        {
+            await pipe.Output.FlushAsync();
+        }
+
+        if (read.IsCompleted || read.IsCanceled)
+        {
+            return;
+        }
+    }
+}
+
+// The plaintext door's IDuplexPipe: the connection's own reader and writer, paired.
+sealed record PlainPipe(PipeReader Input, PipeWriter Output) : IDuplexPipe;

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -212,6 +212,7 @@ nav.top .links a.gh svg { display: block; }
 #tab-vs:checked ~ .ex-menu label[for="tab-vs"],
 #tab-tlsosslpipe:checked ~ .ex-menu label[for="tab-tlsosslpipe"],
 #tab-tlsossl:checked ~ .ex-menu label[for="tab-tlsossl"],
+#tab-tlsmulti:checked ~ .ex-menu label[for="tab-tlsmulti"],
 #tab-tlsbcl:checked ~ .ex-menu label[for="tab-tlsbcl"],
 #tab-big:checked ~ .ex-menu label[for="tab-big"],
 #tab-hop:checked ~ .ex-menu label[for="tab-hop"],
@@ -241,6 +242,7 @@ nav.top .links a.gh svg { display: block; }
 #tab-redis:checked ~ .ex-menu label[for="tab-redis"],
 #tab-files:checked ~ .ex-menu label[for="tab-files"],
 #tab-tls:checked ~ .ex-menu label[for="tab-tls"],
+#tab-tlshybrid:checked ~ .ex-menu label[for="tab-tlshybrid"],
 #tab-tlspipe:checked ~ .ex-menu label[for="tab-tlspipe"] {
   color: var(--accent-soft);
   border-left-color: var(--accent-soft);
@@ -335,6 +337,7 @@ nav.top .links a.gh svg { display: block; }
 #tab-vs:checked ~ .pane-vs { display: block; }
 #tab-tlsosslpipe:checked ~ .pane-tlsosslpipe { display: block; }
 #tab-tlsossl:checked ~ .pane-tlsossl { display: block; }
+#tab-tlsmulti:checked ~ .pane-tlsmulti { display: block; }
 #tab-tlsbcl:checked ~ .pane-tlsbcl { display: block; }
 #tab-big:checked ~ .pane-big { display: block; }
 #tab-hop:checked ~ .pane-hop { display: block; }
@@ -364,6 +367,7 @@ nav.top .links a.gh svg { display: block; }
 #tab-redis:checked ~ .pane-redis { display: block; }
 #tab-files:checked ~ .pane-files { display: block; }
 #tab-tls:checked ~ .pane-tls { display: block; }
+#tab-tlshybrid:checked ~ .pane-tlshybrid { display: block; }
 #tab-tlspipe:checked ~ .pane-tlspipe { display: block; }
 .pane pre {
   margin: 0;
@@ -463,6 +467,7 @@ nav.top .links a.gh svg { display: block; }
   #tab-vs:checked ~ .ex-menu label[for="tab-vs"],
   #tab-tlsosslpipe:checked ~ .ex-menu label[for="tab-tlsosslpipe"],
   #tab-tlsossl:checked ~ .ex-menu label[for="tab-tlsossl"],
+  #tab-tlsmulti:checked ~ .ex-menu label[for="tab-tlsmulti"],
   #tab-tlsbcl:checked ~ .ex-menu label[for="tab-tlsbcl"],
   #tab-big:checked ~ .ex-menu label[for="tab-big"],
   #tab-hop:checked ~ .ex-menu label[for="tab-hop"],
@@ -492,6 +497,7 @@ nav.top .links a.gh svg { display: block; }
   #tab-redis:checked ~ .ex-menu label[for="tab-redis"],
   #tab-files:checked ~ .ex-menu label[for="tab-files"],
   #tab-tls:checked ~ .ex-menu label[for="tab-tls"],
+  #tab-tlshybrid:checked ~ .ex-menu label[for="tab-tlshybrid"],
   #tab-tlspipe:checked ~ .ex-menu label[for="tab-tlspipe"] {
     border-bottom-color: var(--accent-soft);
   }

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,9 +30,11 @@
   <input type="radio" name="mode-tabs" id="tab-hop">
   <input type="radio" name="mode-tabs" id="tab-taskrun">
   <input type="radio" name="mode-tabs" id="tab-tls">
+  <input type="radio" name="mode-tabs" id="tab-tlshybrid">
   <input type="radio" name="mode-tabs" id="tab-tlsossl">
   <input type="radio" name="mode-tabs" id="tab-tlspipe">
   <input type="radio" name="mode-tabs" id="tab-tlsosslpipe">
+  <input type="radio" name="mode-tabs" id="tab-tlsmulti">
   <input type="radio" name="mode-tabs" id="tab-tlsbcl">
   <input type="radio" name="mode-tabs" id="tab-qpipe">
   <input type="radio" name="mode-tabs" id="tab-qraw">
@@ -77,9 +79,11 @@
     <details class="ex-sect">
       <summary>tls</summary>
       <label for="tab-tls">ktls &middot; raw</label>
+      <label for="tab-tlshybrid">hybrid &middot; raw</label>
       <label for="tab-tlsossl">openssl &middot; raw</label>
       <label for="tab-tlspipe">ktls &middot; pipes</label>
       <label for="tab-tlsosslpipe">openssl &middot; pipes</label>
+      <label for="tab-tlsmulti">plaintext + tls</label>
       <label for="tab-tlsbcl">sslstream</label>
     </details>
 
@@ -168,6 +172,156 @@
     </p>
 
     <p class="ex-hint">Pick an example to see the code</p>
+  </div>
+  <div class="pane pane-tlsmulti">
+    <div class="pane-head">
+      <h3>plaintext + TLS &middot; one server</h3>
+      <span class="pane-pkg">ioxide</span>
+    </div>
+<pre><code class="language-csharp">// dotnet add package ioxide
+//   curl  http://127.0.0.1:8080/
+//   curl -ks https://127.0.0.1:8081/
+
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Text;
+using ioxide;
+using ioxide.tls;
+
+// ── Knobs ────────────────────────────────────────────────────────────────────────────────────
+
+ushort port     = 8080;                        // http://127.0.0.1:8080/  - the plaintext door
+ushort tlsPort  = 8081;                        // https://127.0.0.1:8081/ - the TLS door
+int    reactors = Environment.ProcessorCount;  // one ring per reactor, one reactor per core
+
+
+const string certPath = &quot;cert.pem&quot;;   // any PEM pair
+const string keyPath  = &quot;key.pem&quot;;
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+
+var config = new ServerConfig
+{
+    ReactorCount = reactors,
+    Tcp = new TcpOptions
+    {
+        Port = port,
+        ExtraPorts = [tlsPort],   // every reactor listens on both; ListenerPort says which one accepted
+    },
+};
+
+// Default backend: OpenSSL in both directions. Only connections on the TLS door go near this.
+var tlsOptions = new TlsOptions
+{
+    CertificatePath = certPath,
+    KeyPath         = keyPath,
+};
+
+const string bodyText = &quot;multiport-ok\n&quot;;
+byte[] response = Encoding.ASCII.GetBytes(
+    $&quot;HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {bodyText.Length}\r\n\r\n{bodyText}&quot;);
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i &lt; threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    reactor.OnStart = r =&gt; TlsService.Start(r, tlsOptions);
+
+    reactor.TcpHandle = async (r, conn) =&gt;
+    {
+        TlsSession? tls = null;
+        try
+        {
+            // Which door? This branch is the entire difference between the two.
+            if (conn.ListenerPort == tlsPort)
+            {
+                tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
+                await using var pipe = new TlsConnectionDualPipe(conn, tls, ownsSession: false);
+                await ServeAsync(pipe, response);
+            }
+            else
+            {
+                var pipe = new PlainPipe(new TcpConnectionPipeReader(conn), new TcpConnectionPipeWriter(conn));
+                try
+                {
+                    await ServeAsync(pipe, response);
+                }
+                finally
+                {
+                    pipe.Input.Complete();
+                    pipe.Output.Complete();
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($&quot;[tls-multiport] connection failed: {e.Message}&quot;);
+        }
+        finally
+        {
+            tls?.Dispose();
+            conn.DecRef();
+        }
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $&quot;reactor-{i}&quot; };
+    threads[i].Start();
+}
+
+Console.WriteLine($&quot;[tls-multiport] {config.ReactorCount} reactors, &quot;
+                + $&quot;plaintext :{config.Tcp!.Port}, tls :{tlsPort} (openssl both ways), cert {certPath}&quot;);
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}
+
+// One loop for both doors. It reads an IDuplexPipe and nothing else - whether the bytes were
+// decrypted on the way in, or will be encrypted on the way out, is not visible from here.
+static async Task ServeAsync(IDuplexPipe pipe, ReadOnlyMemory&lt;byte&gt; response)
+{
+    while (true)
+    {
+        ReadResult read = await pipe.Input.ReadAsync();
+
+        // Answer per REQUEST, not per read - a request split across reads must not draw two
+        // responses, and two requests in one read must not draw one.
+        int answered = 0;
+        SequencePosition consumed = read.Buffer.Start;
+
+        var reader = new SequenceReader&lt;byte&gt;(read.Buffer);
+        while (reader.TryReadTo(out ReadOnlySequence&lt;byte&gt; _, &quot;\r\n\r\n&quot;u8, advancePastDelimiter: true))
+        {
+            consumed = reader.Position;
+            answered++;
+        }
+
+        // Consumed only whole requests; examined everything, so a partial head parks until more
+        // arrives instead of spinning on the same bytes.
+        pipe.Input.AdvanceTo(consumed, read.Buffer.End);
+
+        for (int n = 0; n &lt; answered; n++)
+        {
+            pipe.Output.Write(response.Span);
+        }
+
+        if (answered &gt; 0)
+        {
+            await pipe.Output.FlushAsync();
+        }
+
+        if (read.IsCompleted || read.IsCanceled)
+        {
+            return;
+        }
+    }
+}
+
+// The plaintext door&#x27;s IDuplexPipe: the connection&#x27;s own reader and writer, paired.
+sealed record PlainPipe(PipeReader Input, PipeWriter Output) : IDuplexPipe;</code></pre>
+    <p class="ex-foot">One server, two doors: plaintext on <code>:8080</code>, TLS on <code>:8081</code>, and ONE serve loop for both. The branch on <code>ListenerPort</code> is the entire difference - the TLS door builds a <code>TlsConnectionDualPipe</code>, the plaintext door pairs the connection's own reader and writer, and the loop reads an <code>IDuplexPipe</code> without knowing which it got. Ports come from <a href="learn/multiport.html">multi-port</a>; TLS is the default backend, OpenSSL both ways.</p>
   </div>
   <div class="pane pane-tlsbcl">
     <div class="pane-head">
@@ -1696,6 +1850,198 @@ foreach (Thread thread in threads)
     thread.Join();
 }</code></pre>
     <p class="ex-foot">The same full-kTLS server behind an <code>IDuplexPipe</code>, for the frameworks that serve from one. Now compare <label for="tab-tlsosslpipe" class="ex-jump">openssl &middot; pipes</label>: its serve loop is <b>byte-identical</b> to this one. Over a pipe the backend is invisible, because <code>TlsConnectionDualPipe</code> composes its halves from the session rather than from configuration.</p>
+  </div>
+  <div class="pane pane-tlshybrid">
+    <div class="pane-head">
+      <h3>hybrid &middot; raw ring</h3>
+      <span class="pane-pkg">ioxide</span>
+    </div>
+<pre><code class="language-csharp">// dotnet add package ioxide
+//   sudo modprobe tls        # the kernel half still needs the module
+//   curl -k https://127.0.0.1:8443/
+
+using System.Text;
+using ioxide;
+using ioxide.tls;
+using ioxide.utils;
+
+// ── Knobs ────────────────────────────────────────────────────────────────────────────────────
+
+ushort port      = 8443;                        // https://127.0.0.1:8443/
+int    reactors  = Environment.ProcessorCount;  // one ring per reactor, one reactor per core
+int    bodyBytes = 8 * 1024;                    // TLS cost is per-byte, so a 2-byte &quot;ok&quot; would hide it
+
+
+const string certPath = &quot;cert.pem&quot;;   // any PEM pair
+const string keyPath  = &quot;key.pem&quot;;
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+
+var config = new ServerConfig
+{
+    ReactorCount = reactors,
+    Tcp = new TcpOptions
+    {
+        Port = port,
+    },
+};
+
+var tlsOptions = new TlsOptions
+{
+    CertificatePath = certPath,
+    KeyPath         = keyPath,
+
+    // NOT the default - TLS is OpenSSL both ways unless you ask for this. It is what lets the
+    // handler below write PLAINTEXT to the connection: the kernel turns it into records on send.
+    // Remove this line and conn.Write would put cleartext on the wire.
+    KernelTx = true,
+};
+
+byte[] body = new byte[bodyBytes];
+ReadOnlySpan&lt;byte&gt; fill = &quot;ioxide-hybrid-tls &quot;u8;
+for (int i = 0; i &lt; bodyBytes; i++)
+{
+    body[i] = fill[i % fill.Length];
+}
+byte[] response =
+[
+    .. Encoding.ASCII.GetBytes($&quot;HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {bodyBytes}\r\n\r\n&quot;),
+    .. body,
+];
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i &lt; threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    // One TlsService per reactor: it owns the OpenSSL contexts and drives handshakes on this ring.
+    reactor.OnStart = r =&gt; TlsService.Start(r, tlsOptions);
+
+    reactor.TcpHandle = async (r, conn) =&gt;
+    {
+        TlsSession? tls = null;
+
+        // Decrypted bytes waiting to be framed. TLS hands back records, not requests: split one
+        // request across two records and each decrypts on its own, so answering per decrypt
+        // answers twice. The carry is what turns &quot;some plaintext arrived&quot; into &quot;a request
+        // arrived&quot;, exactly as the plaintext samples do - ioxide does not parse HTTP for you.
+        var carry = new Carry();
+
+        try
+        {
+            tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
+
+            // A request can ride in with the handshake&#x27;s final flight - answer it before parking
+            // in ReadAsync, or the client waits on a response we never send.
+            carry.Append(tls.DrainPlaintext());
+            if (Answer(conn, carry, response))
+            {
+                await conn.FlushAsync();
+            }
+
+            while (true)
+            {
+                RecvSnapshot snapshot = await conn.ReadAsync();
+
+                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                {
+                    if (item.HasBuffer)
+                    {
+                        // Records in, plaintext out - the session decrypts what the ring received.
+                        Decrypt(tls, in item, carry);
+                        conn.ReturnBuffer(in item);
+                    }
+                }
+
+                if (Answer(conn, carry, response))
+                {
+                    await conn.FlushAsync();
+                }
+
+                if (snapshot.IsClosed || tls.Closed) return;
+                conn.ResetRead();
+            }
+        }
+        catch (Exception e)
+        {
+            // Handlers run fire-and-forget, so a thrown handshake error would vanish silently -
+            // and a missing &#x27;tls&#x27; kernel module manifests exactly here.
+            Console.Error.WriteLine($&quot;[tls-hybrid] connection failed: {e.Message}&quot;);
+        }
+        finally
+        {
+            tls?.Dispose();
+            conn.DecRef();
+        }
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $&quot;reactor-{i}&quot; };
+    threads[i].Start();
+}
+
+Console.WriteLine($&quot;[tls-hybrid] {config.ReactorCount} reactors on :{config.Tcp!.Port}, &quot;
+                + $&quot;{bodyBytes}-byte body, tx=kernel, rx=openssl, cert {certPath}&quot;);
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}
+
+// Decrypt takes a raw pointer (the buffer belongs to the ring); the pointer work stays out of the
+// async handler, which cannot contain unsafe code.
+static unsafe void Decrypt(TlsSession tls, in SpscRecvRing.Item item, Carry carry)
+    =&gt; carry.Append(tls.Decrypt(item.Ptr, item.Len));
+
+// One response per COMPLETE request in the carry, and none for a partial one. Returns whether
+// anything was written, so the caller flushes once for the batch rather than once per request.
+static bool Answer(TcpConnection conn, Carry carry, ReadOnlyMemory&lt;byte&gt; response)
+{
+    bool wrote = false;
+    int end;
+
+    while ((end = carry.Span.IndexOf(&quot;\r\n\r\n&quot;u8)) &gt;= 0)
+    {
+        carry.Consume(end + 4);
+
+        // PLAINTEXT into the slab - safe only because KernelTx = true above. TlsSession.Write
+        // is the call that is correct either way, and is what every other sample uses; this one
+        // spells it out because demonstrating the kTLS write path is the point of the file.
+        conn.Write(response.Span);
+
+        wrote = true;
+    }
+
+    return wrote;
+}
+
+// Decrypted-but-unframed bytes: append at the end, consume from the front. A List&lt;byte&gt; pressed
+// into this job needs CollectionsMarshal to be searched and RemoveRange to be consumed; a plain
+// array does both directly.
+sealed class Carry
+{
+    private byte[] _buf = new byte[8 * 1024];
+    private int _len;
+
+    public ReadOnlySpan&lt;byte&gt; Span =&gt; _buf.AsSpan(0, _len);
+
+    public void Append(ReadOnlySpan&lt;byte&gt; bytes)
+    {
+        if (_buf.Length - _len &lt; bytes.Length)
+        {
+            Array.Resize(ref _buf, Math.Max(_buf.Length * 2, _len + bytes.Length));
+        }
+        bytes.CopyTo(_buf.AsSpan(_len));
+        _len += bytes.Length;
+    }
+
+    public void Consume(int count)
+    {
+        _buf.AsSpan(count, _len - count).CopyTo(_buf);
+        _len -= count;
+    }
+}</code></pre>
+    <p class="ex-foot">The deployable kernel mode: <b>kernel TX, OpenSSL RX</b>. The handler still writes plaintext - the kernel makes the records on send, which is what keeps <code>sendfile</code> and NIC offload reachable - while receive takes the well-trodden userspace path instead of kernel RX's experimental one. <label for="tab-tls" class="ex-jump">ktls &middot; raw</label> is this plus kernel receive; <label for="tab-tlsossl" class="ex-jump">openssl &middot; raw</label> is the default, with the kernel in neither direction.</p>
   </div>
   <div class="pane pane-tlsossl">
     <div class="pane-head">

--- a/ioxide.slnx
+++ b/ioxide.slnx
@@ -48,6 +48,7 @@
     <Project Path="Playground/Tls/Ktls/Playground.Tls.Ktls.csproj" />
     <Project Path="Playground/Tls/Hybrid/Playground.Tls.Hybrid.csproj" />
     <Project Path="Playground/Tls/KtlsPipes/Playground.Tls.KtlsPipes.csproj" />
+    <Project Path="Playground/Tls/MultiPort/Playground.Tls.MultiPort.csproj" />
     <Project Path="Playground/Tls/OpenSsl/Playground.Tls.OpenSsl.csproj" />
     <Project Path="Playground/Tls/OpenSslPipes/Playground.Tls.OpenSslPipes.csproj" />
     <Project Path="Playground/Tls/SslStream/Playground.Tls.SslStream.csproj" />

--- a/scripts/gen-docs-panes.py
+++ b/scripts/gen-docs-panes.py
@@ -23,6 +23,17 @@ PANES = {
         "wire</b>, which is why every other sample goes through <code>TlsSession.Write</code> - "
         "correct in either mode. Compare "
         "<label for=\"tab-tlsossl\" class=\"ex-jump\">openssl &middot; raw</label>."),
+    "tlshybrid": (
+        "Tls/Hybrid", "hybrid &middot; raw ring", "ioxide",
+        ["sudo modprobe tls        # the kernel half still needs the module",
+         "curl -k https://127.0.0.1:8443/"],
+        "The deployable kernel mode: <b>kernel TX, OpenSSL RX</b>. The handler still writes "
+        "plaintext - the kernel makes the records on send, which is what keeps <code>sendfile</code> "
+        "and NIC offload reachable - while receive takes the well-trodden userspace path instead of "
+        "kernel RX's experimental one. "
+        "<label for=\"tab-tls\" class=\"ex-jump\">ktls &middot; raw</label> is this plus kernel "
+        "receive; <label for=\"tab-tlsossl\" class=\"ex-jump\">openssl &middot; raw</label> is the "
+        "default, with the kernel in neither direction."),
     "tlsossl": (
         "Tls/OpenSsl", "OpenSSL &middot; raw ring", "ioxide",
         ["curl -k https://127.0.0.1:8443/        # no modprobe needed"],
@@ -52,6 +63,15 @@ PANES = {
         "<code>TcpConnectionPipeWriter</code> or <code>TlsEncryptingPipeWriter</code>, chosen from the "
         "<em>session</em>. It has to be the session and not the config, because a handshake that left a "
         "partial record keeps the userspace reader whatever was asked for."),
+    "tlsmulti": (
+        "Tls/MultiPort", "plaintext + TLS &middot; one server", "ioxide",
+        ["curl  http://127.0.0.1:8080/", "curl -ks https://127.0.0.1:8081/"],
+        "One server, two doors: plaintext on <code>:8080</code>, TLS on <code>:8081</code>, and ONE "
+        "serve loop for both. The branch on <code>ListenerPort</code> is the entire difference - "
+        "the TLS door builds a <code>TlsConnectionDualPipe</code>, the plaintext door pairs the "
+        "connection's own reader and writer, and the loop reads an <code>IDuplexPipe</code> without "
+        "knowing which it got. Ports come from <a href=\"learn/multiport.html\">multi-port</a>; "
+        "TLS is the default backend, OpenSSL both ways."),
 
     # ── transport ────────────────────────────────────────────────────────────────────────────
     "tlsbcl": (


### PR DESCRIPTION
Two additions, both requested.

**The hybrid gets its pane.** `Tls/Hybrid` existed in the repo but not on the site; now "hybrid · raw ring" sits between ktls and openssl in the tls tab group, with a note that places the three raw modes in one line: openssl (default) / hybrid (deployable kernel TX) / ktls (full, experimental). New tabs need the full plumbing - radio input, label, ID-specific CSS in both the desktop and media-query blocks, and the pane skeleton the generator fills.

**`Tls/MultiPort`** - the [multi-port](docs/learn/multiport.html) pattern made concrete, served through pipes: plaintext on `:8080`, TLS on `:8081` via `ExtraPorts`, and **one serve loop for both doors**. The branch on `ListenerPort` is the entire difference: the TLS door terminates with the default backend (OpenSSL both ways, no kernel module) and serves through `TlsConnectionDualPipe`; the plaintext door pairs the connection's own reader and writer behind a one-line `record`. `ServeAsync` reads an `IDuplexPipe` and cannot tell which door it got.

Verified: both doors serve 200, and two requests pipelined into one TCP segment draw exactly two responses on **each** door through the same loop. Solution registered in slnx, README row added, panes regenerated (site carries 15 now).