### PR TITLE
feat(tls): PEM-from-memory options, multi-context Start; bump to 0.4.161

### DIFF
--- a/src/clients/ioxide.file/ioxide.file.csproj
+++ b/src/clients/ioxide.file/ioxide.file.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.file</RootNamespace>
 
     <PackageId>ioxide.file</PackageId>
-    <Version>0.4.156</Version>
+    <Version>0.4.161</Version>
     <Authors>MDA2AV</Authors>
     <Description>File serving for the ioxide io_uring runtime: immutable asset snapshots with baked responses, pooled positional ring reads, atomic reloads.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
+++ b/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.httpclient</RootNamespace>
 
     <PackageId>ioxide.httpclient</PackageId>
-    <Version>0.4.156</Version>
+    <Version>0.4.161</Version>
     <Authors>MDA2AV</Authors>
     <Description>The ring-native HTTP client for the ioxide io_uring runtime: HTTP/1.1, HTTP/2 and HTTP/3 behind one API, with the protocol chosen per origin via Alt-Svc. One package - the h1 parser, the nghttp2 and nghttp3 bridges, client-side TLS (SNI, ALPN and certificate verification) for https:// origins, and the negotiating client - sharing one set of message types. Every response resumes the awaiting handler inline on its own reactor thread.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.pg/ioxide.pg.csproj
+++ b/src/clients/ioxide.pg/ioxide.pg.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.pg</RootNamespace>
 
     <PackageId>ioxide.pg</PackageId>
-    <Version>0.4.156</Version>
+    <Version>0.4.161</Version>
     <Authors>MDA2AV</Authors>
     <Description>Postgres driver for the ioxide io_uring runtime: pooled ring-native connections per reactor, ring-native connect and handshake, inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.redis/ioxide.redis.csproj
+++ b/src/clients/ioxide.redis/ioxide.redis.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.redis</RootNamespace>
 
     <PackageId>ioxide.redis</PackageId>
-    <Version>0.4.156</Version>
+    <Version>0.4.161</Version>
     <Authors>MDA2AV</Authors>
     <Description>Redis client for the ioxide io_uring runtime: pooled ring-native connections per reactor, full RESP2 protocol, a generic command API plus typed helpers (strings, keys, hashes, lists, sets, sorted sets, pub/sub, transactions, scripting), and pipelining. Inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ioxide/Tls/Interop/OpenSsl.cs
+++ b/src/ioxide/Tls/Interop/OpenSsl.cs
@@ -14,6 +14,7 @@ internal static unsafe partial class OpenSsl
     public const int SSL_ERROR_ZERO_RETURN = 6;
     public const int SSL_CTRL_SET_MIN_PROTO_VERSION = 123;
     public const int SSL_CTRL_SET_MAX_PROTO_VERSION = 124;
+    public const int SSL_CTRL_EXTRA_CHAIN_CERT = 14;
     public const int TLS1_3_VERSION = 0x0304;
     public const int SSL_TLSEXT_ERR_OK = 0;
     public const int SSL_TLSEXT_ERR_NOACK = 3;
@@ -59,6 +60,18 @@ internal static unsafe partial class OpenSsl
 
     [LibraryImport(Crypto)] public static partial nint BIO_new(nint type);
     [LibraryImport(Crypto)] public static partial nint BIO_s_mem();
+    [LibraryImport(Crypto)] public static partial nint BIO_new_mem_buf(byte* buf, int len);
+    [LibraryImport(Crypto)] public static partial int BIO_free(nint bio);
+
+    // PEM-from-memory loading: the same certificate/key material a chain file carries, read
+    // through a memory BIO instead. The password-callback arguments are always null here.
+    [LibraryImport(Crypto)] public static partial nint PEM_read_bio_X509(nint bio, nint x, nint cb, nint u);
+    [LibraryImport(Crypto)] public static partial nint PEM_read_bio_PrivateKey(nint bio, nint pkey, nint cb, nint u);
+    [LibraryImport(Crypto)] public static partial void X509_free(nint x509);
+    [LibraryImport(Crypto)] public static partial void EVP_PKEY_free(nint pkey);
+    [LibraryImport(Crypto)] public static partial void ERR_clear_error();
+    [LibraryImport(Ssl)] public static partial int SSL_CTX_use_certificate(nint ctx, nint x509);
+    [LibraryImport(Ssl)] public static partial int SSL_CTX_use_PrivateKey(nint ctx, nint pkey);
     [LibraryImport(Crypto)] public static partial int BIO_write(nint bio, byte* data, int dlen);
     [LibraryImport(Crypto)] public static partial int BIO_read(nint bio, byte* data, int dlen);
     [LibraryImport(Crypto)] public static partial nuint BIO_ctrl_pending(nint bio);

--- a/src/ioxide/Tls/TlsOptions.cs
+++ b/src/ioxide/Tls/TlsOptions.cs
@@ -2,11 +2,22 @@ namespace ioxide.tls;
 
 public sealed class TlsOptions
 {
-    /// <summary>PEM certificate chain file.</summary>
-    public required string CertificatePath { get; init; }
+    /// <summary>PEM certificate chain file. Exactly one of this and <see cref="CertificatePem"/>
+    /// must be set - <see cref="TlsService.Start"/> refuses anything else.</summary>
+    public string? CertificatePath { get; init; }
 
-    /// <summary>PEM private key file.</summary>
-    public required string KeyPath { get; init; }
+    /// <summary>PEM private key file. Exactly one of this and <see cref="KeyPem"/> must be set.</summary>
+    public string? KeyPath { get; init; }
+
+    /// <summary>
+    /// The certificate chain as PEM text, leaf first - the in-memory alternative to
+    /// <see cref="CertificatePath"/>, for hosts that carry certificates as data (an
+    /// <c>X509Certificate2</c> export, a secrets store) rather than as files on disk.
+    /// </summary>
+    public string? CertificatePem { get; init; }
+
+    /// <summary>The private key as PEM text - the in-memory alternative to <see cref="KeyPath"/>.</summary>
+    public string? KeyPem { get; init; }
 
     /// <summary>
     /// Protocols this port serves, MOST PREFERRED FIRST. The client sends what it supports and the

--- a/src/ioxide/Tls/TlsService.cs
+++ b/src/ioxide/Tls/TlsService.cs
@@ -34,7 +34,12 @@ public sealed class TlsService
     }
 
     /// <summary>Create the per-reactor service and register it. Call from <c>Reactor.OnStart</c>.</summary>
-    public static TlsService Start(Reactor reactor, TlsOptions options)
+    /// <param name="register">
+    /// When false the service is not registered on the reactor - for hosts that run SEVERAL TLS
+    /// contexts on one reactor (one per listen port, say) and hold the instances themselves.
+    /// <see cref="Reactor.GetService{T}"/> only ever returns the last registered one.
+    /// </param>
+    public static TlsService Start(Reactor reactor, TlsOptions options, bool register = true)
     {
         // RX alone cannot be programmed: the handoff shares the TCP_ULP that EnableTx installs.
         // Refuse loudly rather than silently serving the userspace path the caller opted out of.
@@ -43,6 +48,19 @@ public sealed class TlsService
             throw new ArgumentException(
                 "KernelRx requires KernelTx: kTLS RX is programmed at the same handoff as TX. " +
                 "Set KernelTx = true as well, or drop KernelRx.", nameof(options));
+        }
+
+        // The certificate and key each come from exactly one place - a path or in-memory PEM.
+        // Neither set (possible now that the path is not `required`) and both set are refused.
+        if ((options.CertificatePath is null) == (options.CertificatePem is null))
+        {
+            throw new ArgumentException(
+                "Exactly one certificate source: set CertificatePath or CertificatePem.", nameof(options));
+        }
+        if ((options.KeyPath is null) == (options.KeyPem is null))
+        {
+            throw new ArgumentException(
+                "Exactly one key source: set KeyPath or KeyPem.", nameof(options));
         }
 
         nint ctx = OpenSsl.SSL_CTX_new(OpenSsl.TLS_server_method());
@@ -69,14 +87,7 @@ public sealed class TlsService
             OpenSsl.SSL_CTX_set_num_tickets(ctx, 0);
         }
 
-        if (OpenSsl.SSL_CTX_use_certificate_chain_file(ctx, options.CertificatePath) != 1)
-        {
-            throw new IOException($"certificate '{options.CertificatePath}': {OpenSsl.LastError()}");
-        }
-        if (OpenSsl.SSL_CTX_use_PrivateKey_file(ctx, options.KeyPath, OpenSsl.SSL_FILETYPE_PEM) != 1)
-        {
-            throw new IOException($"private key '{options.KeyPath}': {OpenSsl.LastError()}");
-        }
+        LoadCertificate(ctx, options);
 
         // The ALPN protocol to select is handed to the (static) callback via its arg, so the
         // configured TlsOptions.Alpn is honored instead of being hard-coded.
@@ -93,8 +104,123 @@ public sealed class TlsService
         }
 
         var service = new TlsService(ctx, alpnHandle, options.KernelRx, options.KernelTx);
-        reactor.AddService(service);
+        if (register)
+        {
+            reactor.AddService(service);
+        }
         return service;
+    }
+
+    // Certificate and key, from whichever source the options carry. The file route is OpenSSL's
+    // own loaders; the in-memory route reads the same PEM through a memory BIO.
+    private static void LoadCertificate(nint ctx, TlsOptions options)
+    {
+        if (options.CertificatePath is not null)
+        {
+            if (OpenSsl.SSL_CTX_use_certificate_chain_file(ctx, options.CertificatePath) != 1)
+            {
+                throw new IOException($"certificate '{options.CertificatePath}': {OpenSsl.LastError()}");
+            }
+        }
+        else
+        {
+            LoadCertificatePem(ctx, options.CertificatePem!);
+        }
+
+        if (options.KeyPath is not null)
+        {
+            if (OpenSsl.SSL_CTX_use_PrivateKey_file(ctx, options.KeyPath, OpenSsl.SSL_FILETYPE_PEM) != 1)
+            {
+                throw new IOException($"private key '{options.KeyPath}': {OpenSsl.LastError()}");
+            }
+        }
+        else
+        {
+            LoadKeyPem(ctx, options.KeyPem!);
+        }
+    }
+
+    private static unsafe void LoadCertificatePem(nint ctx, string pem)
+    {
+        byte[] bytes = System.Text.Encoding.ASCII.GetBytes(pem);
+        fixed (byte* p = bytes)
+        {
+            // The memory BIO reads the pinned buffer in place, so the fixed block spans every read.
+            nint bio = OpenSsl.BIO_new_mem_buf(p, bytes.Length);
+            if (bio == 0)
+            {
+                throw new IOException($"CertificatePem: {OpenSsl.LastError()}");
+            }
+
+            try
+            {
+                // First PEM block is the leaf; use_certificate takes its own reference.
+                nint leaf = OpenSsl.PEM_read_bio_X509(bio, 0, 0, 0);
+                if (leaf == 0)
+                {
+                    throw new IOException($"CertificatePem carries no certificate: {OpenSsl.LastError()}");
+                }
+                int ok = OpenSsl.SSL_CTX_use_certificate(ctx, leaf);
+                OpenSsl.X509_free(leaf);
+                if (ok != 1)
+                {
+                    throw new IOException($"CertificatePem: {OpenSsl.LastError()}");
+                }
+
+                // Any further blocks are the chain, closest-to-leaf first, exactly as in a chain
+                // file. add_extra_chain_cert takes ownership on success, so no free there.
+                while (true)
+                {
+                    nint extra = OpenSsl.PEM_read_bio_X509(bio, 0, 0, 0);
+                    if (extra == 0)
+                    {
+                        OpenSsl.ERR_clear_error();   // end-of-data queues PEM_R_NO_START_LINE
+                        break;
+                    }
+                    if (OpenSsl.SSL_CTX_ctrl(ctx, OpenSsl.SSL_CTRL_EXTRA_CHAIN_CERT, 0, extra) != 1)
+                    {
+                        OpenSsl.X509_free(extra);
+                        throw new IOException($"CertificatePem chain: {OpenSsl.LastError()}");
+                    }
+                }
+            }
+            finally
+            {
+                OpenSsl.BIO_free(bio);
+            }
+        }
+    }
+
+    private static unsafe void LoadKeyPem(nint ctx, string pem)
+    {
+        byte[] bytes = System.Text.Encoding.ASCII.GetBytes(pem);
+        fixed (byte* p = bytes)
+        {
+            nint bio = OpenSsl.BIO_new_mem_buf(p, bytes.Length);
+            if (bio == 0)
+            {
+                throw new IOException($"KeyPem: {OpenSsl.LastError()}");
+            }
+
+            try
+            {
+                nint key = OpenSsl.PEM_read_bio_PrivateKey(bio, 0, 0, 0);
+                if (key == 0)
+                {
+                    throw new IOException($"KeyPem carries no private key: {OpenSsl.LastError()}");
+                }
+                int ok = OpenSsl.SSL_CTX_use_PrivateKey(ctx, key);
+                OpenSsl.EVP_PKEY_free(key);
+                if (ok != 1)
+                {
+                    throw new IOException($"KeyPem: {OpenSsl.LastError()}");
+                }
+            }
+            finally
+            {
+                OpenSsl.BIO_free(bio);
+            }
+        }
     }
 
     /// <summary>

--- a/src/ioxide/ioxide.csproj
+++ b/src/ioxide/ioxide.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide</RootNamespace>
 
     <PackageId>ioxide</PackageId>
-    <Version>0.4.156</Version>
+    <Version>0.4.161</Version>
     <Authors>MDA2AV</Authors>
     <Description>A shared-nothing io_uring runtime for .NET: one ring per reactor thread, inline completions, zero native dependencies. The engine - reactor, connection, and the IRingHost client seam. Includes TLS termination: the OpenSSL handshake driven over the ring, then kernel TLS (kTLS) transmit offload, so handlers keep writing plaintext. TLS needs OpenSSL 3 and the Linux tls module; nothing else does, and neither is loaded unless you use it.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http2/ioxide.http2.csproj
+++ b/src/protocols/ioxide.http2/ioxide.http2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http2</RootNamespace>
 
     <PackageId>ioxide.http2</PackageId>
-    <Version>0.4.156</Version>
+    <Version>0.4.161</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure-C# HTTP/2 for the ioxide io_uring runtime: framing, HPACK (static and dynamic tables, Huffman) and flow control, with zero native code. A drop-in alternative to ioxide.nghttp2 for deployments that would rather not ship a native library - same connection shape, same request and response types.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http3/ioxide.http3.csproj
+++ b/src/protocols/ioxide.http3/ioxide.http3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http3</RootNamespace>
 
     <PackageId>ioxide.http3</PackageId>
-    <Version>0.4.156</Version>
+    <Version>0.4.161</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure C# HTTP/3 for the ioxide io_uring runtime: frame parsing, QPACK (static table + Huffman) and request dispatch with zero native dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, drop-in alternative to ioxide.nghttp3.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
+++ b/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp2</RootNamespace>
 
     <PackageId>ioxide.nghttp2</PackageId>
-    <Version>0.4.156</Version>
+    <Version>0.4.161</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/2 for the ioxide io_uring runtime: framing, HPACK and flow control from nghttp2, statically linked behind a small shim with no external dependencies beyond libc. Serves HTTP/2 over any TcpConnection - h2c with prior knowledge, or h2 over TLS via ALPN - and backs the HTTP/2 client in ioxide.httpclient from the same session code. nghttp2 is sans-I/O, so ioxide keeps the ring and the loop.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
+++ b/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp3</RootNamespace>
 
     <PackageId>ioxide.nghttp3</PackageId>
-    <Version>0.4.156</Version>
+    <Version>0.4.161</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/3 layer for the ioxide io_uring runtime: nghttp3 (H3 + QPACK) bundled as a single self-contained native library with no external dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, no ioxide.ngtcp2 dependency.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
+++ b/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.ngtcp2</RootNamespace>
 
     <PackageId>ioxide.ngtcp2</PackageId>
-    <Version>0.4.156</Version>
+    <Version>0.4.161</Version>
     <Authors>MDA2AV</Authors>
     <Description>QUIC engine for the ioxide io_uring runtime: ngtcp2 + picotls bundled as a single self-contained native library (only system dependency: libcrypto.so.3 / OpenSSL 3.x). Plugs into the reactor's QUIC transport via QuicConnection. Server side; engine bindings in progress.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
+++ b/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.Kestrel</RootNamespace>
 
     <PackageId>ioxide.Kestrel</PackageId>
-    <Version>0.4.156</Version>
+    <Version>0.4.161</Version>
     <Authors>MDA2AV</Authors>
     <Description>ASP.NET Core Kestrel transport backed by the ioxide io_uring runtime: one reactor (ring) per core, SO_REUSEPORT load-balanced, with Kestrel's HTTP request loop pinned to the reactor thread. Drop-in via UseIoxide().</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/Ioxide.Tests.Tls/TlsTests.cs
+++ b/tests/Ioxide.Tests.Tls/TlsTests.cs
@@ -20,6 +20,22 @@ internal static class TlsTests
             Assert.Equal("tls-ok", body);
         });
 
+        runner.Test("tls: in-memory PEM options serve a request", () =>
+        {
+            // The same material the path route loads, handed over as text - the route a host takes
+            // when its certificate lives in a store or an X509Certificate2, not on disk.
+            (string certPath, string keyPath) = TestCert.Ensure();
+            var options = new TlsOptions
+            {
+                CertificatePem = File.ReadAllText(certPath),
+                KeyPem = File.ReadAllText(keyPath),
+            };
+            int port = TestServer.Start(Handlers.Tls, r => TlsService.Start(r, options));
+            (int status, string body) = Client.GetTls(port, "/");
+            Assert.Equal(200, status);
+            Assert.Equal("tls-ok", body);
+        });
+
         // The opt-in path: EnableTx programs the keys, Write switches to bare slab writes, the
         // MSG_WAITALL flag is cleared, close_notify goes out as a kTLS control send. None of that
         // executes under the default any more, so this round-trip is its entire coverage.


### PR DESCRIPTION
The ioxide half of the GenHTTP-engine plan: publish a version whose TLS surface the engine's improvements can actually build on.

**`TlsOptions.CertificatePem` / `KeyPem`** - the chain and key as PEM text, loaded through a memory BIO (`BIO_new_mem_buf` → `PEM_read_bio_X509`/`PEM_read_bio_PrivateKey`, leaf first, remaining blocks as extra chain certs - mirroring `use_certificate_chain_file`). For hosts that carry certificates as data (GenHTTP hands the adapter an `X509Certificate2`; a path-only option forces temp files). `CertificatePath`/`KeyPath` lose `required`, and `TlsService.Start` refuses anything but exactly one source for each - so the both-set and neither-set states fail loudly at startup, not at handshake.

**`TlsService.Start(reactor, options, register: false)`** - create a TLS context the reactor does not register. `GetService<TlsService>()` is last-write-wins by type, so a host terminating TLS on several ports with different certificates must hold its per-port instances itself; this makes that possible without touching the core service registry. Default unchanged.

**0.4.161** across all eleven packages - publishes on merge.

Verified: new in-memory-PEM round-trip test (suite now 15), all suites green (Unit 29, E2E 46, Http 35, File 2), and a wrk sanity run on tls-openssl sits within 1% of the committed baseline - the diff is startup-path only.

Next, once this publishes: bump ioxide in the GenHTTP engine, migrate its pre-rename API usage, replace the hand-rolled `TlsDuplexPipe`, and make endpoints with `.Security(...)` map natively onto `ExtraPorts` + per-port contexts.