### PR TITLE
docs(examples): every Playground sample and site pane shows its full knob set; bump 0.4.163

### DIFF
--- a/Playground/Clients/File/Program.cs
+++ b/Playground/Clients/File/Program.cs
@@ -30,14 +30,30 @@ int cacheMax = Env.Int("PLAYGROUND_CACHE_MAX", AssetCache.DefaultMaxCachedFileBy
 SampleAssets.Ensure(dir);   // writes a demo index.html + style.css if the directory is empty
 
 // Built once for the whole process, BEFORE the reactors start: every reactor shares this snapshot.
-var assets = new StaticAssets(dir, cacheMax);
+var assets = new StaticAssets(
+    dir,        // served root (PLAYGROUND_DIR); walked once into an immutable snapshot
+    cacheMax);  // maxCachedFileBytes: whole-response pin ceiling per file (0 = always ring-read)
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    ReactorCount   = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),  // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                                        // SQ/CQ depth per ring
+    DualStack      = false,                                                       // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                                                   // bytes per shared recv buffer
+    RecvSlots      = 4096,                                                        // shared recv buffer-ring depth
+    Incremental    = null,                                                        // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                                        // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                                        // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port             = Env.Port("PLAYGROUND_PORT", 8080),
+        ExtraPorts       = [],                                                    // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                                                  // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                                             // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                                                  // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,                            // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                                                 // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                                                    // per-connection recv completion queue depth
     },
 };
 
@@ -51,8 +67,10 @@ for (int i = 0; i < threads.Length; i++)
 
     reactor.OnStart = r =>
     {
-        r.AddService(assets);                                          // the shared snapshot
-        AssetReader.CreatePool(r, readers: 4, bufferBytes: 1 << 20);   // per-reactor ring readers
+        r.AddService(assets);   // the shared snapshot
+        AssetReader.CreatePool(r,
+            readers:     4,         // concurrent ring reads bounded per reactor (pool size)
+            bufferBytes: 1 << 20);  // native read buffer per reader (1 MiB) - size for the largest asset
     };
 
     reactor.TcpHandle = async (r, conn) =>

--- a/Playground/Clients/Https/Program.cs
+++ b/Playground/Clients/Https/Program.cs
@@ -45,10 +45,24 @@ bool insecure = false;
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                          // io_uring rings/threads - one per core
+    RingEntries    = 8192,                              // SQ/CQ depth per ring
+    DualStack      = false,                             // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                         // bytes per shared recv buffer
+    RecvSlots      = 4096,                              // shared recv buffer-ring depth
+    Incremental    = null,                              // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                              // no raw UDP sockets (TCP-only server)
+    Quic           = null,                              // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                          // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                        // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                   // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                        // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,  // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                       // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                          // per-connection recv completion queue depth
     },
 };
 
@@ -66,18 +80,24 @@ for (int i = 0; i < threads.Length; i++)
         // CA belongs in CaFile, not here.
         TlsClientContext tls = TlsClientContext.Create(new TlsClientOptions
         {
-            ServerName        = originName,
-            AlpnProtocols     = ["http/1.1"],
-            CaFile            = caFile,
-            VerifyCertificate = !insecure,
+            ServerName         = originName,             // sent as SNI, checked against the cert (required)
+            AlpnProtocols      = ["http/1.1"],           // offered most-preferred first; [] offers none
+            CaFile             = caFile,                 // PEM trust anchors; null = system store
+            VerifyCertificate  = !insecure,              // off = encrypted but UNAUTHENTICATED (tests only)
+            MinimumVersion     = OpenSslVersions.Tls12,  // lowest TLS accepted; Tls13 (0x0304) = 1.3-only
+            HandshakeTimeoutMs = 10_000,                 // handshake ceiling before the connect fails
         });
 
         HttpClientPool.Start(r, new HttpClientOptions
         {
-            Host     = originIp,
-            Port     = originPort,
-            PoolSize = 2,
-            Tls      = tls,
+            Host              = originIp,         // IPv4 literal - DNS would block the reactor
+            Port              = originPort,       // origin port
+            PoolSize          = 2,                // connections to the origin, per reactor
+            MaxResponseBytes  = 8 * 1024 * 1024,  // per-request ceiling for headers + body
+            SendBufferSize    = 16 * 1024,        // per-connection send buffer
+            ReceiveBufferSize = 16 * 1024,        // per-connection recv buffer; grows to MaxResponseBytes
+            Tls               = tls,              // TLS context for https; null = cleartext
+            AcquireTimeoutMs  = 10_000,           // wait for a free connection when all are busy
         });
     };
 

--- a/Playground/Clients/Pg/Program.cs
+++ b/Playground/Clients/Pg/Program.cs
@@ -23,22 +23,37 @@ using Playground.Shared;
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    ReactorCount   = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),  // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                                        // SQ/CQ depth per ring
+    DualStack      = false,                                                       // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                                                   // bytes per shared recv buffer
+    RecvSlots      = 4096,                                                        // shared recv buffer-ring depth
+    Incremental    = null,                                                        // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                                        // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                                        // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port             = Env.Port("PLAYGROUND_PORT", 8080),
+        ExtraPorts       = [],                                                    // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                                                  // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                                             // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                                                  // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,                            // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                                                 // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                                                    // per-connection recv completion queue depth
     },
 };
 
 var pgOptions = new PgOptions
 {
-    Host = Env.Str("PLAYGROUND_PG_HOST", "127.0.0.1"),
-    Port = Env.Port("PLAYGROUND_PG_PORT", 5432),
-    User = Env.Str("PLAYGROUND_PG_USER", "bench"),
-    Password = Env.StrOrNull("PLAYGROUND_PG_PASSWORD"),
-    Database = Env.Str("PLAYGROUND_PG_DB", "bench"),
-    PoolSize = Env.Int("PLAYGROUND_PG_POOL", 4),          // per reactor, not global
-    CommandTimeoutMs = Env.Int("PLAYGROUND_PG_TIMEOUT", 30_000),
+    Host             = Env.Str("PLAYGROUND_PG_HOST", "127.0.0.1"),  // IPv4 literal - resolve names up front, DNS blocks the reactor
+    Port             = Env.Port("PLAYGROUND_PG_PORT", 5432),        // Postgres wire port
+    User             = Env.Str("PLAYGROUND_PG_USER", "bench"),      // required
+    Password         = Env.StrOrNull("PLAYGROUND_PG_PASSWORD"),     // null = trust auth; else SCRAM-SHA-256
+    Database         = Env.Str("PLAYGROUND_PG_DB", "bench"),        // required
+    PoolSize         = Env.Int("PLAYGROUND_PG_POOL", 4),            // per reactor, not global
+    MaxReceiveBytes  = 64 * 1024 * 1024,                            // ceiling on one backend message; buffer grows to this (64 MB)
+    CommandTimeoutMs = Env.Int("PLAYGROUND_PG_TIMEOUT", 30_000),    // oldest in-flight command past this -> torn down; 0 disables
 };
 
 var threads = new Thread[config.ReactorCount];

--- a/Playground/Clients/Redis/Program.cs
+++ b/Playground/Clients/Redis/Program.cs
@@ -24,19 +24,36 @@ using Playground.Shared;
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    ReactorCount   = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),  // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                                        // SQ/CQ depth per ring
+    DualStack      = false,                                                       // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                                                   // bytes per shared recv buffer
+    RecvSlots      = 4096,                                                        // shared recv buffer-ring depth
+    Incremental    = null,                                                        // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                                        // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                                        // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port             = Env.Port("PLAYGROUND_PORT", 8080),
+        ExtraPorts       = [],                                                    // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                                                  // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                                             // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                                                  // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,                            // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                                                 // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                                                    // per-connection recv completion queue depth
     },
 };
 
 var redisOptions = new RedisOptions
 {
-    Host     = Env.Str("PLAYGROUND_REDIS_HOST", "127.0.0.1"),
-    Port     = Env.Port("PLAYGROUND_REDIS_PORT", 6379),
-    Password = Env.StrOrNull("PLAYGROUND_REDIS_PASSWORD"),
-    PoolSize = Env.Int("PLAYGROUND_REDIS_POOL", 4),
+    Host             = Env.Str("PLAYGROUND_REDIS_HOST", "127.0.0.1"),  // IPv4 literal - resolve names up front, DNS blocks the reactor
+    Port             = Env.Port("PLAYGROUND_REDIS_PORT", 6379),        // Redis wire port
+    Password         = Env.StrOrNull("PLAYGROUND_REDIS_PASSWORD"),     // AUTH password; null = no auth
+    User             = null,                                           // ACL username (Redis 6+); null = default user
+    Database         = 0,                                              // logical DB index to SELECT on connect
+    PoolSize         = Env.Int("PLAYGROUND_REDIS_POOL", 4),            // per reactor, not global
+    CommandTimeoutMs = 30_000,                                         // oldest in-flight command past this -> torn down; 0 disables
 };
 
 var threads = new Thread[config.ReactorCount];

--- a/Playground/Http2/Managed/Program.cs
+++ b/Playground/Http2/Managed/Program.cs
@@ -17,10 +17,24 @@ using Playground.Shared;
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    ReactorCount   = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),  // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                                        // SQ/CQ depth per ring
+    DualStack      = false,                                                       // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                                                   // bytes per shared recv buffer
+    RecvSlots      = 4096,                                                        // shared recv buffer-ring depth
+    Incremental    = null,                                                        // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                                        // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                                        // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port             = Env.Port("PLAYGROUND_PORT", 8080),
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 

--- a/Playground/Http2/Nghttp2/Program.cs
+++ b/Playground/Http2/Nghttp2/Program.cs
@@ -17,10 +17,24 @@ using Playground.Shared;
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    ReactorCount   = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),  // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                                        // SQ/CQ depth per ring
+    DualStack      = false,                                                       // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                                                   // bytes per shared recv buffer
+    RecvSlots      = 4096,                                                        // shared recv buffer-ring depth
+    Incremental    = null,                                                        // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                                        // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                                        // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port             = Env.Port("PLAYGROUND_PORT", 8080),
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 

--- a/Playground/Http2/SslStream/Program.cs
+++ b/Playground/Http2/SslStream/Program.cs
@@ -42,10 +42,24 @@ certificate = X509CertificateLoader.LoadPkcs12(certificate.Export(X509ContentTyp
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 

--- a/Playground/Http2/Tls/Program.cs
+++ b/Playground/Http2/Tls/Program.cs
@@ -59,11 +59,24 @@ Env.OverrideKtls(ref kernelTx, ref kernelRx);
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
-    Incremental = incrementalBuffers ? new IncrementalOptions() : null,
+    ReactorCount   = reactors,                                              // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                                  // SQ/CQ depth per ring
+    DualStack      = false,                                                 // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                                             // bytes per shared recv buffer
+    RecvSlots      = 4096,                                                  // shared recv buffer-ring depth
+    Incremental    = incrementalBuffers ? new IncrementalOptions() : null,  // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                                  // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                                  // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 
@@ -83,14 +96,13 @@ for (int i = 0; i < threads.Length; i++)
 
     reactor.OnStart = r => TlsService.Start(r, new TlsOptions
     {
-        KernelTx = kernelTx,
-        KernelRx = kernelRx,
-        CertificatePath = certPath,
-        KeyPath = keyPath,
-
-        // Most preferred first. ALPN has no weights - RFC 7301 carries a plain ordered list - so
-        // position IS the preference, and a client offering both lands on h2.
-        Alpn = ["h2", "http/1.1"],
+        CertificatePath = certPath,                        // PEM certificate chain file (leaf first)
+        CertificatePem  = null,                            // in-memory PEM alternative - set one, not both
+        KeyPath         = keyPath,                         // PEM private key file
+        KeyPem          = null,                            // in-memory PEM alternative to KeyPath
+        Alpn            = ["h2", "http/1.1"],              // ORDERED, most preferred first - a client offering both gets h2
+        KernelTx        = kernelTx,                        // kTLS encrypt: kernel makes the records (off = OpenSSL both ways)
+        KernelRx        = kernelRx,                        // kTLS decrypt: needs KernelTx; experimental (see the knob above)
     });
 
     reactor.TcpHandle = async (r, conn) =>

--- a/Playground/Http3/Buffered/Program.cs
+++ b/Playground/Http3/Buffered/Program.cs
@@ -74,8 +74,23 @@ using var engine = new QuicEngine(certPath, keyPath, cidLength, alpn: ["h3"], ma
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
-    Tcp = new TcpOptions { Port = tcpPort },
+    ReactorCount   = reactors,
+    RingEntries    = 8192,                                  // SQ/CQ depth per ring
+    DualStack      = false,                                 // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Tcp = new TcpOptions
+    {
+        Port             = tcpPort,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
+    },
     Udp = new UdpOptions { RecvSlots = udpRecvSlots, Gro = gro },
     Quic = new QuicOptions
     {

--- a/Playground/Http3/Nghttp3/Program.cs
+++ b/Playground/Http3/Nghttp3/Program.cs
@@ -37,14 +37,34 @@ ushort quicPort = Env.Port("PLAYGROUND_QUIC_PORT", 8443);
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
-    Tcp = new TcpOptions { Port = Env.Port("PLAYGROUND_PORT", 8080) },
-    Udp = new UdpOptions { RecvSlots = Env.Int("PLAYGROUND_UDP_SLOTS", 16) },   // multishot recv slots
+    ReactorCount   = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),  // one ring per reactor, one reactor per core
+    RingEntries    = 8192,       // io_uring SQ/CQ depth
+    DualStack      = false,      // IPv4-only listeners; true binds dual-stack IPv6 (::)
+    RecvBufferSize = 32 * 1024,  // bytes per slot in the shared TCP recv ring
+    RecvSlots      = 4096,       // slots in that shared recv ring
+    Incremental    = null,       // shared recv ring; non-null = per-connection rings (kernel 6.12+)
+    Tcp = new TcpOptions
+    {
+        Port             = Env.Port("PLAYGROUND_PORT", 8080),  // the TCP listener, so the process serves both
+        ExtraPorts       = [],                          // extra listener ports, each bound by every reactor
+        ListenBacklog    = 1024,                        // listen() accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                   // per-connection write slab before overflow
+        PoolMax          = 1024,                        // max pooled connection objects per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,  // grow the slab; Segmented chains pooled slabs
+        ZeroCopySend     = false,                       // plain SEND; SEND_ZC only wins for large responses
+        RecvQueueEntries = 64,                          // per-connection SPSC recv queue depth (power of two)
+    },
+    Udp = new UdpOptions
+    {
+        RecvSlots = Env.Int("PLAYGROUND_UDP_SLOTS", 16),  // multishot recv slots per reactor - datagrams the ring can hold at once
+        Gro       = true,  // UDP_GRO: coalesce a received datagram burst into one recv
+    },
     Quic = new QuicOptions
     {
-        Port = quicPort,
-        LocalCidLength = 8,
-        ConnectionFactory = engine.CreateFactory(),
+        Port              = quicPort,                // https://127.0.0.1:8443/ over UDP - h3 lives here
+        LocalCidLength    = 8,                       // must match the engine's cidLength
+        IdleTimeoutMs     = 60_000,                  // close a connection idle this long (no packets)
+        ConnectionFactory = engine.CreateFactory(),  // the engine adopts each new connection
     },
 };
 
@@ -53,8 +73,8 @@ var config = new ServerConfig
 long qpackCapacity = Env.Long("PLAYGROUND_QPACK_CAP", 0);
 var h3Options = new Nghttp3Options
 {
-    QpackDynamicTableCapacity = qpackCapacity,
-    QpackBlockedStreams = qpackCapacity > 0 ? 100 : 0,
+    QpackDynamicTableCapacity = qpackCapacity,                // 0 (default) = headers stay literal
+    QpackBlockedStreams       = qpackCapacity > 0 ? 100 : 0,  // raise both together for the dynamic table
 };
 
 // THE allocation-free pattern: build the response ONCE and reuse the instance for every request.

--- a/Playground/Proxy/H1ToH1/Program.cs
+++ b/Playground/Proxy/H1ToH1/Program.cs
@@ -30,10 +30,24 @@ using Playground.Shared;
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    ReactorCount   = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    RingEntries    = 8192,       // SQ/CQ depth per ring
+    DualStack      = false,      // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,  // bytes per shared recv buffer
+    RecvSlots      = 4096,       // shared recv buffer-ring depth
+    Incremental    = null,       // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,       // no raw UDP sockets (TCP-only frontend)
+    Quic           = null,       // no QUIC listener; the frontend is TLS-over-TCP
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8443),
+        Port             = Env.Port("PLAYGROUND_PORT", 8443),
+        ExtraPorts       = [],                                 // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                               // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                          // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                               // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,         // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                              // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                                 // per-connection recv completion queue depth
     },
 };
 
@@ -61,24 +75,34 @@ for (int i = 0; i < threads.Length; i++)
         // protocol, so it offers exactly one.
         TlsService.Start(r, new TlsOptions
         {
-            CertificatePath = certPath,
-            KeyPath = keyPath,
-            Alpn = ["http/1.1"],
+            CertificatePath = certPath,      // PEM cert chain file (set exactly one of Path/Pem)
+            CertificatePem  = null,          // in-memory PEM alternative to CertificatePath
+            KeyPath         = keyPath,       // PEM private key file (set exactly one of Path/Pem)
+            KeyPem          = null,          // in-memory PEM alternative to KeyPath
+            Alpn            = ["http/1.1"],  // protocols offered, most preferred first
+            KernelTx        = false,         // kTLS encrypt (off = OpenSSL both ways)
+            KernelRx        = false,         // kTLS decrypt; requires KernelTx, experimental
         });
 
         // Outbound: one context per reactor, shared by that reactor's pool - it holds no
         // per-connection state, so every connection opened from it gets its own SSL.
         HttpClientPool.Start(r, new HttpClientOptions
         {
-            Host = upstreamHost,
-            Port = upstreamPort,
-            PoolSize = upstreamPool,
+            Host              = upstreamHost,     // origin address (IPv4 literal; DNS would block the reactor)
+            Port              = upstreamPort,     // origin port
+            PoolSize          = upstreamPool,     // connections kept open; round-robin, one request each
+            MaxResponseBytes  = 8 * 1024 * 1024,  // per-request ceiling for headers + body
+            SendBufferSize    = 16 * 1024,        // per-connection send buffer
+            ReceiveBufferSize = 16 * 1024,        // per-connection recv buffer (grows to MaxResponseBytes)
+            AcquireTimeoutMs  = 10_000,           // how long a request waits for a free connection
             Tls = TlsClientContext.Create(new TlsClientOptions
             {
-                ServerName = upstreamName,
-                AlpnProtocols = ["http/1.1"],
-                CaFile = upstreamInsecure ? null : upstreamCa,
-                VerifyCertificate = !upstreamInsecure,
+                ServerName         = upstreamName,                          // sent as SNI, checked against the cert
+                AlpnProtocols      = ["http/1.1"],                          // ALPN offer, most preferred first
+                VerifyCertificate  = !upstreamInsecure,                     // off = encrypted but UNAUTHENTICATED
+                CaFile             = upstreamInsecure ? null : upstreamCa,  // PEM trust anchors; null = system store
+                MinimumVersion     = OpenSslVersions.Tls12,                 // lowest TLS accepted; Tls13 = 1.3 only
+                HandshakeTimeoutMs = 10_000,                                // handshake deadline
             }),
         });
     };

--- a/Playground/Proxy/H1ToH2/Program.cs
+++ b/Playground/Proxy/H1ToH2/Program.cs
@@ -31,10 +31,24 @@ using Playground.Shared;
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    ReactorCount   = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    RingEntries    = 8192,       // SQ/CQ depth per ring
+    DualStack      = false,      // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,  // bytes per shared recv buffer
+    RecvSlots      = 4096,       // shared recv buffer-ring depth
+    Incremental    = null,       // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,       // no raw UDP sockets (TCP-only frontend)
+    Quic           = null,       // no QUIC listener; the frontend is TLS-over-TCP
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8443),
+        Port             = Env.Port("PLAYGROUND_PORT", 8443),
+        ExtraPorts       = [],                                 // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                               // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                          // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                               // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,         // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                              // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                                 // per-connection recv completion queue depth
     },
 };
 
@@ -62,24 +76,32 @@ for (int i = 0; i < threads.Length; i++)
         // protocol, so it offers exactly one.
         TlsService.Start(r, new TlsOptions
         {
-            CertificatePath = certPath,
-            KeyPath = keyPath,
-            Alpn = ["http/1.1"],
+            CertificatePath = certPath,      // PEM cert chain file (set exactly one of Path/Pem)
+            CertificatePem  = null,          // in-memory PEM alternative to CertificatePath
+            KeyPath         = keyPath,       // PEM private key file (set exactly one of Path/Pem)
+            KeyPem          = null,          // in-memory PEM alternative to KeyPath
+            Alpn            = ["http/1.1"],  // protocols offered, most preferred first
+            KernelTx        = false,         // kTLS encrypt (off = OpenSSL both ways)
+            KernelRx        = false,         // kTLS decrypt; requires KernelTx, experimental
         });
 
         // Outbound: one context per reactor, shared by that reactor's pool - it holds no
         // per-connection state, so every connection opened from it gets its own SSL.
         Http2ClientPool.Start(r, new Http2ClientOptions
         {
-            Host = upstreamHost,
-            Port = upstreamPort,
-            PoolSize = upstreamPool,
+            Host             = upstreamHost,     // origin address (IPv4 literal; DNS would block the reactor)
+            Port             = upstreamPort,     // origin port
+            PoolSize         = upstreamPool,     // h2 multiplexes: one connection carries many streams
+            AcquireTimeoutMs = 10_000,           // how long a request waits for a usable connection
+            MaxResponseBytes = 8 * 1024 * 1024,  // per-request ceiling for headers + body
             Tls = TlsClientContext.Create(new TlsClientOptions
             {
-                ServerName = upstreamName,
-                AlpnProtocols = ["h2"],       // h2 over TLS is chosen by ALPN, never assumed
-                CaFile = upstreamInsecure ? null : upstreamCa,
-                VerifyCertificate = !upstreamInsecure,
+                ServerName         = upstreamName,                          // sent as SNI, checked against the cert
+                AlpnProtocols      = ["h2"],                                // h2 over TLS is chosen by ALPN, never assumed
+                VerifyCertificate  = !upstreamInsecure,                     // off = encrypted but UNAUTHENTICATED
+                CaFile             = upstreamInsecure ? null : upstreamCa,  // PEM trust anchors; null = system store
+                MinimumVersion     = OpenSslVersions.Tls12,                 // lowest TLS accepted; Tls13 = 1.3 only
+                HandshakeTimeoutMs = 10_000,                                // handshake deadline
             }),
         });
     };

--- a/Playground/Proxy/H1ToH3/Program.cs
+++ b/Playground/Proxy/H1ToH3/Program.cs
@@ -32,10 +32,24 @@ using Playground.Shared;
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    ReactorCount   = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    RingEntries    = 8192,       // SQ/CQ depth per ring
+    DualStack      = false,      // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,  // bytes per shared recv buffer
+    RecvSlots      = 4096,       // shared recv buffer-ring depth
+    Incremental    = null,       // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,       // no raw UDP sockets (TCP-only frontend)
+    Quic           = null,       // no QUIC listener; the frontend is TLS-over-TCP
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8443),
+        Port             = Env.Port("PLAYGROUND_PORT", 8443),
+        ExtraPorts       = [],                                 // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                               // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                          // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                               // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,         // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                              // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                                 // per-connection recv completion queue depth
     },
 };
 
@@ -56,9 +70,13 @@ for (int i = 0; i < threads.Length; i++)
         // protocol, so it offers exactly one.
         TlsService.Start(r, new TlsOptions
         {
-            CertificatePath = certPath,
-            KeyPath = keyPath,
-            Alpn = ["http/1.1"],
+            CertificatePath = certPath,      // PEM cert chain file (set exactly one of Path/Pem)
+            CertificatePem  = null,          // in-memory PEM alternative to CertificatePath
+            KeyPath         = keyPath,       // PEM private key file (set exactly one of Path/Pem)
+            KeyPem          = null,          // in-memory PEM alternative to KeyPath
+            Alpn            = ["http/1.1"],  // protocols offered, most preferred first
+            KernelTx        = false,         // kTLS encrypt (off = OpenSSL both ways)
+            KernelRx        = false,         // kTLS decrypt; requires KernelTx, experimental
         });
 
         // Outbound: no TLS options, because QUIC has no cleartext mode - TLS 1.3 is inside the
@@ -66,10 +84,12 @@ for (int i = 0; i < threads.Length; i++)
         // this pool is what makes the reactor grow its client-side QUIC transport.
         Http3ClientPool.Start(r, new Http3ClientOptions
         {
-            Host = upstreamHost,
-            Port = upstreamPort,
-            ServerName = upstreamName,
-            PoolSize = upstreamPool,
+            Host             = upstreamHost,     // origin address (IPv4 literal; DNS would block the reactor)
+            Port             = upstreamPort,     // origin's QUIC (UDP) port
+            ServerName       = upstreamName,     // SNI / :authority, checked against the cert
+            PoolSize         = upstreamPool,     // h3 multiplexes: one connection carries many streams
+            AcquireTimeoutMs = 10_000,           // how long a request waits (handshake included)
+            MaxResponseBytes = 8 * 1024 * 1024,  // per-request ceiling for headers + body
         });
     };
 

--- a/Playground/Proxy/H2ToH1/Program.cs
+++ b/Playground/Proxy/H2ToH1/Program.cs
@@ -39,10 +39,24 @@ using Playground.Shared;
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    ReactorCount   = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    RingEntries    = 8192,       // SQ/CQ depth per ring
+    DualStack      = false,      // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,  // bytes per shared recv buffer
+    RecvSlots      = 4096,       // shared recv buffer-ring depth
+    Incremental    = null,       // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,       // no raw UDP sockets (TCP-only frontend)
+    Quic           = null,       // no QUIC listener; the frontend is TLS-over-TCP
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8443),
+        Port             = Env.Port("PLAYGROUND_PORT", 8443),
+        ExtraPorts       = [],                                 // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                               // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                          // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                               // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,         // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                              // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                                 // per-connection recv completion queue depth
     },
 };
 
@@ -70,24 +84,34 @@ for (int i = 0; i < threads.Length; i++)
         // client that cannot do h2 fails ALPN rather than silently getting something else.
         TlsService.Start(r, new TlsOptions
         {
-            CertificatePath = certPath,
-            KeyPath = keyPath,
-            Alpn = ["h2"],
+            CertificatePath = certPath,  // PEM cert chain file (set exactly one of Path/Pem)
+            CertificatePem  = null,      // in-memory PEM alternative to CertificatePath
+            KeyPath         = keyPath,   // PEM private key file (set exactly one of Path/Pem)
+            KeyPem          = null,      // in-memory PEM alternative to KeyPath
+            Alpn            = ["h2"],    // protocols offered, most preferred first
+            KernelTx        = false,     // kTLS encrypt (off = OpenSSL both ways)
+            KernelRx        = false,     // kTLS decrypt; requires KernelTx, experimental
         });
 
         // Outbound: one context per reactor, shared by that reactor's pool - it holds no
         // per-connection state, so every connection opened from it gets its own SSL.
         HttpClientPool.Start(r, new HttpClientOptions
         {
-            Host = upstreamHost,
-            Port = upstreamPort,
-            PoolSize = upstreamPool,
+            Host              = upstreamHost,     // origin address (IPv4 literal; DNS would block the reactor)
+            Port              = upstreamPort,     // origin port
+            PoolSize          = upstreamPool,     // connections kept open; round-robin, one request each
+            MaxResponseBytes  = 8 * 1024 * 1024,  // per-request ceiling for headers + body
+            SendBufferSize    = 16 * 1024,        // per-connection send buffer
+            ReceiveBufferSize = 16 * 1024,        // per-connection recv buffer (grows to MaxResponseBytes)
+            AcquireTimeoutMs  = 10_000,           // how long a request waits for a free connection
             Tls = TlsClientContext.Create(new TlsClientOptions
             {
-                ServerName = upstreamName,
-                AlpnProtocols = ["http/1.1"],
-                CaFile = upstreamInsecure ? null : upstreamCa,
-                VerifyCertificate = !upstreamInsecure,
+                ServerName         = upstreamName,                          // sent as SNI, checked against the cert
+                AlpnProtocols      = ["http/1.1"],                          // ALPN offer, most preferred first
+                VerifyCertificate  = !upstreamInsecure,                     // off = encrypted but UNAUTHENTICATED
+                CaFile             = upstreamInsecure ? null : upstreamCa,  // PEM trust anchors; null = system store
+                MinimumVersion     = OpenSslVersions.Tls12,                 // lowest TLS accepted; Tls13 = 1.3 only
+                HandshakeTimeoutMs = 10_000,                                // handshake deadline
             }),
         });
     };

--- a/Playground/Proxy/H2ToH2/Program.cs
+++ b/Playground/Proxy/H2ToH2/Program.cs
@@ -33,10 +33,24 @@ using Playground.Shared;
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    ReactorCount   = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    RingEntries    = 8192,       // SQ/CQ depth per ring
+    DualStack      = false,      // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,  // bytes per shared recv buffer
+    RecvSlots      = 4096,       // shared recv buffer-ring depth
+    Incremental    = null,       // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,       // no raw UDP sockets (TCP-only frontend)
+    Quic           = null,       // no QUIC listener; the frontend is TLS-over-TCP
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8443),
+        Port             = Env.Port("PLAYGROUND_PORT", 8443),
+        ExtraPorts       = [],                                 // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                               // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                          // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                               // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,         // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                              // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                                 // per-connection recv completion queue depth
     },
 };
 
@@ -64,24 +78,32 @@ for (int i = 0; i < threads.Length; i++)
         // client that cannot do h2 fails ALPN rather than silently getting something else.
         TlsService.Start(r, new TlsOptions
         {
-            CertificatePath = certPath,
-            KeyPath = keyPath,
-            Alpn = ["h2"],
+            CertificatePath = certPath,  // PEM cert chain file (set exactly one of Path/Pem)
+            CertificatePem  = null,      // in-memory PEM alternative to CertificatePath
+            KeyPath         = keyPath,   // PEM private key file (set exactly one of Path/Pem)
+            KeyPem          = null,      // in-memory PEM alternative to KeyPath
+            Alpn            = ["h2"],    // protocols offered, most preferred first
+            KernelTx        = false,     // kTLS encrypt (off = OpenSSL both ways)
+            KernelRx        = false,     // kTLS decrypt; requires KernelTx, experimental
         });
 
         // Outbound: one context per reactor, shared by that reactor's pool - it holds no
         // per-connection state, so every connection opened from it gets its own SSL.
         Http2ClientPool.Start(r, new Http2ClientOptions
         {
-            Host = upstreamHost,
-            Port = upstreamPort,
-            PoolSize = upstreamPool,
+            Host             = upstreamHost,     // origin address (IPv4 literal; DNS would block the reactor)
+            Port             = upstreamPort,     // origin port
+            PoolSize         = upstreamPool,     // h2 multiplexes: one connection carries many streams
+            AcquireTimeoutMs = 10_000,           // how long a request waits for a usable connection
+            MaxResponseBytes = 8 * 1024 * 1024,  // per-request ceiling for headers + body
             Tls = TlsClientContext.Create(new TlsClientOptions
             {
-                ServerName = upstreamName,
-                AlpnProtocols = ["h2"],       // h2 over TLS is chosen by ALPN, never assumed
-                CaFile = upstreamInsecure ? null : upstreamCa,
-                VerifyCertificate = !upstreamInsecure,
+                ServerName         = upstreamName,                          // sent as SNI, checked against the cert
+                AlpnProtocols      = ["h2"],                                // h2 over TLS is chosen by ALPN, never assumed
+                VerifyCertificate  = !upstreamInsecure,                     // off = encrypted but UNAUTHENTICATED
+                CaFile             = upstreamInsecure ? null : upstreamCa,  // PEM trust anchors; null = system store
+                MinimumVersion     = OpenSslVersions.Tls12,                 // lowest TLS accepted; Tls13 = 1.3 only
+                HandshakeTimeoutMs = 10_000,                                // handshake deadline
             }),
         });
     };

--- a/Playground/Proxy/H2ToH3/Program.cs
+++ b/Playground/Proxy/H2ToH3/Program.cs
@@ -32,10 +32,24 @@ using Playground.Shared;
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    ReactorCount   = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    RingEntries    = 8192,       // SQ/CQ depth per ring
+    DualStack      = false,      // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,  // bytes per shared recv buffer
+    RecvSlots      = 4096,       // shared recv buffer-ring depth
+    Incremental    = null,       // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,       // no raw UDP sockets (TCP-only frontend)
+    Quic           = null,       // no QUIC listener; the frontend is TLS-over-TCP
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8443),
+        Port             = Env.Port("PLAYGROUND_PORT", 8443),
+        ExtraPorts       = [],                                 // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                               // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                          // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                               // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,         // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                              // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                                 // per-connection recv completion queue depth
     },
 };
 
@@ -56,9 +70,13 @@ for (int i = 0; i < threads.Length; i++)
         // client that cannot do h2 fails ALPN rather than silently getting something else.
         TlsService.Start(r, new TlsOptions
         {
-            CertificatePath = certPath,
-            KeyPath = keyPath,
-            Alpn = ["h2"],
+            CertificatePath = certPath,  // PEM cert chain file (set exactly one of Path/Pem)
+            CertificatePem  = null,      // in-memory PEM alternative to CertificatePath
+            KeyPath         = keyPath,   // PEM private key file (set exactly one of Path/Pem)
+            KeyPem          = null,      // in-memory PEM alternative to KeyPath
+            Alpn            = ["h2"],    // protocols offered, most preferred first
+            KernelTx        = false,     // kTLS encrypt (off = OpenSSL both ways)
+            KernelRx        = false,     // kTLS decrypt; requires KernelTx, experimental
         });
 
         // Outbound: no TLS options, because QUIC has no cleartext mode - TLS 1.3 is inside the
@@ -66,10 +84,12 @@ for (int i = 0; i < threads.Length; i++)
         // this pool is what makes the reactor grow its client-side QUIC transport.
         Http3ClientPool.Start(r, new Http3ClientOptions
         {
-            Host = upstreamHost,
-            Port = upstreamPort,
-            ServerName = upstreamName,
-            PoolSize = upstreamPool,
+            Host             = upstreamHost,     // origin address (IPv4 literal; DNS would block the reactor)
+            Port             = upstreamPort,     // origin's QUIC (UDP) port
+            ServerName       = upstreamName,     // SNI / :authority, checked against the cert
+            PoolSize         = upstreamPool,     // h3 multiplexes: one connection carries many streams
+            AcquireTimeoutMs = 10_000,           // how long a request waits (handshake included)
+            MaxResponseBytes = 8 * 1024 * 1024,  // per-request ceiling for headers + body
         });
     };
 

--- a/Playground/Proxy/H3ToH1/Program.cs
+++ b/Playground/Proxy/H3ToH1/Program.cs
@@ -21,18 +21,31 @@ using Playground.Shared;
     Env.StrOrNull("PLAYGROUND_QUIC_CERT"),
     Env.StrOrNull("PLAYGROUND_QUIC_KEY"));
 
-using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: ["h3"]);
+using var engine = new QuicEngine(certPath, keyPath,
+    cidLength: 8,                       // CID bytes this endpoint mints (1..20)
+    alpn: ["h3"],                       // the only protocol offered (else no_application_protocol)
+    maxSendRetentionBytes: 16L << 20);  // per-connection send-retention high-water (default 16 MiB)
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
-    Tcp = null,   // the proxy serves h3 only; its TCP sockets are all outbound
-    Udp = new UdpOptions { RecvSlots = Env.Int("PLAYGROUND_UDP_SLOTS", 16) },
+    ReactorCount   = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    RingEntries    = 8192,       // SQ/CQ depth per ring
+    DualStack      = false,      // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,  // bytes per shared recv buffer
+    RecvSlots      = 4096,       // shared recv buffer-ring depth
+    Incremental    = null,       // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Tcp            = null,       // the proxy serves h3 only; its TCP sockets are all outbound
+    Udp = new UdpOptions
+    {
+        RecvSlots = Env.Int("PLAYGROUND_UDP_SLOTS", 16),  // multishot recv slots per reactor (datagrams in flight)
+        Gro       = true,                                 // UDP_GRO: coalesce datagrams into one recv (fewer syscalls)
+    },
     Quic = new QuicOptions
     {
-        Port = Env.Port("PLAYGROUND_QUIC_PORT", 8443),
-        LocalCidLength = 8,
-        ConnectionFactory = engine.CreateFactory(),
+        Port              = Env.Port("PLAYGROUND_QUIC_PORT", 8443),  // h3 over UDP - the QUIC listener
+        LocalCidLength    = 8,                                       // CID bytes this endpoint mints (must match the engine)
+        IdleTimeoutMs     = 60_000,                                  // transport idle backstop; 0 disables sweep eviction
+        ConnectionFactory = engine.CreateFactory(),                  // adopts new connections into the engine
     },
 };
 
@@ -61,15 +74,21 @@ for (int i = 0; i < threads.Length; i++)
         // per-connection state, so every connection opened from it gets its own SSL.
         HttpClientPool.Start(r, new HttpClientOptions
         {
-            Host = upstreamHost,
-            Port = upstreamPort,
-            PoolSize = upstreamPool,
+            Host              = upstreamHost,     // origin address (IPv4 literal; DNS would block the reactor)
+            Port              = upstreamPort,     // origin port
+            PoolSize          = upstreamPool,     // connections kept open; round-robin, one request each
+            MaxResponseBytes  = 8 * 1024 * 1024,  // per-request ceiling for headers + body
+            SendBufferSize    = 16 * 1024,        // per-connection send buffer
+            ReceiveBufferSize = 16 * 1024,        // per-connection recv buffer (grows to MaxResponseBytes)
+            AcquireTimeoutMs  = 10_000,           // how long a request waits for a free connection
             Tls = TlsClientContext.Create(new TlsClientOptions
             {
-                ServerName = upstreamName,
-                AlpnProtocols = ["http/1.1"],
-                CaFile = upstreamInsecure ? null : upstreamCa,
-                VerifyCertificate = !upstreamInsecure,
+                ServerName         = upstreamName,                          // sent as SNI, checked against the cert
+                AlpnProtocols      = ["http/1.1"],                          // ALPN offer, most preferred first
+                VerifyCertificate  = !upstreamInsecure,                     // off = encrypted but UNAUTHENTICATED
+                CaFile             = upstreamInsecure ? null : upstreamCa,  // PEM trust anchors; null = system store
+                MinimumVersion     = OpenSslVersions.Tls12,                 // lowest TLS accepted; Tls13 = 1.3 only
+                HandshakeTimeoutMs = 10_000,                                // handshake deadline
             }),
         });
     };

--- a/Playground/Proxy/H3ToH2/Program.cs
+++ b/Playground/Proxy/H3ToH2/Program.cs
@@ -24,18 +24,31 @@ using Playground.Shared;
     Env.StrOrNull("PLAYGROUND_QUIC_CERT"),
     Env.StrOrNull("PLAYGROUND_QUIC_KEY"));
 
-using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: ["h3"]);
+using var engine = new QuicEngine(certPath, keyPath,
+    cidLength: 8,                       // CID bytes this endpoint mints (1..20)
+    alpn: ["h3"],                       // the only protocol offered (else no_application_protocol)
+    maxSendRetentionBytes: 16L << 20);  // per-connection send-retention high-water (default 16 MiB)
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
-    Tcp = null,   // the proxy serves h3 only; its TCP sockets are all outbound
-    Udp = new UdpOptions { RecvSlots = Env.Int("PLAYGROUND_UDP_SLOTS", 16) },
+    ReactorCount   = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    RingEntries    = 8192,       // SQ/CQ depth per ring
+    DualStack      = false,      // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,  // bytes per shared recv buffer
+    RecvSlots      = 4096,       // shared recv buffer-ring depth
+    Incremental    = null,       // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Tcp            = null,       // the proxy serves h3 only; its TCP sockets are all outbound
+    Udp = new UdpOptions
+    {
+        RecvSlots = Env.Int("PLAYGROUND_UDP_SLOTS", 16),  // multishot recv slots per reactor (datagrams in flight)
+        Gro       = true,                                 // UDP_GRO: coalesce datagrams into one recv (fewer syscalls)
+    },
     Quic = new QuicOptions
     {
-        Port = Env.Port("PLAYGROUND_QUIC_PORT", 8443),
-        LocalCidLength = 8,
-        ConnectionFactory = engine.CreateFactory(),
+        Port              = Env.Port("PLAYGROUND_QUIC_PORT", 8443),  // h3 over UDP - the QUIC listener
+        LocalCidLength    = 8,                                       // CID bytes this endpoint mints (must match the engine)
+        IdleTimeoutMs     = 60_000,                                  // transport idle backstop; 0 disables sweep eviction
+        ConnectionFactory = engine.CreateFactory(),                  // adopts new connections into the engine
     },
 };
 
@@ -64,15 +77,19 @@ for (int i = 0; i < threads.Length; i++)
         // per-connection state, so every connection opened from it gets its own SSL.
         Http2ClientPool.Start(r, new Http2ClientOptions
         {
-            Host = upstreamHost,
-            Port = upstreamPort,
-            PoolSize = upstreamPool,
+            Host             = upstreamHost,     // origin address (IPv4 literal; DNS would block the reactor)
+            Port             = upstreamPort,     // origin port
+            PoolSize         = upstreamPool,     // h2 multiplexes: one connection carries many streams
+            AcquireTimeoutMs = 10_000,           // how long a request waits for a usable connection
+            MaxResponseBytes = 8 * 1024 * 1024,  // per-request ceiling for headers + body
             Tls = TlsClientContext.Create(new TlsClientOptions
             {
-                ServerName = upstreamName,
-                AlpnProtocols = ["h2"],       // h2 over TLS is chosen by ALPN, never assumed
-                CaFile = upstreamInsecure ? null : upstreamCa,
-                VerifyCertificate = !upstreamInsecure,
+                ServerName         = upstreamName,                          // sent as SNI, checked against the cert
+                AlpnProtocols      = ["h2"],                                // h2 over TLS is chosen by ALPN, never assumed
+                VerifyCertificate  = !upstreamInsecure,                     // off = encrypted but UNAUTHENTICATED
+                CaFile             = upstreamInsecure ? null : upstreamCa,  // PEM trust anchors; null = system store
+                MinimumVersion     = OpenSslVersions.Tls12,                 // lowest TLS accepted; Tls13 = 1.3 only
+                HandshakeTimeoutMs = 10_000,                                // handshake deadline
             }),
         });
     };

--- a/Playground/Proxy/H3ToH3/Program.cs
+++ b/Playground/Proxy/H3ToH3/Program.cs
@@ -29,27 +29,42 @@ using Playground.Shared;
     Env.StrOrNull("PLAYGROUND_QUIC_CERT"),
     Env.StrOrNull("PLAYGROUND_QUIC_KEY"));
 
-using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: ["h3"]);
+using var engine = new QuicEngine(certPath, keyPath,
+    cidLength: 8,                       // CID bytes this endpoint mints (1..20)
+    alpn: ["h3"],                       // the only protocol offered (else no_application_protocol)
+    maxSendRetentionBytes: 16L << 20);  // per-connection send-retention high-water (default 16 MiB)
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
-    Tcp = null,   // h3 in, h3 out: nothing here speaks TCP at all
-    Udp = new UdpOptions { RecvSlots = Env.Int("PLAYGROUND_UDP_SLOTS", 16) },
+    ReactorCount   = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    RingEntries    = 8192,       // SQ/CQ depth per ring
+    DualStack      = false,      // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,  // bytes per shared recv buffer
+    RecvSlots      = 4096,       // shared recv buffer-ring depth
+    Incremental    = null,       // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Tcp            = null,       // h3 in, h3 out: nothing here speaks TCP at all
+    Udp = new UdpOptions
+    {
+        RecvSlots = Env.Int("PLAYGROUND_UDP_SLOTS", 16),  // multishot recv slots per reactor (datagrams in flight)
+        Gro       = true,                                 // UDP_GRO: coalesce datagrams into one recv (fewer syscalls)
+    },
     Quic = new QuicOptions
     {
-        Port = Env.Port("PLAYGROUND_QUIC_PORT", 8443),
-        LocalCidLength = 8,
-        ConnectionFactory = engine.CreateFactory(),
+        Port              = Env.Port("PLAYGROUND_QUIC_PORT", 8443),  // h3 over UDP - the QUIC listener
+        LocalCidLength    = 8,                                       // CID bytes this endpoint mints (must match the engine)
+        IdleTimeoutMs     = 60_000,                                  // transport idle backstop; 0 disables sweep eviction
+        ConnectionFactory = engine.CreateFactory(),                  // adopts new connections into the engine
     },
 };
 
 var upstream = new Http3ClientOptions
 {
-    Host = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),   // IPv4 literal: DNS would block the reactor
-    Port = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8444),         // the upstream's QUIC (UDP) port
-    ServerName = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost"),
-    PoolSize = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1),         // h3 multiplexes: one connection carries all
+    Host             = Env.Str("PLAYGROUND_UPSTREAM_HOST", "127.0.0.1"),  // IPv4 literal: DNS would block the reactor
+    Port             = Env.Port("PLAYGROUND_UPSTREAM_PORT", 8444),        // the upstream's QUIC (UDP) port
+    ServerName       = Env.Str("PLAYGROUND_UPSTREAM_SNI", "localhost"),   // SNI / :authority, checked against the cert
+    PoolSize         = Env.Int("PLAYGROUND_UPSTREAM_POOL", 1),            // h3 multiplexes: one connection carries all
+    AcquireTimeoutMs = 10_000,                                            // how long a request waits (handshake included)
+    MaxResponseBytes = 8 * 1024 * 1024,                                   // per-request ceiling for headers + body
 };
 
 var threads = new Thread[config.ReactorCount];

--- a/Playground/Quic/Alpn/Program.cs
+++ b/Playground/Quic/Alpn/Program.cs
@@ -52,14 +52,24 @@ using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: null, m
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
-    Tcp = null,   // QUIC-only: no TCP listener is bound
-    Udp = new UdpOptions { RecvSlots = udpRecvSlots },
+    ReactorCount   = reactors,   // one ring per reactor, one reactor per core
+    RingEntries    = 8192,       // io_uring SQ/CQ depth
+    DualStack      = false,      // IPv4-only sockets; true binds dual-stack IPv6 (::)
+    RecvBufferSize = 32 * 1024,  // bytes per slot in the shared TCP recv ring
+    RecvSlots      = 4096,       // slots in that shared recv ring
+    Incremental    = null,       // shared recv ring; non-null = per-connection rings (kernel 6.12+)
+    Tcp            = null,       // QUIC-only: no TCP listener is bound
+    Udp = new UdpOptions
+    {
+        RecvSlots = udpRecvSlots,  // multishot recv slots per reactor - datagrams the ring can hold at once
+        Gro       = true,          // UDP_GRO: coalesce a received datagram burst into one recv
+    },
     Quic = new QuicOptions
     {
-        Port = quicPort,
-        LocalCidLength = 8,
-        ConnectionFactory = engine.CreateFactory(),
+        Port              = quicPort,                // https://127.0.0.1:8443/ - UDP, not TCP
+        LocalCidLength    = 8,                       // must match the engine's cidLength
+        IdleTimeoutMs     = 60_000,                  // close a connection idle this long (no packets)
+        ConnectionFactory = engine.CreateFactory(),  // the engine adopts each new connection
     },
 };
 

--- a/Playground/Tcp/Big/Program.cs
+++ b/Playground/Tcp/Big/Program.cs
@@ -39,13 +39,24 @@ WriteOverflowStrategy overflow = WriteOverflowStrategy.Grow;
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port          = port,
-        WriteSlabSize = slabSize,
-        WriteOverflow = overflow,
-        ZeroCopySend  = zeroCopy,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = slabSize,                       // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = overflow,                       // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = zeroCopy,                       // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 

--- a/Playground/Tcp/Hop/Program.cs
+++ b/Playground/Tcp/Hop/Program.cs
@@ -29,10 +29,24 @@ Env.Override(ref port, ref reactors);
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 

--- a/Playground/Tcp/Incremental/Program.cs
+++ b/Playground/Tcp/Incremental/Program.cs
@@ -19,7 +19,11 @@ using Playground.Shared;
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    ReactorCount   = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),  // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
 
     // Selecting the mode is setting this block. The shared-ring knobs (RecvBufferSize,
     // RecvSlots) go unused once it is set.
@@ -27,12 +31,21 @@ var config = new ServerConfig
     {
         MaxConnections = Env.Int("PLAYGROUND_INC_CONNS", 4096),      // per reactor
         RecvSlots      = Env.Int("PLAYGROUND_INC_SLOTS", 16),        // per connection
-        RecvBufferSize = Env.Int("PLAYGROUND_INC_BUFSIZE", 4096),
+        RecvBufferSize = Env.Int("PLAYGROUND_INC_BUFSIZE", 4096),    // bytes per buffer, kernel appends across recvs
     },
 
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port             = Env.Port("PLAYGROUND_PORT", 8080),
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 

--- a/Playground/Tcp/Pipe/Program.cs
+++ b/Playground/Tcp/Pipe/Program.cs
@@ -19,10 +19,24 @@ using Playground.Shared;
 
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),
+    ReactorCount   = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),  // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port             = Env.Port("PLAYGROUND_PORT", 8080),
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 

--- a/Playground/Tcp/Raw/Program.cs
+++ b/Playground/Tcp/Raw/Program.cs
@@ -14,13 +14,28 @@ using Playground.Shared;
 //  against. Needs: ioxide
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
-// The engine. One ring per reactor, one reactor per thread - run one per core.
+// The engine. Every ServerConfig + TcpOptions knob is set here at its default, so the whole tuning
+// surface is visible in one place - edit any line. One ring per reactor, one reactor per thread.
 var config = new ServerConfig
 {
-    ReactorCount = Env.Int("PLAYGROUND_REACTORS", 12),
+    ReactorCount   = Env.Int("PLAYGROUND_REACTORS", 12),  // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                 // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = Env.Port("PLAYGROUND_PORT", 8080),
+        Port             = Env.Port("PLAYGROUND_PORT", 8080),
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 

--- a/Playground/Tcp/TaskRun/Program.cs
+++ b/Playground/Tcp/TaskRun/Program.cs
@@ -32,10 +32,24 @@ Env.Override(ref port, ref reactors);
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 

--- a/Playground/Tls/Hybrid/Program.cs
+++ b/Playground/Tls/Hybrid/Program.cs
@@ -39,22 +39,39 @@ string? keyOverride  = null;
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 
 var tlsOptions = new TlsOptions
 {
-    CertificatePath = certPath,
-    KeyPath         = keyPath,
+    CertificatePath = certPath,                            // PEM chain file (or CertificatePem for in-memory)
+    KeyPath         = keyPath,                             // PEM key file (or KeyPem for in-memory)
+    Alpn            = ["http/1.1"],                        // protocols this port serves, most-preferred first
 
     // NOT the default - TLS is OpenSSL both ways unless you ask for this. It is what lets the
     // handler below write PLAINTEXT to the connection: the kernel turns it into records on send.
     // Remove this line and conn.Write would put cleartext on the wire.
-    KernelTx = true,
+    KernelTx        = true,
+
+    KernelRx        = false,                               // kTLS receive (experimental; requires KernelTx)
 };
 
 byte[] body = new byte[bodyBytes];

--- a/Playground/Tls/Ktls/Program.cs
+++ b/Playground/Tls/Ktls/Program.cs
@@ -39,27 +39,42 @@ string? keyOverride  = null;
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 
 var tlsOptions = new TlsOptions
 {
-    CertificatePath = certPath,
-    KeyPath         = keyPath,
+    CertificatePath = certPath,                            // PEM chain file (or CertificatePem for in-memory)
+    KeyPath         = keyPath,                             // PEM key file (or KeyPem for in-memory)
+    Alpn            = ["http/1.1"],                        // protocols this port serves, most-preferred first
 
     // NOT the default - TLS is OpenSSL both ways unless you ask for this. It is what lets the
     // handler below write PLAINTEXT to the connection: the kernel turns it into records on send.
     // Remove this line and conn.Write would put cleartext on the wire.
-    KernelTx = true,
+    KernelTx        = true,
 
     // Full kTLS: the kernel decrypts inbound too. Experimental - about one first connection in
     // twelve fails outright, and a client sending a TLS 1.3 KeyUpdate loses the connection.
     // Tls/Hybrid is this same server without this line: kernel TX, OpenSSL RX, deployable today.
-    KernelRx = true,
+    KernelRx        = true,
 };
 
 byte[] body = new byte[bodyBytes];

--- a/Playground/Tls/KtlsPipes/Program.cs
+++ b/Playground/Tls/KtlsPipes/Program.cs
@@ -57,25 +57,40 @@ string? keyOverride  = null;
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 
 var tlsOptions = new TlsOptions
 {
-    CertificatePath = certPath,
-    KeyPath = keyPath,
+    CertificatePath = certPath,                            // PEM chain file (or CertificatePem for in-memory)
+    KeyPath         = keyPath,                             // PEM key file (or KeyPem for in-memory)
+    Alpn            = ["http/1.1"],                        // protocols this port serves, most-preferred first
 
     // NOT the default - TLS is OpenSSL both ways unless you ask for this.
     // Playground/Tls/OpenSslPipes is the same server without these two lines.
-    KernelTx = true,
+    KernelTx        = true,
 
     // Full kTLS: the kernel decrypts inbound too. Experimental - about one first connection in
     // twelve fails outright, and a KeyUpdate is fatal. Drop this line for the hybrid.
-    KernelRx = true,
+    KernelRx        = true,
 };
 
 byte[] body = new byte[bodyBytes];

--- a/Playground/Tls/MultiPort/Program.cs
+++ b/Playground/Tls/MultiPort/Program.cs
@@ -39,19 +39,35 @@ string? keyOverride  = null;
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
-        ExtraPorts = [tlsPort],   // every reactor listens on both; ListenerPort says which one accepted
+        Port             = port,
+        ExtraPorts       = [tlsPort],                      // every reactor listens on both; ListenerPort says which one accepted
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 
 // Default backend: OpenSSL in both directions. Only connections on the TLS door go near this.
 var tlsOptions = new TlsOptions
 {
-    CertificatePath = certPath,
-    KeyPath         = keyPath,
+    CertificatePath = certPath,                            // PEM chain file (or CertificatePem for in-memory)
+    KeyPath         = keyPath,                             // PEM key file (or KeyPem for in-memory)
+    Alpn            = ["http/1.1"],                        // protocols this port serves, most-preferred first
+    KernelTx        = false,                               // kTLS transmit offload (kernel makes the records)
+    KernelRx        = false,                               // kTLS receive (experimental; requires KernelTx)
 };
 
 const string bodyText = "multiport-ok\n";

--- a/Playground/Tls/OpenSsl/Program.cs
+++ b/Playground/Tls/OpenSsl/Program.cs
@@ -56,20 +56,38 @@ string? keyOverride  = null;
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 
 var tlsOptions = new TlsOptions
 {
-    // No KernelTx line - false is the default, so this sample IS the stock configuration: no TLS
+    CertificatePath = certPath,                            // PEM chain file (or CertificatePem for in-memory)
+    KeyPath         = keyPath,                             // PEM key file (or KeyPem for in-memory)
+    Alpn            = ["http/1.1"],                        // protocols this port serves, most-preferred first
+
+    // KernelTx stays false (the default), so this sample IS the stock configuration: no TLS
     // ULP on the socket, OpenSSL encrypts and decrypts, MSG_WAITALL stays on, and nothing here
     // needs the 'tls' kernel module. Tls/Ktls is the sample that opts into the kernel path.
-    CertificatePath = certPath,
-    KeyPath         = keyPath,
+    KernelTx        = false,
+    KernelRx        = false,                               // kTLS receive (experimental; requires KernelTx)
 };
 
 byte[] body = new byte[bodyBytes];

--- a/Playground/Tls/OpenSslPipes/Program.cs
+++ b/Playground/Tls/OpenSslPipes/Program.cs
@@ -55,22 +55,39 @@ string? keyOverride  = null;
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 
 var tlsOptions = new TlsOptions
 {
-    CertificatePath = certPath,
-    KeyPath = keyPath,
+    CertificatePath = certPath,                            // PEM chain file (or CertificatePem for in-memory)
+    KeyPath         = keyPath,                             // PEM key file (or KeyPem for in-memory)
+    Alpn            = ["http/1.1"],                        // protocols this port serves, most-preferred first
 
-    // No KernelTx line - false is the default. No TLS ULP on the socket, so OpenSSL encrypts and
+    // KernelTx stays false (the default). No TLS ULP on the socket, so OpenSSL encrypts and
     // decrypts and nothing here needs the 'tls' kernel module - which also keeps TLS 1.2, any
     // ciphersuite and session resumption. Playground/Tls/KtlsPipes adds the one line that
     // changes this.
+    KernelTx        = false,
+    KernelRx        = false,                               // kTLS receive (experimental; requires KernelTx)
 };
 
 byte[] body = new byte[bodyBytes];

--- a/Playground/Tls/SslStream/Program.cs
+++ b/Playground/Tls/SslStream/Program.cs
@@ -39,10 +39,24 @@ var certificate = X509Certificate2.CreateFromPemFile(certPath, keyPath);
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -202,19 +202,35 @@ const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
-        ExtraPorts = [tlsPort],   // every reactor listens on both; ListenerPort says which one accepted
+        Port             = port,
+        ExtraPorts       = [tlsPort],                      // every reactor listens on both; ListenerPort says which one accepted
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 
 // Default backend: OpenSSL in both directions. Only connections on the TLS door go near this.
 var tlsOptions = new TlsOptions
 {
-    CertificatePath = certPath,
-    KeyPath         = keyPath,
+    CertificatePath = certPath,                            // PEM chain file (or CertificatePem for in-memory)
+    KeyPath         = keyPath,                             // PEM key file (or KeyPem for in-memory)
+    Alpn            = [&quot;http/1.1&quot;],                        // protocols this port serves, most-preferred first
+    KernelTx        = false,                               // kTLS transmit offload (kernel makes the records)
+    KernelRx        = false,                               // kTLS receive (experimental; requires KernelTx)
 };
 
 const string bodyText = &quot;multiport-ok\n&quot;;
@@ -352,10 +368,24 @@ var certificate = X509Certificate2.CreateFromPemFile(certPath, keyPath);
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 
@@ -460,13 +490,24 @@ WriteOverflowStrategy overflow = WriteOverflowStrategy.Grow;
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port          = port,
-        WriteSlabSize = slabSize,
-        WriteOverflow = overflow,
-        ZeroCopySend  = zeroCopy,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = slabSize,                       // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = overflow,                       // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = zeroCopy,                       // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 
@@ -549,10 +590,24 @@ int    reactors = Environment.ProcessorCount;  // one ring per reactor, one reac
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 
@@ -628,10 +683,24 @@ int    reactors = Environment.ProcessorCount;  // one ring per reactor, one reac
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 
@@ -722,10 +791,24 @@ certificate = X509CertificateLoader.LoadPkcs12(certificate.Export(X509ContentTyp
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 
@@ -851,8 +934,23 @@ using var engine = new QuicEngine(certPath, keyPath, cidLength, alpn: [&quot;h3&
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
-    Tcp = new TcpOptions { Port = tcpPort },
+    ReactorCount   = reactors,
+    RingEntries    = 8192,                                  // SQ/CQ depth per ring
+    DualStack      = false,                                 // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Tcp = new TcpOptions
+    {
+        Port             = tcpPort,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
+    },
     Udp = new UdpOptions { RecvSlots = udpRecvSlots, Gro = gro },
     Quic = new QuicOptions
     {
@@ -1006,14 +1104,24 @@ using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: null, m
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
-    Tcp = null,   // QUIC-only: no TCP listener is bound
-    Udp = new UdpOptions { RecvSlots = udpRecvSlots },
+    ReactorCount   = reactors,   // one ring per reactor, one reactor per core
+    RingEntries    = 8192,       // io_uring SQ/CQ depth
+    DualStack      = false,      // IPv4-only sockets; true binds dual-stack IPv6 (::)
+    RecvBufferSize = 32 * 1024,  // bytes per slot in the shared TCP recv ring
+    RecvSlots      = 4096,       // slots in that shared recv ring
+    Incremental    = null,       // shared recv ring; non-null = per-connection rings (kernel 6.12+)
+    Tcp            = null,       // QUIC-only: no TCP listener is bound
+    Udp = new UdpOptions
+    {
+        RecvSlots = udpRecvSlots,  // multishot recv slots per reactor - datagrams the ring can hold at once
+        Gro       = true,          // UDP_GRO: coalesce a received datagram burst into one recv
+    },
     Quic = new QuicOptions
     {
-        Port = quicPort,
-        LocalCidLength = 8,
-        ConnectionFactory = engine.CreateFactory(),
+        Port              = quicPort,                // https://127.0.0.1:8443/ - UDP, not TCP
+        LocalCidLength    = 8,                       // must match the engine&#x27;s cidLength
+        IdleTimeoutMs     = 60_000,                  // close a connection idle this long (no packets)
+        ConnectionFactory = engine.CreateFactory(),  // the engine adopts each new connection
     },
 };
 
@@ -1121,10 +1229,24 @@ bool insecure = false;
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                          // io_uring rings/threads - one per core
+    RingEntries    = 8192,                              // SQ/CQ depth per ring
+    DualStack      = false,                             // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                         // bytes per shared recv buffer
+    RecvSlots      = 4096,                              // shared recv buffer-ring depth
+    Incremental    = null,                              // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                              // no raw UDP sockets (TCP-only server)
+    Quic           = null,                              // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                          // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                        // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                   // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                        // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,  // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                       // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                          // per-connection recv completion queue depth
     },
 };
 
@@ -1142,18 +1264,24 @@ for (int i = 0; i &lt; threads.Length; i++)
         // CA belongs in CaFile, not here.
         TlsClientContext tls = TlsClientContext.Create(new TlsClientOptions
         {
-            ServerName        = originName,
-            AlpnProtocols     = [&quot;http/1.1&quot;],
-            CaFile            = caFile,
-            VerifyCertificate = !insecure,
+            ServerName         = originName,             // sent as SNI, checked against the cert (required)
+            AlpnProtocols      = [&quot;http/1.1&quot;],           // offered most-preferred first; [] offers none
+            CaFile             = caFile,                 // PEM trust anchors; null = system store
+            VerifyCertificate  = !insecure,              // off = encrypted but UNAUTHENTICATED (tests only)
+            MinimumVersion     = OpenSslVersions.Tls12,  // lowest TLS accepted; Tls13 (0x0304) = 1.3-only
+            HandshakeTimeoutMs = 10_000,                 // handshake ceiling before the connect fails
         });
 
         HttpClientPool.Start(r, new HttpClientOptions
         {
-            Host     = originIp,
-            Port     = originPort,
-            PoolSize = 2,
-            Tls      = tls,
+            Host              = originIp,         // IPv4 literal - DNS would block the reactor
+            Port              = originPort,       // origin port
+            PoolSize          = 2,                // connections to the origin, per reactor
+            MaxResponseBytes  = 8 * 1024 * 1024,  // per-request ceiling for headers + body
+            SendBufferSize    = 16 * 1024,        // per-connection send buffer
+            ReceiveBufferSize = 16 * 1024,        // per-connection recv buffer; grows to MaxResponseBytes
+            Tls               = tls,              // TLS context for https; null = cleartext
+            AcquireTimeoutMs  = 10_000,           // wait for a free connection when all are busy
         });
     };
 
@@ -1562,27 +1690,42 @@ const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 
 var tlsOptions = new TlsOptions
 {
-    CertificatePath = certPath,
-    KeyPath         = keyPath,
+    CertificatePath = certPath,                            // PEM chain file (or CertificatePem for in-memory)
+    KeyPath         = keyPath,                             // PEM key file (or KeyPem for in-memory)
+    Alpn            = [&quot;http/1.1&quot;],                        // protocols this port serves, most-preferred first
 
     // NOT the default - TLS is OpenSSL both ways unless you ask for this. It is what lets the
     // handler below write PLAINTEXT to the connection: the kernel turns it into records on send.
     // Remove this line and conn.Write would put cleartext on the wire.
-    KernelTx = true,
+    KernelTx        = true,
 
     // Full kTLS: the kernel decrypts inbound too. Experimental - about one first connection in
     // twelve fails outright, and a client sending a TLS 1.3 KeyUpdate loses the connection.
     // Tls/Hybrid is this same server without this line: kernel TX, OpenSSL RX, deployable today.
-    KernelRx = true,
+    KernelRx        = true,
 };
 
 byte[] body = new byte[bodyBytes];
@@ -1763,25 +1906,40 @@ const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 
 var tlsOptions = new TlsOptions
 {
-    CertificatePath = certPath,
-    KeyPath = keyPath,
+    CertificatePath = certPath,                            // PEM chain file (or CertificatePem for in-memory)
+    KeyPath         = keyPath,                             // PEM key file (or KeyPem for in-memory)
+    Alpn            = [&quot;http/1.1&quot;],                        // protocols this port serves, most-preferred first
 
     // NOT the default - TLS is OpenSSL both ways unless you ask for this.
     // Playground/Tls/OpenSslPipes is the same server without these two lines.
-    KernelTx = true,
+    KernelTx        = true,
 
     // Full kTLS: the kernel decrypts inbound too. Experimental - about one first connection in
     // twelve fails outright, and a KeyUpdate is fatal. Drop this line for the hybrid.
-    KernelRx = true,
+    KernelRx        = true,
 };
 
 byte[] body = new byte[bodyBytes];
@@ -1903,22 +2061,39 @@ const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 
 var tlsOptions = new TlsOptions
 {
-    CertificatePath = certPath,
-    KeyPath         = keyPath,
+    CertificatePath = certPath,                            // PEM chain file (or CertificatePem for in-memory)
+    KeyPath         = keyPath,                             // PEM key file (or KeyPem for in-memory)
+    Alpn            = [&quot;http/1.1&quot;],                        // protocols this port serves, most-preferred first
 
     // NOT the default - TLS is OpenSSL both ways unless you ask for this. It is what lets the
     // handler below write PLAINTEXT to the connection: the kernel turns it into records on send.
     // Remove this line and conn.Write would put cleartext on the wire.
-    KernelTx = true,
+    KernelTx        = true,
+
+    KernelRx        = false,                               // kTLS receive (experimental; requires KernelTx)
 };
 
 byte[] body = new byte[bodyBytes];
@@ -2094,20 +2269,38 @@ const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 
 var tlsOptions = new TlsOptions
 {
-    // No KernelTx line - false is the default, so this sample IS the stock configuration: no TLS
+    CertificatePath = certPath,                            // PEM chain file (or CertificatePem for in-memory)
+    KeyPath         = keyPath,                             // PEM key file (or KeyPem for in-memory)
+    Alpn            = [&quot;http/1.1&quot;],                        // protocols this port serves, most-preferred first
+
+    // KernelTx stays false (the default), so this sample IS the stock configuration: no TLS
     // ULP on the socket, OpenSSL encrypts and decrypts, MSG_WAITALL stays on, and nothing here
     // needs the &#x27;tls&#x27; kernel module. Tls/Ktls is the sample that opts into the kernel path.
-    CertificatePath = certPath,
-    KeyPath         = keyPath,
+    KernelTx        = false,
+    KernelRx        = false,                               // kTLS receive (experimental; requires KernelTx)
 };
 
 byte[] body = new byte[bodyBytes];
@@ -2287,22 +2480,39 @@ const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 
 var tlsOptions = new TlsOptions
 {
-    CertificatePath = certPath,
-    KeyPath = keyPath,
+    CertificatePath = certPath,                            // PEM chain file (or CertificatePem for in-memory)
+    KeyPath         = keyPath,                             // PEM key file (or KeyPem for in-memory)
+    Alpn            = [&quot;http/1.1&quot;],                        // protocols this port serves, most-preferred first
 
-    // No KernelTx line - false is the default. No TLS ULP on the socket, so OpenSSL encrypts and
+    // KernelTx stays false (the default). No TLS ULP on the socket, so OpenSSL encrypts and
     // decrypts and nothing here needs the &#x27;tls&#x27; kernel module - which also keeps TLS 1.2, any
     // ciphersuite and session resumption. Playground/Tls/KtlsPipes adds the one line that
     // changes this.
+    KernelTx        = false,
+    KernelRx        = false,                               // kTLS receive (experimental; requires KernelTx)
 };
 
 byte[] body = new byte[bodyBytes];
@@ -2408,16 +2618,24 @@ using ioxide.nghttp2;
 
 var config = new ServerConfig
 {
-    ReactorCount = Environment.ProcessorCount,   // one ring per reactor, one reactor per core
-    RingEntries  = 8192,                         // io_uring SQ/CQ depth
-
-    RecvBufferSize = 32 * 1024,
-    RecvSlots      = 4096,
-
+    ReactorCount   = Environment.ProcessorCount,  // one ring per reactor, one reactor per core
+    RingEntries    = 8192,                         // io_uring SQ/CQ depth
+    DualStack      = false,                         // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                    // bytes per shared recv buffer
+    RecvSlots      = 4096,                          // shared recv buffer-ring depth
+    Incremental    = null,                          // per-connection recv rings (6.12+) - see the incremental example
+    Udp            = null,                          // no raw UDP sockets
+    Quic           = null,                          // no QUIC transport
     Tcp = new TcpOptions
     {
-        Port          = 8080,
-        WriteSlabSize = 16 * 1024,               // a batch of multiplexed responses leaves in one send
+        Port             = 8080,
+        ExtraPorts       = [],                     // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                   // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,              // a batch of multiplexed responses leaves in one send
+        PoolMax          = 1024,                   // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                  // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                     // per-connection recv completion queue depth
     },
 };
 
@@ -2473,8 +2691,25 @@ using ioxide.http2;
 
 var config = new ServerConfig
 {
-    ReactorCount = Environment.ProcessorCount,
-    Tcp = new TcpOptions { Port = 8080 },
+    ReactorCount   = Environment.ProcessorCount,  // one ring per reactor, one reactor per core
+    RingEntries    = 8192,                         // SQ/CQ depth per ring
+    DualStack      = false,                         // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                    // bytes per shared recv buffer
+    RecvSlots      = 4096,                          // shared recv buffer-ring depth
+    Incremental    = null,                          // per-connection recv rings (6.12+) - see the incremental example
+    Udp            = null,                          // no raw UDP sockets
+    Quic           = null,                          // no QUIC transport
+    Tcp = new TcpOptions
+    {
+        Port             = 8080,
+        ExtraPorts       = [],                     // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                   // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,              // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                   // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                  // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                     // per-connection recv completion queue depth
+    },
 };
 
 byte[] body = &quot;ok&quot;u8.ToArray();
@@ -2567,11 +2802,24 @@ bool kernelRx = false;
 
 var config = new ServerConfig
 {
-    ReactorCount = reactors,
-    Incremental = incrementalBuffers ? new IncrementalOptions() : null,
+    ReactorCount   = reactors,                                              // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                                  // SQ/CQ depth per ring
+    DualStack      = false,                                                 // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                                             // bytes per shared recv buffer
+    RecvSlots      = 4096,                                                  // shared recv buffer-ring depth
+    Incremental    = incrementalBuffers ? new IncrementalOptions() : null,  // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                                  // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                                  // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port = port,
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
     },
 };
 
@@ -2591,14 +2839,13 @@ for (int i = 0; i &lt; threads.Length; i++)
 
     reactor.OnStart = r =&gt; TlsService.Start(r, new TlsOptions
     {
-        KernelTx = kernelTx,
-        KernelRx = kernelRx,
-        CertificatePath = certPath,
-        KeyPath = keyPath,
-
-        // Most preferred first. ALPN has no weights - RFC 7301 carries a plain ordered list - so
-        // position IS the preference, and a client offering both lands on h2.
-        Alpn = [&quot;h2&quot;, &quot;http/1.1&quot;],
+        CertificatePath = certPath,                        // PEM certificate chain file (leaf first)
+        CertificatePem  = null,                            // in-memory PEM alternative - set one, not both
+        KeyPath         = keyPath,                         // PEM private key file
+        KeyPem          = null,                            // in-memory PEM alternative to KeyPath
+        Alpn            = [&quot;h2&quot;, &quot;http/1.1&quot;],              // ORDERED, most preferred first - a client offering both gets h2
+        KernelTx        = kernelTx,                        // kTLS encrypt: kernel makes the records (off = OpenSSL both ways)
+        KernelRx        = kernelRx,                        // kTLS decrypt: needs KernelTx; experimental (see the knob above)
     });
 
     reactor.TcpHandle = async (r, conn) =&gt;
@@ -2747,6 +2994,7 @@ var config = new ServerConfig
 
     RecvBufferSize = 32 * 1024,
     RecvSlots      = 4096,
+    Incremental    = null,                       // per-connection recv rings (6.12+) - see the incremental example
 
     Tcp = null,                                  // QUIC only: no TCP listener is opened
 
@@ -2823,6 +3071,7 @@ var config = new ServerConfig
 
     RecvBufferSize = 32 * 1024,
     RecvSlots      = 4096,
+    Incremental    = null,                       // per-connection recv rings (6.12+) - see the incremental example
 
     Tcp = null,                                  // QUIC only: no TCP listener is opened
 
@@ -2898,6 +3147,7 @@ var config = new ServerConfig
 
     RecvBufferSize = 32 * 1024,
     RecvSlots      = 4096,
+    Incremental    = null,                       // per-connection recv rings (6.12+) - see the incremental example
 
     Tcp = null,                                  // QUIC only: no TCP listener is opened
 
@@ -3029,10 +3279,24 @@ const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
-    ReactorCount = Environment.ProcessorCount,
+    ReactorCount   = Environment.ProcessorCount,
+    RingEntries    = 8192,       // SQ/CQ depth per ring
+    DualStack      = false,      // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,  // bytes per shared recv buffer
+    RecvSlots      = 4096,       // shared recv buffer-ring depth
+    Incremental    = null,       // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,       // no raw UDP sockets (TCP-only frontend)
+    Quic           = null,       // no QUIC listener; the frontend is TLS-over-TCP
     Tcp = new TcpOptions
     {
-        Port = 8443,
+        Port             = 8443,
+        ExtraPorts       = [],                                 // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                               // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                          // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                               // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,         // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                              // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                                 // per-connection recv completion queue depth
     },
 };
 
@@ -3060,24 +3324,34 @@ for (int i = 0; i &lt; threads.Length; i++)
         // protocol, so it offers exactly one.
         TlsService.Start(r, new TlsOptions
         {
-            CertificatePath = certPath,
-            KeyPath = keyPath,
-            Alpn = [&quot;http/1.1&quot;],
+            CertificatePath = certPath,      // PEM cert chain file (set exactly one of Path/Pem)
+            CertificatePem  = null,          // in-memory PEM alternative to CertificatePath
+            KeyPath         = keyPath,       // PEM private key file (set exactly one of Path/Pem)
+            KeyPem          = null,          // in-memory PEM alternative to KeyPath
+            Alpn            = [&quot;http/1.1&quot;],  // protocols offered, most preferred first
+            KernelTx        = false,         // kTLS encrypt (off = OpenSSL both ways)
+            KernelRx        = false,         // kTLS decrypt; requires KernelTx, experimental
         });
 
         // Outbound: one context per reactor, shared by that reactor&#x27;s pool - it holds no
         // per-connection state, so every connection opened from it gets its own SSL.
         HttpClientPool.Start(r, new HttpClientOptions
         {
-            Host = upstreamHost,
-            Port = upstreamPort,
-            PoolSize = upstreamPool,
+            Host              = upstreamHost,     // origin address (IPv4 literal; DNS would block the reactor)
+            Port              = upstreamPort,     // origin port
+            PoolSize          = upstreamPool,     // connections kept open; round-robin, one request each
+            MaxResponseBytes  = 8 * 1024 * 1024,  // per-request ceiling for headers + body
+            SendBufferSize    = 16 * 1024,        // per-connection send buffer
+            ReceiveBufferSize = 16 * 1024,        // per-connection recv buffer (grows to MaxResponseBytes)
+            AcquireTimeoutMs  = 10_000,           // how long a request waits for a free connection
             Tls = TlsClientContext.Create(new TlsClientOptions
             {
-                ServerName = upstreamName,
-                AlpnProtocols = [&quot;http/1.1&quot;],
-                CaFile = upstreamInsecure ? null : upstreamCa,
-                VerifyCertificate = !upstreamInsecure,
+                ServerName         = upstreamName,                          // sent as SNI, checked against the cert
+                AlpnProtocols      = [&quot;http/1.1&quot;],                          // ALPN offer, most preferred first
+                VerifyCertificate  = !upstreamInsecure,                     // off = encrypted but UNAUTHENTICATED
+                CaFile             = upstreamInsecure ? null : upstreamCa,  // PEM trust anchors; null = system store
+                MinimumVersion     = OpenSslVersions.Tls12,                 // lowest TLS accepted; Tls13 = 1.3 only
+                HandshakeTimeoutMs = 10_000,                                // handshake deadline
             }),
         });
     };
@@ -3224,10 +3498,24 @@ const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
-    ReactorCount = Environment.ProcessorCount,
+    ReactorCount   = Environment.ProcessorCount,
+    RingEntries    = 8192,       // SQ/CQ depth per ring
+    DualStack      = false,      // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,  // bytes per shared recv buffer
+    RecvSlots      = 4096,       // shared recv buffer-ring depth
+    Incremental    = null,       // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,       // no raw UDP sockets (TCP-only frontend)
+    Quic           = null,       // no QUIC listener; the frontend is TLS-over-TCP
     Tcp = new TcpOptions
     {
-        Port = 8443,
+        Port             = 8443,
+        ExtraPorts       = [],                                 // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                               // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                          // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                               // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,         // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                              // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                                 // per-connection recv completion queue depth
     },
 };
 
@@ -3255,24 +3543,32 @@ for (int i = 0; i &lt; threads.Length; i++)
         // protocol, so it offers exactly one.
         TlsService.Start(r, new TlsOptions
         {
-            CertificatePath = certPath,
-            KeyPath = keyPath,
-            Alpn = [&quot;http/1.1&quot;],
+            CertificatePath = certPath,      // PEM cert chain file (set exactly one of Path/Pem)
+            CertificatePem  = null,          // in-memory PEM alternative to CertificatePath
+            KeyPath         = keyPath,       // PEM private key file (set exactly one of Path/Pem)
+            KeyPem          = null,          // in-memory PEM alternative to KeyPath
+            Alpn            = [&quot;http/1.1&quot;],  // protocols offered, most preferred first
+            KernelTx        = false,         // kTLS encrypt (off = OpenSSL both ways)
+            KernelRx        = false,         // kTLS decrypt; requires KernelTx, experimental
         });
 
         // Outbound: one context per reactor, shared by that reactor&#x27;s pool - it holds no
         // per-connection state, so every connection opened from it gets its own SSL.
         Http2ClientPool.Start(r, new Http2ClientOptions
         {
-            Host = upstreamHost,
-            Port = upstreamPort,
-            PoolSize = upstreamPool,
+            Host             = upstreamHost,     // origin address (IPv4 literal; DNS would block the reactor)
+            Port             = upstreamPort,     // origin port
+            PoolSize         = upstreamPool,     // h2 multiplexes: one connection carries many streams
+            AcquireTimeoutMs = 10_000,           // how long a request waits for a usable connection
+            MaxResponseBytes = 8 * 1024 * 1024,  // per-request ceiling for headers + body
             Tls = TlsClientContext.Create(new TlsClientOptions
             {
-                ServerName = upstreamName,
-                AlpnProtocols = [&quot;h2&quot;],       // h2 over TLS is chosen by ALPN, never assumed
-                CaFile = upstreamInsecure ? null : upstreamCa,
-                VerifyCertificate = !upstreamInsecure,
+                ServerName         = upstreamName,                          // sent as SNI, checked against the cert
+                AlpnProtocols      = [&quot;h2&quot;],                                // h2 over TLS is chosen by ALPN, never assumed
+                VerifyCertificate  = !upstreamInsecure,                     // off = encrypted but UNAUTHENTICATED
+                CaFile             = upstreamInsecure ? null : upstreamCa,  // PEM trust anchors; null = system store
+                MinimumVersion     = OpenSslVersions.Tls12,                 // lowest TLS accepted; Tls13 = 1.3 only
+                HandshakeTimeoutMs = 10_000,                                // handshake deadline
             }),
         });
     };
@@ -3420,10 +3716,24 @@ const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
-    ReactorCount = Environment.ProcessorCount,
+    ReactorCount   = Environment.ProcessorCount,
+    RingEntries    = 8192,       // SQ/CQ depth per ring
+    DualStack      = false,      // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,  // bytes per shared recv buffer
+    RecvSlots      = 4096,       // shared recv buffer-ring depth
+    Incremental    = null,       // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,       // no raw UDP sockets (TCP-only frontend)
+    Quic           = null,       // no QUIC listener; the frontend is TLS-over-TCP
     Tcp = new TcpOptions
     {
-        Port = 8443,
+        Port             = 8443,
+        ExtraPorts       = [],                                 // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                               // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                          // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                               // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,         // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                              // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                                 // per-connection recv completion queue depth
     },
 };
 
@@ -3444,9 +3754,13 @@ for (int i = 0; i &lt; threads.Length; i++)
         // protocol, so it offers exactly one.
         TlsService.Start(r, new TlsOptions
         {
-            CertificatePath = certPath,
-            KeyPath = keyPath,
-            Alpn = [&quot;http/1.1&quot;],
+            CertificatePath = certPath,      // PEM cert chain file (set exactly one of Path/Pem)
+            CertificatePem  = null,          // in-memory PEM alternative to CertificatePath
+            KeyPath         = keyPath,       // PEM private key file (set exactly one of Path/Pem)
+            KeyPem          = null,          // in-memory PEM alternative to KeyPath
+            Alpn            = [&quot;http/1.1&quot;],  // protocols offered, most preferred first
+            KernelTx        = false,         // kTLS encrypt (off = OpenSSL both ways)
+            KernelRx        = false,         // kTLS decrypt; requires KernelTx, experimental
         });
 
         // Outbound: no TLS options, because QUIC has no cleartext mode - TLS 1.3 is inside the
@@ -3454,10 +3768,12 @@ for (int i = 0; i &lt; threads.Length; i++)
         // this pool is what makes the reactor grow its client-side QUIC transport.
         Http3ClientPool.Start(r, new Http3ClientOptions
         {
-            Host = upstreamHost,
-            Port = upstreamPort,
-            ServerName = upstreamName,
-            PoolSize = upstreamPool,
+            Host             = upstreamHost,     // origin address (IPv4 literal; DNS would block the reactor)
+            Port             = upstreamPort,     // origin&#x27;s QUIC (UDP) port
+            ServerName       = upstreamName,     // SNI / :authority, checked against the cert
+            PoolSize         = upstreamPool,     // h3 multiplexes: one connection carries many streams
+            AcquireTimeoutMs = 10_000,           // how long a request waits (handshake included)
+            MaxResponseBytes = 8 * 1024 * 1024,  // per-request ceiling for headers + body
         });
     };
 
@@ -3602,10 +3918,24 @@ const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
-    ReactorCount = Environment.ProcessorCount,
+    ReactorCount   = Environment.ProcessorCount,
+    RingEntries    = 8192,       // SQ/CQ depth per ring
+    DualStack      = false,      // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,  // bytes per shared recv buffer
+    RecvSlots      = 4096,       // shared recv buffer-ring depth
+    Incremental    = null,       // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,       // no raw UDP sockets (TCP-only frontend)
+    Quic           = null,       // no QUIC listener; the frontend is TLS-over-TCP
     Tcp = new TcpOptions
     {
-        Port = 8443,
+        Port             = 8443,
+        ExtraPorts       = [],                                 // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                               // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                          // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                               // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,         // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                              // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                                 // per-connection recv completion queue depth
     },
 };
 
@@ -3633,24 +3963,34 @@ for (int i = 0; i &lt; threads.Length; i++)
         // client that cannot do h2 fails ALPN rather than silently getting something else.
         TlsService.Start(r, new TlsOptions
         {
-            CertificatePath = certPath,
-            KeyPath = keyPath,
-            Alpn = [&quot;h2&quot;],
+            CertificatePath = certPath,  // PEM cert chain file (set exactly one of Path/Pem)
+            CertificatePem  = null,      // in-memory PEM alternative to CertificatePath
+            KeyPath         = keyPath,   // PEM private key file (set exactly one of Path/Pem)
+            KeyPem          = null,      // in-memory PEM alternative to KeyPath
+            Alpn            = [&quot;h2&quot;],    // protocols offered, most preferred first
+            KernelTx        = false,     // kTLS encrypt (off = OpenSSL both ways)
+            KernelRx        = false,     // kTLS decrypt; requires KernelTx, experimental
         });
 
         // Outbound: one context per reactor, shared by that reactor&#x27;s pool - it holds no
         // per-connection state, so every connection opened from it gets its own SSL.
         HttpClientPool.Start(r, new HttpClientOptions
         {
-            Host = upstreamHost,
-            Port = upstreamPort,
-            PoolSize = upstreamPool,
+            Host              = upstreamHost,     // origin address (IPv4 literal; DNS would block the reactor)
+            Port              = upstreamPort,     // origin port
+            PoolSize          = upstreamPool,     // connections kept open; round-robin, one request each
+            MaxResponseBytes  = 8 * 1024 * 1024,  // per-request ceiling for headers + body
+            SendBufferSize    = 16 * 1024,        // per-connection send buffer
+            ReceiveBufferSize = 16 * 1024,        // per-connection recv buffer (grows to MaxResponseBytes)
+            AcquireTimeoutMs  = 10_000,           // how long a request waits for a free connection
             Tls = TlsClientContext.Create(new TlsClientOptions
             {
-                ServerName = upstreamName,
-                AlpnProtocols = [&quot;http/1.1&quot;],
-                CaFile = upstreamInsecure ? null : upstreamCa,
-                VerifyCertificate = !upstreamInsecure,
+                ServerName         = upstreamName,                          // sent as SNI, checked against the cert
+                AlpnProtocols      = [&quot;http/1.1&quot;],                          // ALPN offer, most preferred first
+                VerifyCertificate  = !upstreamInsecure,                     // off = encrypted but UNAUTHENTICATED
+                CaFile             = upstreamInsecure ? null : upstreamCa,  // PEM trust anchors; null = system store
+                MinimumVersion     = OpenSslVersions.Tls12,                 // lowest TLS accepted; Tls13 = 1.3 only
+                HandshakeTimeoutMs = 10_000,                                // handshake deadline
             }),
         });
     };
@@ -3754,10 +4094,24 @@ const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
-    ReactorCount = Environment.ProcessorCount,
+    ReactorCount   = Environment.ProcessorCount,
+    RingEntries    = 8192,       // SQ/CQ depth per ring
+    DualStack      = false,      // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,  // bytes per shared recv buffer
+    RecvSlots      = 4096,       // shared recv buffer-ring depth
+    Incremental    = null,       // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,       // no raw UDP sockets (TCP-only frontend)
+    Quic           = null,       // no QUIC listener; the frontend is TLS-over-TCP
     Tcp = new TcpOptions
     {
-        Port = 8443,
+        Port             = 8443,
+        ExtraPorts       = [],                                 // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                               // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                          // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                               // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,         // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                              // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                                 // per-connection recv completion queue depth
     },
 };
 
@@ -3785,24 +4139,32 @@ for (int i = 0; i &lt; threads.Length; i++)
         // client that cannot do h2 fails ALPN rather than silently getting something else.
         TlsService.Start(r, new TlsOptions
         {
-            CertificatePath = certPath,
-            KeyPath = keyPath,
-            Alpn = [&quot;h2&quot;],
+            CertificatePath = certPath,  // PEM cert chain file (set exactly one of Path/Pem)
+            CertificatePem  = null,      // in-memory PEM alternative to CertificatePath
+            KeyPath         = keyPath,   // PEM private key file (set exactly one of Path/Pem)
+            KeyPem          = null,      // in-memory PEM alternative to KeyPath
+            Alpn            = [&quot;h2&quot;],    // protocols offered, most preferred first
+            KernelTx        = false,     // kTLS encrypt (off = OpenSSL both ways)
+            KernelRx        = false,     // kTLS decrypt; requires KernelTx, experimental
         });
 
         // Outbound: one context per reactor, shared by that reactor&#x27;s pool - it holds no
         // per-connection state, so every connection opened from it gets its own SSL.
         Http2ClientPool.Start(r, new Http2ClientOptions
         {
-            Host = upstreamHost,
-            Port = upstreamPort,
-            PoolSize = upstreamPool,
+            Host             = upstreamHost,     // origin address (IPv4 literal; DNS would block the reactor)
+            Port             = upstreamPort,     // origin port
+            PoolSize         = upstreamPool,     // h2 multiplexes: one connection carries many streams
+            AcquireTimeoutMs = 10_000,           // how long a request waits for a usable connection
+            MaxResponseBytes = 8 * 1024 * 1024,  // per-request ceiling for headers + body
             Tls = TlsClientContext.Create(new TlsClientOptions
             {
-                ServerName = upstreamName,
-                AlpnProtocols = [&quot;h2&quot;],       // h2 over TLS is chosen by ALPN, never assumed
-                CaFile = upstreamInsecure ? null : upstreamCa,
-                VerifyCertificate = !upstreamInsecure,
+                ServerName         = upstreamName,                          // sent as SNI, checked against the cert
+                AlpnProtocols      = [&quot;h2&quot;],                                // h2 over TLS is chosen by ALPN, never assumed
+                VerifyCertificate  = !upstreamInsecure,                     // off = encrypted but UNAUTHENTICATED
+                CaFile             = upstreamInsecure ? null : upstreamCa,  // PEM trust anchors; null = system store
+                MinimumVersion     = OpenSslVersions.Tls12,                 // lowest TLS accepted; Tls13 = 1.3 only
+                HandshakeTimeoutMs = 10_000,                                // handshake deadline
             }),
         });
     };
@@ -3906,10 +4268,24 @@ const string keyPath  = &quot;key.pem&quot;;
 
 var config = new ServerConfig
 {
-    ReactorCount = Environment.ProcessorCount,
+    ReactorCount   = Environment.ProcessorCount,
+    RingEntries    = 8192,       // SQ/CQ depth per ring
+    DualStack      = false,      // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,  // bytes per shared recv buffer
+    RecvSlots      = 4096,       // shared recv buffer-ring depth
+    Incremental    = null,       // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,       // no raw UDP sockets (TCP-only frontend)
+    Quic           = null,       // no QUIC listener; the frontend is TLS-over-TCP
     Tcp = new TcpOptions
     {
-        Port = 8443,
+        Port             = 8443,
+        ExtraPorts       = [],                                 // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                               // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                          // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                               // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,         // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                              // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                                 // per-connection recv completion queue depth
     },
 };
 
@@ -3930,9 +4306,13 @@ for (int i = 0; i &lt; threads.Length; i++)
         // client that cannot do h2 fails ALPN rather than silently getting something else.
         TlsService.Start(r, new TlsOptions
         {
-            CertificatePath = certPath,
-            KeyPath = keyPath,
-            Alpn = [&quot;h2&quot;],
+            CertificatePath = certPath,  // PEM cert chain file (set exactly one of Path/Pem)
+            CertificatePem  = null,      // in-memory PEM alternative to CertificatePath
+            KeyPath         = keyPath,   // PEM private key file (set exactly one of Path/Pem)
+            KeyPem          = null,      // in-memory PEM alternative to KeyPath
+            Alpn            = [&quot;h2&quot;],    // protocols offered, most preferred first
+            KernelTx        = false,     // kTLS encrypt (off = OpenSSL both ways)
+            KernelRx        = false,     // kTLS decrypt; requires KernelTx, experimental
         });
 
         // Outbound: no TLS options, because QUIC has no cleartext mode - TLS 1.3 is inside the
@@ -3940,10 +4320,12 @@ for (int i = 0; i &lt; threads.Length; i++)
         // this pool is what makes the reactor grow its client-side QUIC transport.
         Http3ClientPool.Start(r, new Http3ClientOptions
         {
-            Host = upstreamHost,
-            Port = upstreamPort,
-            ServerName = upstreamName,
-            PoolSize = upstreamPool,
+            Host             = upstreamHost,     // origin address (IPv4 literal; DNS would block the reactor)
+            Port             = upstreamPort,     // origin&#x27;s QUIC (UDP) port
+            ServerName       = upstreamName,     // SNI / :authority, checked against the cert
+            PoolSize         = upstreamPool,     // h3 multiplexes: one connection carries many streams
+            AcquireTimeoutMs = 10_000,           // how long a request waits (handshake included)
+            MaxResponseBytes = 8 * 1024 * 1024,  // per-request ceiling for headers + body
         });
     };
 
@@ -4041,18 +4423,31 @@ using ioxide.ngtcp2;
 const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
 const string keyPath  = &quot;key.pem&quot;;
 
-using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: [&quot;h3&quot;]);
+using var engine = new QuicEngine(certPath, keyPath,
+    cidLength: 8,                       // CID bytes this endpoint mints (1..20)
+    alpn: [&quot;h3&quot;],                       // the only protocol offered (else no_application_protocol)
+    maxSendRetentionBytes: 16L &lt;&lt; 20);  // per-connection send-retention high-water (default 16 MiB)
 
 var config = new ServerConfig
 {
-    ReactorCount = Environment.ProcessorCount,
-    Tcp = null,   // the proxy serves h3 only; its TCP sockets are all outbound
-    Udp = new UdpOptions { RecvSlots = 16 },
+    ReactorCount   = Environment.ProcessorCount,
+    RingEntries    = 8192,       // SQ/CQ depth per ring
+    DualStack      = false,      // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,  // bytes per shared recv buffer
+    RecvSlots      = 4096,       // shared recv buffer-ring depth
+    Incremental    = null,       // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Tcp            = null,       // the proxy serves h3 only; its TCP sockets are all outbound
+    Udp = new UdpOptions
+    {
+        RecvSlots = 16,  // multishot recv slots per reactor (datagrams in flight)
+        Gro       = true,                                 // UDP_GRO: coalesce datagrams into one recv (fewer syscalls)
+    },
     Quic = new QuicOptions
     {
-        Port = 8443,
-        LocalCidLength = 8,
-        ConnectionFactory = engine.CreateFactory(),
+        Port              = 8443,  // h3 over UDP - the QUIC listener
+        LocalCidLength    = 8,                                       // CID bytes this endpoint mints (must match the engine)
+        IdleTimeoutMs     = 60_000,                                  // transport idle backstop; 0 disables sweep eviction
+        ConnectionFactory = engine.CreateFactory(),                  // adopts new connections into the engine
     },
 };
 
@@ -4081,15 +4476,21 @@ for (int i = 0; i &lt; threads.Length; i++)
         // per-connection state, so every connection opened from it gets its own SSL.
         HttpClientPool.Start(r, new HttpClientOptions
         {
-            Host = upstreamHost,
-            Port = upstreamPort,
-            PoolSize = upstreamPool,
+            Host              = upstreamHost,     // origin address (IPv4 literal; DNS would block the reactor)
+            Port              = upstreamPort,     // origin port
+            PoolSize          = upstreamPool,     // connections kept open; round-robin, one request each
+            MaxResponseBytes  = 8 * 1024 * 1024,  // per-request ceiling for headers + body
+            SendBufferSize    = 16 * 1024,        // per-connection send buffer
+            ReceiveBufferSize = 16 * 1024,        // per-connection recv buffer (grows to MaxResponseBytes)
+            AcquireTimeoutMs  = 10_000,           // how long a request waits for a free connection
             Tls = TlsClientContext.Create(new TlsClientOptions
             {
-                ServerName = upstreamName,
-                AlpnProtocols = [&quot;http/1.1&quot;],
-                CaFile = upstreamInsecure ? null : upstreamCa,
-                VerifyCertificate = !upstreamInsecure,
+                ServerName         = upstreamName,                          // sent as SNI, checked against the cert
+                AlpnProtocols      = [&quot;http/1.1&quot;],                          // ALPN offer, most preferred first
+                VerifyCertificate  = !upstreamInsecure,                     // off = encrypted but UNAUTHENTICATED
+                CaFile             = upstreamInsecure ? null : upstreamCa,  // PEM trust anchors; null = system store
+                MinimumVersion     = OpenSslVersions.Tls12,                 // lowest TLS accepted; Tls13 = 1.3 only
+                HandshakeTimeoutMs = 10_000,                                // handshake deadline
             }),
         });
     };
@@ -4166,18 +4567,31 @@ using ioxide.ngtcp2;
 const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
 const string keyPath  = &quot;key.pem&quot;;
 
-using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: [&quot;h3&quot;]);
+using var engine = new QuicEngine(certPath, keyPath,
+    cidLength: 8,                       // CID bytes this endpoint mints (1..20)
+    alpn: [&quot;h3&quot;],                       // the only protocol offered (else no_application_protocol)
+    maxSendRetentionBytes: 16L &lt;&lt; 20);  // per-connection send-retention high-water (default 16 MiB)
 
 var config = new ServerConfig
 {
-    ReactorCount = Environment.ProcessorCount,
-    Tcp = null,   // the proxy serves h3 only; its TCP sockets are all outbound
-    Udp = new UdpOptions { RecvSlots = 16 },
+    ReactorCount   = Environment.ProcessorCount,
+    RingEntries    = 8192,       // SQ/CQ depth per ring
+    DualStack      = false,      // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,  // bytes per shared recv buffer
+    RecvSlots      = 4096,       // shared recv buffer-ring depth
+    Incremental    = null,       // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Tcp            = null,       // the proxy serves h3 only; its TCP sockets are all outbound
+    Udp = new UdpOptions
+    {
+        RecvSlots = 16,  // multishot recv slots per reactor (datagrams in flight)
+        Gro       = true,                                 // UDP_GRO: coalesce datagrams into one recv (fewer syscalls)
+    },
     Quic = new QuicOptions
     {
-        Port = 8443,
-        LocalCidLength = 8,
-        ConnectionFactory = engine.CreateFactory(),
+        Port              = 8443,  // h3 over UDP - the QUIC listener
+        LocalCidLength    = 8,                                       // CID bytes this endpoint mints (must match the engine)
+        IdleTimeoutMs     = 60_000,                                  // transport idle backstop; 0 disables sweep eviction
+        ConnectionFactory = engine.CreateFactory(),                  // adopts new connections into the engine
     },
 };
 
@@ -4206,15 +4620,19 @@ for (int i = 0; i &lt; threads.Length; i++)
         // per-connection state, so every connection opened from it gets its own SSL.
         Http2ClientPool.Start(r, new Http2ClientOptions
         {
-            Host = upstreamHost,
-            Port = upstreamPort,
-            PoolSize = upstreamPool,
+            Host             = upstreamHost,     // origin address (IPv4 literal; DNS would block the reactor)
+            Port             = upstreamPort,     // origin port
+            PoolSize         = upstreamPool,     // h2 multiplexes: one connection carries many streams
+            AcquireTimeoutMs = 10_000,           // how long a request waits for a usable connection
+            MaxResponseBytes = 8 * 1024 * 1024,  // per-request ceiling for headers + body
             Tls = TlsClientContext.Create(new TlsClientOptions
             {
-                ServerName = upstreamName,
-                AlpnProtocols = [&quot;h2&quot;],       // h2 over TLS is chosen by ALPN, never assumed
-                CaFile = upstreamInsecure ? null : upstreamCa,
-                VerifyCertificate = !upstreamInsecure,
+                ServerName         = upstreamName,                          // sent as SNI, checked against the cert
+                AlpnProtocols      = [&quot;h2&quot;],                                // h2 over TLS is chosen by ALPN, never assumed
+                VerifyCertificate  = !upstreamInsecure,                     // off = encrypted but UNAUTHENTICATED
+                CaFile             = upstreamInsecure ? null : upstreamCa,  // PEM trust anchors; null = system store
+                MinimumVersion     = OpenSslVersions.Tls12,                 // lowest TLS accepted; Tls13 = 1.3 only
+                HandshakeTimeoutMs = 10_000,                                // handshake deadline
             }),
         });
     };
@@ -4287,27 +4705,42 @@ using ioxide.ngtcp2;
 const string certPath = &quot;cert.pem&quot;;      // any PEM pair; the sample generates one on first run
 const string keyPath  = &quot;key.pem&quot;;
 
-using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: [&quot;h3&quot;]);
+using var engine = new QuicEngine(certPath, keyPath,
+    cidLength: 8,                       // CID bytes this endpoint mints (1..20)
+    alpn: [&quot;h3&quot;],                       // the only protocol offered (else no_application_protocol)
+    maxSendRetentionBytes: 16L &lt;&lt; 20);  // per-connection send-retention high-water (default 16 MiB)
 
 var config = new ServerConfig
 {
-    ReactorCount = Environment.ProcessorCount,
-    Tcp = null,   // h3 in, h3 out: nothing here speaks TCP at all
-    Udp = new UdpOptions { RecvSlots = 16 },
+    ReactorCount   = Environment.ProcessorCount,
+    RingEntries    = 8192,       // SQ/CQ depth per ring
+    DualStack      = false,      // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,  // bytes per shared recv buffer
+    RecvSlots      = 4096,       // shared recv buffer-ring depth
+    Incremental    = null,       // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Tcp            = null,       // h3 in, h3 out: nothing here speaks TCP at all
+    Udp = new UdpOptions
+    {
+        RecvSlots = 16,  // multishot recv slots per reactor (datagrams in flight)
+        Gro       = true,                                 // UDP_GRO: coalesce datagrams into one recv (fewer syscalls)
+    },
     Quic = new QuicOptions
     {
-        Port = 8443,
-        LocalCidLength = 8,
-        ConnectionFactory = engine.CreateFactory(),
+        Port              = 8443,  // h3 over UDP - the QUIC listener
+        LocalCidLength    = 8,                                       // CID bytes this endpoint mints (must match the engine)
+        IdleTimeoutMs     = 60_000,                                  // transport idle backstop; 0 disables sweep eviction
+        ConnectionFactory = engine.CreateFactory(),                  // adopts new connections into the engine
     },
 };
 
 var upstream = new Http3ClientOptions
 {
-    Host = &quot;127.0.0.1&quot;,   // IPv4 literal: DNS would block the reactor
-    Port = 8444,         // the upstream&#x27;s QUIC (UDP) port
-    ServerName = &quot;localhost&quot;,
-    PoolSize = 1,         // h3 multiplexes: one connection carries all
+    Host             = &quot;127.0.0.1&quot;,  // IPv4 literal: DNS would block the reactor
+    Port             = 8444,        // the upstream&#x27;s QUIC (UDP) port
+    ServerName       = &quot;localhost&quot;,   // SNI / :authority, checked against the cert
+    PoolSize         = 1,            // h3 multiplexes: one connection carries all
+    AcquireTimeoutMs = 10_000,                                            // how long a request waits (handshake included)
+    MaxResponseBytes = 8 * 1024 * 1024,                                   // per-request ceiling for headers + body
 };
 
 var threads = new Thread[config.ReactorCount];

--- a/docs/learn/multiport.html
+++ b/docs/learn/multiport.html
@@ -51,11 +51,24 @@
     Every reactor binds each one with SO_REUSEPORT and arms a multishot accept on it.</p>
 <pre><code class="language-csharp">var config = new ServerConfig
 {
-    ReactorCount = Environment.ProcessorCount,
+    ReactorCount   = Environment.ProcessorCount,  // io_uring rings/threads - one per core
+    RingEntries    = 8192,                         // SQ/CQ depth per ring
+    DualStack      = false,                         // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                    // bytes per shared recv buffer
+    RecvSlots      = 4096,                          // shared recv buffer-ring depth
+    Incremental    = null,                          // per-connection recv rings (6.12+)
+    Udp            = null,                          // no raw UDP sockets
+    Quic           = null,                          // no QUIC transport
     Tcp = new TcpOptions
     {
-        Port       = 8080,        // plaintext
-        ExtraPorts = [8443],      // TLS, same reactors
+        Port             = 8080,                    // plaintext
+        ExtraPorts       = [8443],                  // TLS, same reactors
+        ListenBacklog    = 1024,                     // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                // per-connection write buffer before overflow
+        PoolMax          = 1024,                      // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,  // Grow = realloc one slab; Segmented = chain + SENDMSG
+        ZeroCopySend     = false,                      // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                         // per-connection recv completion queue depth
     },
 };</code></pre>
     <p>With no <code>ExtraPorts</code>, behaviour is exactly as before - one listener, one accept.

--- a/docs/learn/quic-h3.html
+++ b/docs/learn/quic-h3.html
@@ -135,6 +135,12 @@
 
 var config = new ServerConfig
 {
+    ReactorCount   = Environment.ProcessorCount,  // io_uring rings/threads - one per core
+    RingEntries    = 8192,                         // SQ/CQ depth per ring
+    DualStack      = false,                         // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                    // bytes per shared recv buffer
+    RecvSlots      = 4096,                          // shared recv buffer-ring depth
+    Incremental    = null,                          // per-connection recv rings (6.12+)
     Tcp = null,                        // QUIC-only: no TCP listener at all
     Udp = new UdpOptions
     {

--- a/docs/learn/tls.html
+++ b/docs/learn/tls.html
@@ -86,15 +86,34 @@
     <code>TlsService</code> per reactor from <code>OnStart</code> (same pattern as any client):</p>
 <pre><code class="language-csharp">var config = new ServerConfig
 {
-    ReactorCount = Environment.ProcessorCount,
-    Tcp = new TcpOptions { Port = 8080, ExtraPorts = [8443] },
+    ReactorCount   = Environment.ProcessorCount,  // io_uring rings/threads - one per core
+    RingEntries    = 8192,                         // SQ/CQ depth per ring
+    DualStack      = false,                         // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                    // bytes per shared recv buffer
+    RecvSlots      = 4096,                          // shared recv buffer-ring depth
+    Incremental    = null,                          // per-connection recv rings (6.12+)
+    Udp            = null,                          // no raw UDP sockets
+    Quic           = null,                          // no QUIC transport
+    Tcp = new TcpOptions
+    {
+        Port             = 8080,                    // plaintext
+        ExtraPorts       = [8443],                  // TLS terminates on this second listener
+        ListenBacklog    = 1024,                    // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,               // per-connection write buffer before overflow
+        PoolMax          = 1024,                     // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,  // Grow = realloc one slab; Segmented = chain + SENDMSG
+        ZeroCopySend     = false,                     // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                        // per-connection recv completion queue depth
+    },
 };
 
 var options = new TlsOptions
 {
-    CertificatePath = "/certs/server.crt",   // PEM chain
-    KeyPath         = "/certs/server.key",    // PEM private key
-    Alpn            = ["http/1.1"],           // ordered, most preferred first
+    CertificatePath = "/certs/server.crt",   // PEM chain  (or CertificatePem = "..." for in-memory)
+    KeyPath         = "/certs/server.key",    // PEM key    (or KeyPem = "..." for in-memory)
+    Alpn            = ["http/1.1"],           // protocols served, most preferred first
+    KernelTx        = false,                   // kTLS transmit offload (kernel makes the records)
+    KernelRx        = false,                   // kTLS receive (experimental; requires KernelTx)
 };
 
 reactor.OnStart = r =&gt; TlsService.Start(r, options);</code></pre>

--- a/src/clients/ioxide.file/ioxide.file.csproj
+++ b/src/clients/ioxide.file/ioxide.file.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.file</RootNamespace>
 
     <PackageId>ioxide.file</PackageId>
-    <Version>0.4.162</Version>
+    <Version>0.4.163</Version>
     <Authors>MDA2AV</Authors>
     <Description>File serving for the ioxide io_uring runtime: immutable asset snapshots with baked responses, pooled positional ring reads, atomic reloads.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
+++ b/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.httpclient</RootNamespace>
 
     <PackageId>ioxide.httpclient</PackageId>
-    <Version>0.4.162</Version>
+    <Version>0.4.163</Version>
     <Authors>MDA2AV</Authors>
     <Description>The ring-native HTTP client for the ioxide io_uring runtime: HTTP/1.1, HTTP/2 and HTTP/3 behind one API, with the protocol chosen per origin via Alt-Svc. One package - the h1 parser, the nghttp2 and nghttp3 bridges, client-side TLS (SNI, ALPN and certificate verification) for https:// origins, and the negotiating client - sharing one set of message types. Every response resumes the awaiting handler inline on its own reactor thread.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.pg/ioxide.pg.csproj
+++ b/src/clients/ioxide.pg/ioxide.pg.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.pg</RootNamespace>
 
     <PackageId>ioxide.pg</PackageId>
-    <Version>0.4.162</Version>
+    <Version>0.4.163</Version>
     <Authors>MDA2AV</Authors>
     <Description>Postgres driver for the ioxide io_uring runtime: pooled ring-native connections per reactor, ring-native connect and handshake, inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.redis/ioxide.redis.csproj
+++ b/src/clients/ioxide.redis/ioxide.redis.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.redis</RootNamespace>
 
     <PackageId>ioxide.redis</PackageId>
-    <Version>0.4.162</Version>
+    <Version>0.4.163</Version>
     <Authors>MDA2AV</Authors>
     <Description>Redis client for the ioxide io_uring runtime: pooled ring-native connections per reactor, full RESP2 protocol, a generic command API plus typed helpers (strings, keys, hashes, lists, sets, sorted sets, pub/sub, transactions, scripting), and pipelining. Inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ioxide/ioxide.csproj
+++ b/src/ioxide/ioxide.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide</RootNamespace>
 
     <PackageId>ioxide</PackageId>
-    <Version>0.4.162</Version>
+    <Version>0.4.163</Version>
     <Authors>MDA2AV</Authors>
     <Description>A shared-nothing io_uring runtime for .NET: one ring per reactor thread, inline completions, zero native dependencies. The engine - reactor, connection, and the IRingHost client seam. Includes TLS termination: the OpenSSL handshake driven over the ring, then kernel TLS (kTLS) transmit offload, so handlers keep writing plaintext. TLS needs OpenSSL 3 and the Linux tls module; nothing else does, and neither is loaded unless you use it.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http2/ioxide.http2.csproj
+++ b/src/protocols/ioxide.http2/ioxide.http2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http2</RootNamespace>
 
     <PackageId>ioxide.http2</PackageId>
-    <Version>0.4.162</Version>
+    <Version>0.4.163</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure-C# HTTP/2 for the ioxide io_uring runtime: framing, HPACK (static and dynamic tables, Huffman) and flow control, with zero native code. A drop-in alternative to ioxide.nghttp2 for deployments that would rather not ship a native library - same connection shape, same request and response types.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http3/ioxide.http3.csproj
+++ b/src/protocols/ioxide.http3/ioxide.http3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http3</RootNamespace>
 
     <PackageId>ioxide.http3</PackageId>
-    <Version>0.4.162</Version>
+    <Version>0.4.163</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure C# HTTP/3 for the ioxide io_uring runtime: frame parsing, QPACK (static table + Huffman) and request dispatch with zero native dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, drop-in alternative to ioxide.nghttp3.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
+++ b/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp2</RootNamespace>
 
     <PackageId>ioxide.nghttp2</PackageId>
-    <Version>0.4.162</Version>
+    <Version>0.4.163</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/2 for the ioxide io_uring runtime: framing, HPACK and flow control from nghttp2, statically linked behind a small shim with no external dependencies beyond libc. Serves HTTP/2 over any TcpConnection - h2c with prior knowledge, or h2 over TLS via ALPN - and backs the HTTP/2 client in ioxide.httpclient from the same session code. nghttp2 is sans-I/O, so ioxide keeps the ring and the loop.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
+++ b/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp3</RootNamespace>
 
     <PackageId>ioxide.nghttp3</PackageId>
-    <Version>0.4.162</Version>
+    <Version>0.4.163</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/3 layer for the ioxide io_uring runtime: nghttp3 (H3 + QPACK) bundled as a single self-contained native library with no external dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, no ioxide.ngtcp2 dependency.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
+++ b/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.ngtcp2</RootNamespace>
 
     <PackageId>ioxide.ngtcp2</PackageId>
-    <Version>0.4.162</Version>
+    <Version>0.4.163</Version>
     <Authors>MDA2AV</Authors>
     <Description>QUIC engine for the ioxide io_uring runtime: ngtcp2 + picotls bundled as a single self-contained native library (only system dependency: libcrypto.so.3 / OpenSSL 3.x). Plugs into the reactor's QUIC transport via QuicConnection. Server side; engine bindings in progress.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
+++ b/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.Kestrel</RootNamespace>
 
     <PackageId>ioxide.Kestrel</PackageId>
-    <Version>0.4.162</Version>
+    <Version>0.4.163</Version>
     <Authors>MDA2AV</Authors>
     <Description>ASP.NET Core Kestrel transport backed by the ioxide io_uring runtime: one reactor (ring) per core, SO_REUSEPORT load-balanced, with Kestrel's HTTP request loop pinned to the reactor thread. Drop-in via UseIoxide().</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
The all-knobs documentation pass — this is the docs/playground work, which did NOT make it into #162 (that merged at the 0.4.162 point, before this landed).

**Playground (33 samples):** every sample now declares its entire configurable surface as literals at their defaults with aligned comments, grouped by the type each feeds — `ServerConfig` + `TcpOptions`/`UdpOptions`/`QuicOptions`, plus the protocol/client options each uses (`TlsOptions`, `Nghttp3Options`, `QuicEngine` args, `PgOptions`, `RedisOptions`, `HttpClientOptions`, `TlsClientOptions`, `StaticAssets`). Existing values and `Env` overrides preserved, handlers untouched. `Tcp/Raw` and `Http3/Buffered` are the TCP and QUIC references.

**Site:** both pane generators regenerated from the samples, and the hand-written panes (`h2`, `h2cs`, streamed `h3`, quic pipes/raw) brought to the same full set. The tls/multiport/quic-h3 learn-page config examples expanded to match (`overview.html` keeps its one-line intro by design).

**Version:** all eleven packages 0.4.162 → 0.4.163 (docs-only otherwise, so the packages are unchanged bytes).

Verified: full solution builds 0 errors; `Tcp/Raw` serves 200 with the expanded config.