### PR TITLE
feat(playground): PLAYGROUND_INCREMENTAL knob to A/B per-connection recv rings

### DIFF
--- a/Playground/Http2/Managed/Program.cs
+++ b/Playground/Http2/Managed/Program.cs
@@ -22,7 +22,7 @@ var config = new ServerConfig
     DualStack      = false,                                                       // true = one IPv6 socket also accepts IPv4-mapped
     RecvBufferSize = 32 * 1024,                                                   // bytes per shared recv buffer
     RecvSlots      = 4096,                                                        // shared recv buffer-ring depth
-    Incremental    = null,                                                        // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Incremental    = Env.Flag("PLAYGROUND_INCREMENTAL") ? new IncrementalOptions { MaxConnections = 1024, RecvSlots = 8, RecvBufferSize = 16 * 1024 } : null,                                                        // per-connection recv rings (6.12+) - see Tcp/Incremental
     Udp            = null,                                                        // no raw UDP sockets (TCP-only server)
     Quic           = null,                                                        // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions

--- a/Playground/Http2/Nghttp2/Program.cs
+++ b/Playground/Http2/Nghttp2/Program.cs
@@ -22,7 +22,7 @@ var config = new ServerConfig
     DualStack      = false,                                                       // true = one IPv6 socket also accepts IPv4-mapped
     RecvBufferSize = 32 * 1024,                                                   // bytes per shared recv buffer
     RecvSlots      = 4096,                                                        // shared recv buffer-ring depth
-    Incremental    = null,                                                        // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Incremental    = Env.Flag("PLAYGROUND_INCREMENTAL") ? new IncrementalOptions { MaxConnections = 1024, RecvSlots = 8, RecvBufferSize = 16 * 1024 } : null,                                                        // per-connection recv rings (6.12+) - see Tcp/Incremental
     Udp            = null,                                                        // no raw UDP sockets (TCP-only server)
     Quic           = null,                                                        // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions

--- a/Playground/Http2/Tls/Program.cs
+++ b/Playground/Http2/Tls/Program.cs
@@ -38,10 +38,6 @@ Env.Override(ref port, ref reactors, ref bodyBytes);
 string? certOverride = null;
 string? keyOverride  = null;
 
-// Per-connection incremental buffer rings instead of the shared ring (kernel 6.12+). The h2 code
-// is identical either way; this only changes how recv buffers are handed out.
-bool incrementalBuffers = false;
-
 // Hand OUTBOUND encryption to the kernel: the handler writes plaintext and the kernel makes the
 // records. Off by default - OpenSSL both ways is the portable path, and on loopback the kernel
 // is not faster. Its real payoff is sendfile and NIC offload, which a benchmark here cannot see.
@@ -64,7 +60,7 @@ var config = new ServerConfig
     DualStack      = false,                                                 // true = one IPv6 socket also accepts IPv4-mapped
     RecvBufferSize = 32 * 1024,                                             // bytes per shared recv buffer
     RecvSlots      = 4096,                                                  // shared recv buffer-ring depth
-    Incremental    = incrementalBuffers ? new IncrementalOptions() : null,  // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Incremental    = Env.Flag("PLAYGROUND_INCREMENTAL") ? new IncrementalOptions { MaxConnections = 1024, RecvSlots = 8, RecvBufferSize = 16 * 1024 } : null,  // per-connection recv rings (6.12+) - see Tcp/Incremental
     Udp            = null,                                                  // no raw UDP sockets (TCP-only server)
     Quic           = null,                                                  // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions

--- a/Playground/Tcp/Pipe/Program.cs
+++ b/Playground/Tcp/Pipe/Program.cs
@@ -24,7 +24,7 @@ var config = new ServerConfig
     DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
     RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
     RecvSlots      = 4096,                                 // shared recv buffer-ring depth
-    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Incremental    = Env.Flag("PLAYGROUND_INCREMENTAL") ? new IncrementalOptions { MaxConnections = 1024, RecvSlots = 8, RecvBufferSize = 16 * 1024 } : null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
     Udp            = null,                                 // no raw UDP sockets (TCP-only server)
     Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions

--- a/Playground/Tcp/Raw/Program.cs
+++ b/Playground/Tcp/Raw/Program.cs
@@ -23,7 +23,7 @@ var config = new ServerConfig
     DualStack      = false,                                 // true = one IPv6 socket also accepts IPv4-mapped
     RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
     RecvSlots      = 4096,                                 // shared recv buffer-ring depth
-    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Incremental    = Env.Flag("PLAYGROUND_INCREMENTAL") ? new IncrementalOptions { MaxConnections = 1024, RecvSlots = 8, RecvBufferSize = 16 * 1024 } : null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
     Udp            = null,                                 // no raw UDP sockets (TCP-only server)
     Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions

--- a/Playground/Tls/Hybrid/Program.cs
+++ b/Playground/Tls/Hybrid/Program.cs
@@ -44,7 +44,7 @@ var config = new ServerConfig
     DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
     RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
     RecvSlots      = 4096,                                 // shared recv buffer-ring depth
-    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Incremental    = Env.Flag("PLAYGROUND_INCREMENTAL") ? new IncrementalOptions { MaxConnections = 1024, RecvSlots = 8, RecvBufferSize = 16 * 1024 } : null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
     Udp            = null,                                 // no raw UDP sockets (TCP-only server)
     Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions

--- a/Playground/Tls/OpenSsl/Program.cs
+++ b/Playground/Tls/OpenSsl/Program.cs
@@ -61,7 +61,7 @@ var config = new ServerConfig
     DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
     RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
     RecvSlots      = 4096,                                 // shared recv buffer-ring depth
-    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Incremental    = Env.Flag("PLAYGROUND_INCREMENTAL") ? new IncrementalOptions { MaxConnections = 1024, RecvSlots = 8, RecvBufferSize = 16 * 1024 } : null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
     Udp            = null,                                 // no raw UDP sockets (TCP-only server)
     Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions

--- a/Playground/Tls/OpenSslPipes/Program.cs
+++ b/Playground/Tls/OpenSslPipes/Program.cs
@@ -60,7 +60,7 @@ var config = new ServerConfig
     DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
     RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
     RecvSlots      = 4096,                                 // shared recv buffer-ring depth
-    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Incremental    = Env.Flag("PLAYGROUND_INCREMENTAL") ? new IncrementalOptions { MaxConnections = 1024, RecvSlots = 8, RecvBufferSize = 16 * 1024 } : null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
     Udp            = null,                                 // no raw UDP sockets (TCP-only server)
     Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions

--- a/docs/index.html
+++ b/docs/index.html
@@ -2784,10 +2784,6 @@ int    bodyBytes = 2;                           // &quot;ok&quot; - this sample 
 const string certPath = &quot;cert.pem&quot;;   // any PEM pair
 const string keyPath  = &quot;key.pem&quot;;
 
-// Per-connection incremental buffer rings instead of the shared ring (kernel 6.12+). The h2 code
-// is identical either way; this only changes how recv buffers are handed out.
-bool incrementalBuffers = false;
-
 // Hand OUTBOUND encryption to the kernel: the handler writes plaintext and the kernel makes the
 // records. Off by default - OpenSSL both ways is the portable path, and on loopback the kernel
 // is not faster. Its real payoff is sendfile and NIC offload, which a benchmark here cannot see.
@@ -2807,7 +2803,7 @@ var config = new ServerConfig
     DualStack      = false,                                                 // true = one IPv6 socket also accepts IPv4-mapped
     RecvBufferSize = 32 * 1024,                                             // bytes per shared recv buffer
     RecvSlots      = 4096,                                                  // shared recv buffer-ring depth
-    Incremental    = incrementalBuffers ? new IncrementalOptions() : null,  // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Incremental    = null,  // per-connection recv rings (6.12+) - see Tcp/Incremental
     Udp            = null,                                                  // no raw UDP sockets (TCP-only server)
     Quic           = null,                                                  // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions

--- a/scripts/gen-docs-panes.py
+++ b/scripts/gen-docs-panes.py
@@ -174,6 +174,10 @@ def inline(code: str) -> str:
         'const string certPath = "cert.pem";   // any PEM pair\nconst string keyPath  = "key.pem";\n')
     code = re.sub(r"\(string certPath, string keyPath\) = QuicCert\.Ensure\(certOverride, keyOverride\);\n", "", code)
 
+    # PLAYGROUND_INCREMENTAL is a bench escape hatch (per-connection recv rings); the pane shows the
+    # sample's default - the shared ring - just like the other Env knobs collapse to their literals.
+    code = re.sub(r'Env\.Flag\("PLAYGROUND_INCREMENTAL"\) \? new IncrementalOptions \{[^}]*\} : null', "null", code)
+
     code = BANNER.sub("", code)
     assert "Env." not in code and "QuicCert" not in code, \
         "harness plumbing survived: " + "; ".join(


### PR DESCRIPTION
## What

An opt-in `PLAYGROUND_INCREMENTAL` env toggle on the TCP-based samples (h1 raw/pipe, h2c nghttp2 + managed, h2-tls, tls openssl/pipes/hybrid), so **incremental** recv (`IOU_PBUF_RING_INC`, per-connection rings) can be A/B'd against the default **shared** buffer-group ring without editing code.

**Off by default** — unset falls straight through to `null` (the shared ring), so every sample behaves byte-for-byte as before. Only `PLAYGROUND_INCREMENTAL=1` switches it on (`incremental=True` in the startup line). Sizing reuses the same modest per-connection defaults across all samples.

## Docs panes

`gen-docs-panes.py` collapses the toggle to the shared default, so the teaching panes are unchanged — same escape-hatch treatment the other `Env` knobs already get. The only pane that changes is Http2/Tls: its bespoke `incrementalBuffers` bool is replaced by the standard toggle for consistency, so its pane now reads `Incremental = null` like every other sample.

## Why / findings

I benchmarked incremental vs shared across these samples (loopback):

- **Small-request serving: neutral** — a fast echo returns each buffer immediately, so the recv ring is never the bottleneck; per-connection vs shared rings do identical work (±few-% noise across h1/h2/tls).
- **The one repeatable edge: TLS receiving a moderate body** (~64 KiB upload, **~+15–20%**, 3/3 runs) — incremental keeps a connection's ciphertext contiguous in one buffer, so OpenSSL decrypts a record from a single span instead of stitching across group-ring buffers. Cleartext doesn't benefit (no decryption).
- **20 MiB uploads: neutral/noise** — cleartext ~+2.5% (clean), TLS lost in variance (single-connection decrypt is CPU-bound; the buffer-handoff saving is a small fraction at that size). Incremental also carries a small cold-start cost (larger pre-reserved per-reactor buffer region faults in on first use).

So it's a bench convenience, not a default recommendation — with the narrow exception of TLS-upload-heavy workloads at moderate body sizes.

## Test

Full solution builds; `gen-docs-panes.py` runs clean (1 pane rewritten, no `Env.` leaks).
