### PR TITLE
refactor(file)!: ioxide.file is io_uring reads only - no HTTP, no cached bytes

### DIFF
--- a/Playground/Clients/File/Program.cs
+++ b/Playground/Clients/File/Program.cs
@@ -11,17 +11,28 @@ using Playground.Shared;
 //  locked and nothing is cached in memory. This sample frames HTTP/1.1 around the bytes; the same
 //  file data can be handed to any protocol.
 //
+//  Two ways to move the bytes, selected by PLAYGROUND_FILE_BUFFERED:
+//    - default (cleartext): conn.ReadFileAsync reads the file STRAIGHT INTO the write slab, so the
+//      header and body leave in a single flush - no intermediate buffer, no copy. The leanest path
+//      for a plain connection.
+//    - buffered (=1): read into a reader buffer first, then hand those bytes on. This is the shape
+//      a TLS connection needs - the body has to pass through an encrypt (TlsSession.Write) before
+//      the wire, so it can't be read straight into the send slab. Here (cleartext) the buffer is
+//      just copied into the slab to mirror that structure.
+//
 //  Descriptors are trusted for the snapshot's lifetime - a deploy is picked up by reloading the
 //  snapshot (SIGHUP), which reopens the files, not by re-stat'ing every request.
 //
 //      PLAYGROUND_DIR=/srv/www dotnet run -c Release --project Playground/Clients/File
 //      curl http://127.0.0.1:8080/index.html
+//      PLAYGROUND_FILE_BUFFERED=1 dotnet run ...   # the buffer path (the shape TLS uses)
 //      kill -HUP <pid>        # reload the snapshot after a deploy
 //
 //  Needs: ioxide, ioxide.file
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
-string dir = Env.Str("PLAYGROUND_DIR", "/tmp/ioxide-assets");
+string dir      = Env.Str("PLAYGROUND_DIR", "/tmp/ioxide-assets");
+bool   buffered = Env.Flag("PLAYGROUND_FILE_BUFFERED");   // read into a buffer (the TLS shape) vs into the slab
 
 SampleAssets.Ensure(dir);   // writes a demo index.html + style.css if the directory is empty
 
@@ -43,7 +54,7 @@ var config = new ServerConfig
         Port             = Env.Port("PLAYGROUND_PORT", 8080),
         ExtraPorts       = [],                                                    // extra listener ports (one handler, several doors)
         ListenBacklog    = 1024,                                                  // accept-queue depth per SO_REUSEPORT listener
-        WriteSlabSize    = 16 * 1024,                                             // per-connection write buffer before overflow kicks in
+        WriteSlabSize    = 16 * 1024,                                             // per-connection write buffer; ReadFileAsync grows it to fit a bigger file
         PoolMax          = 1024,                                                  // pooled connection objects kept per reactor
         WriteOverflow    = WriteOverflowStrategy.Grow,                            // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
         ZeroCopySend     = false,                                                 // SEND_ZC: kernel copies less, wins on large writes
@@ -60,6 +71,8 @@ for (int i = 0; i < threads.Length; i++)
     reactor.OnStart = r =>
     {
         r.AddService(assets);   // the shared snapshot
+        // The buffer path needs a pool of native read buffers; the slab path reads into the
+        // connection's own write slab and needs none, but registering it is harmless either way.
         AssetReader.CreatePool(r,
             readers:     4,         // concurrent ring reads bounded per reactor (pool size)
             bufferBytes: 1 << 20);  // native read buffer per reader (1 MiB) - size for the largest asset
@@ -101,7 +114,14 @@ for (int i = 0; i < threads.Length; i++)
                     // bytes off the ring and frame HTTP around them.
                     if (found)
                     {
-                        await SendFileAsync(conn, readers, asset.Path, asset.Fd, asset.Length);
+                        if (buffered)
+                        {
+                            await SendBufferedAsync(conn, readers, asset);
+                        }
+                        else
+                        {
+                            await SendSlabAsync(conn, asset);
+                        }
                     }
                     else
                     {
@@ -135,23 +155,39 @@ using var reload = PosixSignalRegistration.Create(PosixSignal.SIGHUP, context =>
 });
 
 Console.WriteLine($"[file] {config.ReactorCount} reactors on :{config.Tcp.Port} - "
-                + $"{assets.Count} files under {assets.RootDir} (ring reads, nothing cached)");
+                + $"{assets.Count} files under {assets.RootDir} "
+                + $"({(buffered ? "buffer path" : "slab path")}, nothing cached)");
 
 foreach (Thread thread in threads)
 {
     thread.Join();
 }
 
-// Stream a file off the ring, framing Content-Length up front. Each ring read (up to the reader's
-// buffer) is one write + one flush; files bigger than the buffer take several reads at advancing
-// offsets, so they're served whole with one flush per read rather than one per slab.
-static async Task SendFileAsync(
-    TcpConnection conn, RingPool<AssetReader> readers, string path, int fd, long totalLength)
+// Cleartext fast path: read the whole file STRAIGHT INTO the write slab (it grows to fit), right
+// after the header, so header + body leave in one flush - no reader buffer, no copy. Ideal for the
+// typical multi-KB web asset; a very large file grows the slab by its full size, so stream those
+// with the buffer path instead.
+static async Task SendSlabAsync(TcpConnection conn, AssetCache.Asset asset)
+{
+    Span<byte> header = stackalloc byte[256];
+    conn.Write(header[..WriteHeader(header, asset.Path, asset.Length)]);
+
+    // io_uring positional read into the slab at the current tail; AdvanceWrite commits the bytes.
+    int n = await conn.ReadFileAsync(asset.Fd, (int)asset.Length, fileOffset: 0);
+    conn.AdvanceWrite(n);
+    await conn.FlushAsync();
+}
+
+// Buffer path: read into a reader buffer, then move those bytes on. The copy into the slab stands in
+// for the transform a TLS connection does here instead - tls.Write(conn, reader.Buffer[..n]), which
+// encrypts into the slab. Files bigger than the buffer take several reads at advancing offsets,
+// one flush each.
+static async Task SendBufferedAsync(TcpConnection conn, RingPool<AssetReader> readers, AssetCache.Asset asset)
 {
     AssetReader reader = await readers.RentAsync();
     try
     {
-        int first = await reader.ReadAsync(fd, offset: 0);   // io_uring positional read
+        int first = await reader.ReadAsync(asset.Fd, offset: 0);   // io_uring positional read
         if (first < 0)
         {
             conn.Write("HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n"u8);
@@ -159,17 +195,16 @@ static async Task SendFileAsync(
             return;
         }
 
-        // ioxide.file hands over bytes; the HTTP framing is ours. Header + first chunk go out
-        // together in one flush.
+        // Header + first chunk go out together in one flush.
         Span<byte> header = stackalloc byte[256];
-        conn.Write(header[..WriteHeader(header, path, totalLength)]);
+        conn.Write(header[..WriteHeader(header, asset.Path, asset.Length)]);
         WriteNative(conn, reader.Buffer, first);
         await conn.FlushAsync();
 
         long offset = first;
-        while (offset < totalLength)
+        while (offset < asset.Length)
         {
-            int read = await reader.ReadAsync(fd, offset);
+            int read = await reader.ReadAsync(asset.Fd, offset);
             if (read <= 0) break;   // EOF or mid-stream error; the response is already committed
             WriteNative(conn, reader.Buffer, read);
             await conn.FlushAsync();

--- a/Playground/Clients/File/Program.cs
+++ b/Playground/Clients/File/Program.cs
@@ -1,6 +1,5 @@
 using System.Buffers.Text;
 using System.Runtime.InteropServices;
-using Microsoft.Win32.SafeHandles;
 using ioxide;
 using ioxide.file;
 using ioxide.utils;
@@ -12,8 +11,8 @@ using Playground.Shared;
 //  locked and nothing is cached in memory. This sample frames HTTP/1.1 around the bytes; the same
 //  file data can be handed to any protocol.
 //
-//  Every hit is revalidated against disk (size + mtime + inode), so an edit or an atomic rename is
-//  served live from the new inode rather than stale - the module reopens the changed file for you.
+//  Descriptors are trusted for the snapshot's lifetime - a deploy is picked up by reloading the
+//  snapshot (SIGHUP), which reopens the files, not by re-stat'ing every request.
 //
 //      PLAYGROUND_DIR=/srv/www dotnet run -c Release --project Playground/Clients/File
 //      curl http://127.0.0.1:8080/index.html
@@ -51,8 +50,6 @@ var config = new ServerConfig
         RecvQueueEntries = 64,                                                    // per-connection recv completion queue depth
     },
 };
-
-const int BodyChunk = 12 * 1024;   // how much native memory we push through the write slab at a time
 
 var threads = new Thread[config.ReactorCount];
 
@@ -100,19 +97,11 @@ for (int i = 0; i < threads.Length; i++)
                         }
                     }
 
-                    // TryOpenCurrent hands back the descriptor for the CURRENT bytes: the shared fd
-                    // when unchanged, or a freshly reopened one when the file changed on disk (which
-                    // we then close). Either way the sample just reads bytes and frames HTTP.
-                    if (found && AssetCache.TryOpenCurrent(asset, out int fd, out long length, out SafeFileHandle? reopened))
+                    // The fd is trusted for the snapshot's lifetime, so serving is just: read the
+                    // bytes off the ring and frame HTTP around them.
+                    if (found)
                     {
-                        try
-                        {
-                            await SendFileAsync(conn, readers, asset.Path, fd, length);
-                        }
-                        finally
-                        {
-                            reopened?.Dispose();
-                        }
+                        await SendFileAsync(conn, readers, asset.Path, asset.Fd, asset.Length);
                     }
                     else
                     {
@@ -153,8 +142,9 @@ foreach (Thread thread in threads)
     thread.Join();
 }
 
-// Stream a file off the ring, framing Content-Length up front. Files bigger than the reader's buffer
-// are read in successive chunks at advancing offsets, so they're served whole.
+// Stream a file off the ring, framing Content-Length up front. Each ring read (up to the reader's
+// buffer) is one write + one flush; files bigger than the buffer take several reads at advancing
+// offsets, so they're served whole with one flush per read rather than one per slab.
 static async Task SendFileAsync(
     TcpConnection conn, RingPool<AssetReader> readers, string path, int fd, long totalLength)
 {
@@ -169,17 +159,20 @@ static async Task SendFileAsync(
             return;
         }
 
-        // ioxide.file hands over bytes; the HTTP framing is ours.
+        // ioxide.file hands over bytes; the HTTP framing is ours. Header + first chunk go out
+        // together in one flush.
         Span<byte> header = stackalloc byte[256];
         conn.Write(header[..WriteHeader(header, path, totalLength)]);
-        await SendNativeAsync(conn, reader.Buffer, first);
+        WriteNative(conn, reader.Buffer, first);
+        await conn.FlushAsync();
 
         long offset = first;
         while (offset < totalLength)
         {
             int read = await reader.ReadAsync(fd, offset);
             if (read <= 0) break;   // EOF or mid-stream error; the response is already committed
-            await SendNativeAsync(conn, reader.Buffer, read);
+            WriteNative(conn, reader.Buffer, read);
+            await conn.FlushAsync();
             offset += read;
         }
     }
@@ -189,24 +182,9 @@ static async Task SendFileAsync(
     }
 }
 
-// Push native memory through the write slab in chunks: one flush for a small payload, a short
-// sequence for anything bigger than the slab.
-static async Task SendNativeAsync(TcpConnection conn, nint data, int length)
-{
-    int sent = 0;
-    while (true)
-    {
-        int chunk = Math.Min(length - sent, BodyChunk);
-        unsafe
-        {
-            conn.Write(new ReadOnlySpan<byte>((void*)(data + sent), chunk));
-        }
-        await conn.FlushAsync();
-        sent += chunk;
-
-        if (sent >= length) return;
-    }
-}
+// Copy native memory (a ring-read buffer) into the connection's write slab in one go.
+static unsafe void WriteNative(TcpConnection conn, nint data, int length)
+    => conn.Write(new ReadOnlySpan<byte>((void*)data, length));
 
 // Write the 200 status line + Content-Type + Content-Length for this file.
 static int WriteHeader(Span<byte> destination, string path, long bodyLength)

--- a/Playground/Clients/File/Program.cs
+++ b/Playground/Clients/File/Program.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Text;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 using ioxide;
@@ -6,15 +7,15 @@ using ioxide.utils;
 using Playground.Shared;
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-//  file - a static file server, whole. The asset cache opens every file ONCE and shares the
-//  descriptors across all reactors: they are stable and read positionally, so nothing is locked.
-//  Small files are served from a pre-baked HTTP response with no I/O at all; larger ones stream
-//  off the ring through a rented reader.
+//  file - a static file server. ioxide.file opens every file under the root ONCE and shares the
+//  descriptors across all reactors - stable and read positionally off the ring, so nothing is
+//  locked and nothing is cached in memory. This sample frames HTTP/1.1 around the bytes; the same
+//  file data can be handed to any protocol.
 //
 //  Every hit is revalidated against disk (size + mtime + inode), so an edit or an atomic rename is
-//  served live from the new inode rather than stale from RAM.
+//  served live from the new inode rather than stale - the module reopens the changed file for you.
 //
-//      PLAYGROUND_DIR=/srv/www dotnet run -c Release --project Playground/File
+//      PLAYGROUND_DIR=/srv/www dotnet run -c Release --project Playground/Clients/File
 //      curl http://127.0.0.1:8080/index.html
 //      kill -HUP <pid>        # reload the snapshot after a deploy
 //
@@ -23,16 +24,10 @@ using Playground.Shared;
 
 string dir = Env.Str("PLAYGROUND_DIR", "/tmp/ioxide-assets");
 
-// Per-file byte ceiling for pinning bodies in memory. 0 forces every request through the ring-read
-// path, which is the interesting one to benchmark.
-int cacheMax = Env.Int("PLAYGROUND_CACHE_MAX", AssetCache.DefaultMaxCachedFileBytes);
-
 SampleAssets.Ensure(dir);   // writes a demo index.html + style.css if the directory is empty
 
 // Built once for the whole process, BEFORE the reactors start: every reactor shares this snapshot.
-var assets = new StaticAssets(
-    dir,        // served root (PLAYGROUND_DIR); walked once into an immutable snapshot
-    cacheMax);  // maxCachedFileBytes: whole-response pin ceiling per file (0 = always ring-read)
+var assets = new StaticAssets(dir);   // served root (PLAYGROUND_DIR), walked once into a snapshot
 
 var config = new ServerConfig
 {
@@ -85,11 +80,11 @@ for (int i = 0; i < threads.Length; i++)
                 RecvSnapshot recv = await conn.ReadAsync();
 
                 // The lease pins the snapshot for the whole request, so a concurrent Reload() can't
-                // free the fd or the baked response out from under an in-flight send.
+                // close the fd out from under an in-flight read.
                 using (StaticAssets.Lease lease = snapshot.Acquire())
                 {
-                    // Resolve the target against the cache while the recv bytes are still valid -
-                    // the lookup is span-based, so no string is ever allocated for a cache hit.
+                    // Resolve the target against the snapshot while the recv bytes are still valid -
+                    // the lookup is span-based, so no string is ever allocated for a hit.
                     bool found = false;
                     AssetCache.Asset asset = default;
 
@@ -105,38 +100,24 @@ for (int i = 0; i < threads.Length; i++)
                         }
                     }
 
-                    if (!found)
+                    // TryOpenCurrent hands back the descriptor for the CURRENT bytes: the shared fd
+                    // when unchanged, or a freshly reopened one when the file changed on disk (which
+                    // we then close). Either way the sample just reads bytes and frames HTTP.
+                    if (found && AssetCache.TryOpenCurrent(asset, out int fd, out long length, out SafeFileHandle? reopened))
                     {
-                        conn.Write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"u8);
-                        await conn.FlushAsync();
+                        try
+                        {
+                            await SendFileAsync(conn, readers, asset.Path, fd, length);
+                        }
+                        finally
+                        {
+                            reopened?.Dispose();
+                        }
                     }
                     else
                     {
-                        // Is what we cached still what's on disk?
-                        bool fresh = AssetCache.IsFresh(asset, out bool exists, out long size);
-
-                        if (!exists)
-                        {
-                            conn.Write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"u8);
-                            await conn.FlushAsync();
-                        }
-                        else if (fresh && asset.Response != 0)
-                        {
-                            // The hot path: a complete HTTP response baked at snapshot time, sitting
-                            // in native memory. No open, no read, no formatting - just send it.
-                            await SendNativeAsync(conn, asset.Response, asset.ResponseLength);
-                        }
-                        else if (fresh)
-                        {
-                            // Too big to pin: read it off the ring at advancing offsets.
-                            await SendFromDiskAsync(conn, readers, asset, asset.Fd, asset.Length);
-                        }
-                        else
-                        {
-                            // Changed under us: open the path fresh so an atomic rename resolves to
-                            // the NEW inode, and stream that instead of serving stale bytes.
-                            await SendChangedAsync(conn, readers, asset, size);
-                        }
+                        conn.Write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"u8);
+                        await conn.FlushAsync();
                     }
                 }
 
@@ -165,11 +146,47 @@ using var reload = PosixSignalRegistration.Create(PosixSignal.SIGHUP, context =>
 });
 
 Console.WriteLine($"[file] {config.ReactorCount} reactors on :{config.Tcp.Port} - "
-                + $"{assets.Count} files under {assets.RootDir} (pin <= {cacheMax}B)");
+                + $"{assets.Count} files under {assets.RootDir} (ring reads, nothing cached)");
 
 foreach (Thread thread in threads)
 {
     thread.Join();
+}
+
+// Stream a file off the ring, framing Content-Length up front. Files bigger than the reader's buffer
+// are read in successive chunks at advancing offsets, so they're served whole.
+static async Task SendFileAsync(
+    TcpConnection conn, RingPool<AssetReader> readers, string path, int fd, long totalLength)
+{
+    AssetReader reader = await readers.RentAsync();
+    try
+    {
+        int first = await reader.ReadAsync(fd, offset: 0);   // io_uring positional read
+        if (first < 0)
+        {
+            conn.Write("HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n"u8);
+            await conn.FlushAsync();
+            return;
+        }
+
+        // ioxide.file hands over bytes; the HTTP framing is ours.
+        Span<byte> header = stackalloc byte[256];
+        conn.Write(header[..WriteHeader(header, path, totalLength)]);
+        await SendNativeAsync(conn, reader.Buffer, first);
+
+        long offset = first;
+        while (offset < totalLength)
+        {
+            int read = await reader.ReadAsync(fd, offset);
+            if (read <= 0) break;   // EOF or mid-stream error; the response is already committed
+            await SendNativeAsync(conn, reader.Buffer, read);
+            offset += read;
+        }
+    }
+    finally
+    {
+        readers.Return(reader);
+    }
 }
 
 // Push native memory through the write slab in chunks: one flush for a small payload, a short
@@ -191,65 +208,38 @@ static async Task SendNativeAsync(TcpConnection conn, nint data, int length)
     }
 }
 
-// Stream an asset off the ring, framing Content-Length up front. Files bigger than the reader's
-// buffer are read in successive chunks at advancing offsets, so they're served whole.
-static async Task SendFromDiskAsync(
-    TcpConnection conn, RingPool<AssetReader> readers, AssetCache.Asset asset, int fd, long totalLength)
+// Write the 200 status line + Content-Type + Content-Length for this file.
+static int WriteHeader(Span<byte> destination, string path, long bodyLength)
 {
-    AssetReader reader = await readers.RentAsync();
-    try
-    {
-        int first = await reader.ReadAsync(fd, offset: 0);   // io_uring positional read
-        if (first < 0)
-        {
-            conn.Write("HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n"u8);
-            await conn.FlushAsync();
-            return;
-        }
-
-        Span<byte> header = stackalloc byte[256];
-        conn.Write(header[..AssetCache.WriteResponseHeader(header, asset.Path, (int)totalLength)]);
-        await SendNativeAsync(conn, reader.Buffer, first);
-
-        long offset = first;
-        while (offset < totalLength)
-        {
-            int read = await reader.ReadAsync(fd, offset);
-            if (read <= 0) break;   // EOF or mid-stream error; the response is already committed
-            await SendNativeAsync(conn, reader.Buffer, read);
-            offset += read;
-        }
-    }
-    finally
-    {
-        readers.Return(reader);
-    }
+    int h = 0;
+    h += Copy(destination[h..], "HTTP/1.1 200 OK\r\nContent-Type: "u8);
+    h += Copy(destination[h..], MimeFor(path));
+    h += Copy(destination[h..], "\r\nContent-Length: "u8);
+    Utf8Formatter.TryFormat(bodyLength, destination[h..], out int digits);
+    h += digits;
+    h += Copy(destination[h..], "\r\n\r\n"u8);
+    return h;
 }
 
-static async Task SendChangedAsync(
-    TcpConnection conn, RingPool<AssetReader> readers, AssetCache.Asset asset, long size)
+static int Copy(Span<byte> destination, ReadOnlySpan<byte> source)
 {
-    SafeFileHandle handle;
-    try
-    {
-        handle = File.OpenHandle(asset.Path, FileMode.Open, FileAccess.Read, FileShare.Read);
-    }
-    catch
-    {
-        conn.Write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"u8);
-        await conn.FlushAsync();
-        return;
-    }
-
-    try
-    {
-        await SendFromDiskAsync(conn, readers, asset, (int)handle.DangerousGetHandle(), size);
-    }
-    finally
-    {
-        handle.Dispose();
-    }
+    source.CopyTo(destination);
+    return source.Length;
 }
+
+static ReadOnlySpan<byte> MimeFor(string path) => Path.GetExtension(path) switch
+{
+    ".html"  => "text/html"u8,
+    ".css"   => "text/css"u8,
+    ".js"    => "application/javascript"u8,
+    ".json"  => "application/json"u8,
+    ".svg"   => "image/svg+xml"u8,
+    ".png"   => "image/png"u8,
+    ".webp"  => "image/webp"u8,
+    ".woff2" => "font/woff2"u8,
+    ".txt"   => "text/plain"u8,
+    _        => "application/octet-stream"u8
+};
 
 static bool TryReadTarget(ReadOnlySpan<byte> request, out ReadOnlySpan<byte> target)
 {

--- a/docs/index.html
+++ b/docs/index.html
@@ -5132,13 +5132,15 @@ foreach (Thread t in threads) t.Join();</code></pre>
       <span class="pane-pkg">ioxide + ioxide.file</span>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide ioxide.file
+using System.Buffers.Text;
+using Microsoft.Win32.SafeHandles;
 using ioxide;
 using ioxide.file;
 using ioxide.utils;
 
 // Opens every file ONCE and shares the descriptors across all reactors: stable and read
-// positionally, so nothing is locked. Built before the reactors start.
-var assets = new StaticAssets(&quot;/srv/www&quot;, maxCachedFileBytes: 256 * 1024);
+// positionally off the ring, nothing cached. Built before the reactors start.
+var assets = new StaticAssets(&quot;/srv/www&quot;);
 
 var config = new ServerConfig
 {
@@ -5208,28 +5210,22 @@ for (int id = 0; id &lt; threads.Length; id++)
                         }
                     }
 
-                    // Revalidated against disk (size + mtime + inode): an edit or atomic rename
-                    // is served live from the new inode rather than stale from RAM.
-                    bool fresh = false, exists = false;
-                    if (found) fresh = AssetCache.IsFresh(asset, out exists, out _);
-
-                    if (found &amp;&amp; exists &amp;&amp; fresh &amp;&amp; asset.Response != 0)
+                    // TryOpenCurrent hands back the descriptor for the CURRENT bytes: the shared fd
+                    // when unchanged, or a freshly reopened one when the file changed on disk (an
+                    // edit or atomic rename), which we then close. ioxide.file gives you bytes -
+                    // revalidated against disk (size + mtime + inode) - and the HTTP framing is yours.
+                    if (found &amp;&amp; AssetCache.TryOpenCurrent(asset, out int fd, out long length, out SafeFileHandle? reopened))
                     {
-                        // A complete HTTP response already in native memory: no open, no read.
-                        await SendNativeAsync(conn, asset.Response, asset.ResponseLength);
-                    }
-                    else if (found &amp;&amp; exists)
-                    {
-                        AssetReader reader = await readers.RentAsync();   // too big to pin
+                        AssetReader reader = await readers.RentAsync();
                         try
                         {
-                            Span&lt;byte&gt; header = stackalloc byte[256];
-                            conn.Write(header[..AssetCache.WriteResponseHeader(header, asset.Path, (int)asset.Length)]);
+                            Span&lt;byte&gt; header = stackalloc byte[128];
+                            conn.Write(header[..WriteHeader(header, length)]);
 
                             long offset = 0;
-                            while (offset &lt; asset.Length)
+                            while (offset &lt; length)
                             {
-                                int read = await reader.ReadAsync(asset.Fd, offset);   // ring read
+                                int read = await reader.ReadAsync(fd, offset);   // io_uring positional read
                                 if (read &lt;= 0) break;
                                 await SendNativeAsync(conn, reader.Buffer, read);
                                 offset += read;
@@ -5238,6 +5234,7 @@ for (int id = 0; id &lt; threads.Length; id++)
                         finally
                         {
                             readers.Return(reader);
+                            reopened?.Dispose();
                         }
                     }
                     else
@@ -5280,6 +5277,18 @@ static async Task SendNativeAsync(TcpConnection conn, nint data, int length)
         if (sent &gt;= length) return;
     }
 }
+
+// ioxide.file speaks no HTTP - you frame the response. Status + Content-Length here; a real server
+// adds Content-Type from the file extension.
+static int WriteHeader(Span&lt;byte&gt; dst, long length)
+{
+    int h = Copy(dst, &quot;HTTP/1.1 200 OK\r\nContent-Length: &quot;u8);
+    Utf8Formatter.TryFormat(length, dst[h..], out int digits);
+    h += digits;
+    return h + Copy(dst[h..], &quot;\r\n\r\n&quot;u8);
+}
+
+static int Copy(Span&lt;byte&gt; dst, ReadOnlySpan&lt;byte&gt; src) { src.CopyTo(dst); return src.Length; }
 
 static bool TryReadTarget(ReadOnlySpan&lt;byte&gt; request, out ReadOnlySpan&lt;byte&gt; target)
 {

--- a/docs/index.html
+++ b/docs/index.html
@@ -5141,6 +5141,13 @@ using ioxide.utils;
 // positionally off the ring, nothing cached. Built before the reactors start.
 var assets = new StaticAssets(&quot;/srv/www&quot;);
 
+// Two ways to move the bytes:
+//   - slab (cleartext): conn.ReadFileAsync reads the file straight into the write slab, so header
+//     + body leave in one flush - no buffer, no copy. The leanest plain path.
+//   - buffer: read into a reader buffer first. A TLS connection needs this shape - the body has to
+//     pass through tls.Write (encrypt) before the wire, so it can&#x27;t land straight in the slab.
+bool buffered = false;
+
 var config = new ServerConfig
 {
     ReactorCount = Environment.ProcessorCount,   // one ring per reactor, one reactor per core
@@ -5213,25 +5220,8 @@ for (int id = 0; id &lt; threads.Length; id++)
                     // so serving is just: read the bytes off the ring and frame HTTP around them.
                     if (found)
                     {
-                        AssetReader reader = await readers.RentAsync();
-                        try
-                        {
-                            Span&lt;byte&gt; header = stackalloc byte[128];
-                            conn.Write(header[..WriteHeader(header, asset.Length)]);
-
-                            long offset = 0;
-                            while (offset &lt; asset.Length)
-                            {
-                                int read = await reader.ReadAsync(asset.Fd, offset);   // io_uring positional read
-                                if (read &lt;= 0) break;
-                                await SendNativeAsync(conn, reader.Buffer, read);   // one write + flush per read
-                                offset += read;
-                            }
-                        }
-                        finally
-                        {
-                            readers.Return(reader);
-                        }
+                        if (buffered) await SendBufferedAsync(conn, readers, asset);
+                        else          await SendSlabAsync(conn, asset);
                     }
                     else
                     {
@@ -5258,11 +5248,46 @@ for (int id = 0; id &lt; threads.Length; id++)
 Console.WriteLine($&quot;serving {assets.Count} files from {assets.RootDir} on :{config.Tcp.Port}&quot;);
 foreach (Thread t in threads) t.Join();
 
-static async Task SendNativeAsync(TcpConnection conn, nint data, int length)
+// Cleartext fast path: read the whole file STRAIGHT INTO the write slab (it grows to fit), right
+// after the header, so header + body leave in one flush - no reader buffer, no copy.
+static async Task SendSlabAsync(TcpConnection conn, AssetCache.Asset asset)
 {
-    unsafe { conn.Write(new ReadOnlySpan&lt;byte&gt;((void*)data, length)); }
-    await conn.FlushAsync();
+    Span&lt;byte&gt; header = stackalloc byte[128];
+    conn.Write(header[..WriteHeader(header, asset.Length)]);
+
+    int n = await conn.ReadFileAsync(asset.Fd, (int)asset.Length, fileOffset: 0);   // io_uring read into the slab
+    conn.AdvanceWrite(n);
+    await conn.FlushAsync();   // header + body, one send
 }
+
+// Buffer path: read into a reader buffer, then move the bytes on. The copy into the slab stands in
+// for the transform TLS does here instead - tls.Write(conn, reader.Buffer[..n]) encrypts into the slab.
+static async Task SendBufferedAsync(TcpConnection conn, RingPool&lt;AssetReader&gt; readers, AssetCache.Asset asset)
+{
+    AssetReader reader = await readers.RentAsync();
+    try
+    {
+        Span&lt;byte&gt; header = stackalloc byte[128];
+        conn.Write(header[..WriteHeader(header, asset.Length)]);
+
+        long offset = 0;
+        while (offset &lt; asset.Length)
+        {
+            int read = await reader.ReadAsync(asset.Fd, offset);   // io_uring positional read
+            if (read &lt;= 0) break;
+            WriteNative(conn, reader.Buffer, read);
+            await conn.FlushAsync();   // one write + flush per read
+            offset += read;
+        }
+    }
+    finally
+    {
+        readers.Return(reader);
+    }
+}
+
+static unsafe void WriteNative(TcpConnection conn, nint data, int length)
+    =&gt; conn.Write(new ReadOnlySpan&lt;byte&gt;((void*)data, length));
 
 // ioxide.file speaks no HTTP - you frame the response. Status + Content-Length here; a real server
 // adds Content-Type from the file extension.

--- a/docs/index.html
+++ b/docs/index.html
@@ -5133,7 +5133,6 @@ foreach (Thread t in threads) t.Join();</code></pre>
     </div>
 <pre><code class="language-csharp">// dotnet add package ioxide ioxide.file
 using System.Buffers.Text;
-using Microsoft.Win32.SafeHandles;
 using ioxide;
 using ioxide.file;
 using ioxide.utils;
@@ -5210,31 +5209,28 @@ for (int id = 0; id &lt; threads.Length; id++)
                         }
                     }
 
-                    // TryOpenCurrent hands back the descriptor for the CURRENT bytes: the shared fd
-                    // when unchanged, or a freshly reopened one when the file changed on disk (an
-                    // edit or atomic rename), which we then close. ioxide.file gives you bytes -
-                    // revalidated against disk (size + mtime + inode) - and the HTTP framing is yours.
-                    if (found &amp;&amp; AssetCache.TryOpenCurrent(asset, out int fd, out long length, out SafeFileHandle? reopened))
+                    // The fd is trusted for the snapshot's lifetime (reload on SIGHUP after a deploy),
+                    // so serving is just: read the bytes off the ring and frame HTTP around them.
+                    if (found)
                     {
                         AssetReader reader = await readers.RentAsync();
                         try
                         {
                             Span&lt;byte&gt; header = stackalloc byte[128];
-                            conn.Write(header[..WriteHeader(header, length)]);
+                            conn.Write(header[..WriteHeader(header, asset.Length)]);
 
                             long offset = 0;
-                            while (offset &lt; length)
+                            while (offset &lt; asset.Length)
                             {
-                                int read = await reader.ReadAsync(fd, offset);   // io_uring positional read
+                                int read = await reader.ReadAsync(asset.Fd, offset);   // io_uring positional read
                                 if (read &lt;= 0) break;
-                                await SendNativeAsync(conn, reader.Buffer, read);
+                                await SendNativeAsync(conn, reader.Buffer, read);   // one write + flush per read
                                 offset += read;
                             }
                         }
                         finally
                         {
                             readers.Return(reader);
-                            reopened?.Dispose();
                         }
                     }
                     else
@@ -5264,18 +5260,8 @@ foreach (Thread t in threads) t.Join();
 
 static async Task SendNativeAsync(TcpConnection conn, nint data, int length)
 {
-    const int Chunk = 12 * 1024;
-    int sent = 0;
-
-    while (true)
-    {
-        int take = Math.Min(length - sent, Chunk);
-        unsafe { conn.Write(new ReadOnlySpan&lt;byte&gt;((void*)(data + sent), take)); }
-        await conn.FlushAsync();
-        sent += take;
-
-        if (sent &gt;= length) return;
-    }
+    unsafe { conn.Write(new ReadOnlySpan&lt;byte&gt;((void*)data, length)); }
+    await conn.FlushAsync();
 }
 
 // ioxide.file speaks no HTTP - you frame the response. Status + Content-Length here; a real server

--- a/src/clients/ioxide.file/AssetCache.cs
+++ b/src/clients/ioxide.file/AssetCache.cs
@@ -1,24 +1,21 @@
 using System.Buffers;
-using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Win32.SafeHandles;
 
 namespace ioxide.file;
 
 /// <summary>
-/// An immutable snapshot of a directory, keyed by URL path: one open descriptor plus size/mtime/inode
-/// per file, opened once and shared across reactors (reads are positional off the ring, so nothing is
-/// locked). No bytes are cached and no HTTP is spoken - a caller looks a path up, reads the current
-/// file data off the ring, and frames it however it likes. Deploys swap whole snapshots via
-/// <see cref="StaticAssets.Reload"/>. One open descriptor per file - mind RLIMIT_NOFILE.
+/// An immutable snapshot of a directory, keyed by URL path: one open descriptor plus the length per
+/// file, opened once and shared across reactors (reads are positional off the ring, so nothing is
+/// locked). No bytes are cached and no HTTP is spoken - a caller looks a path up, reads the file data
+/// off the ring, and frames it however it likes. Descriptors are trusted for the snapshot's lifetime;
+/// a deploy is picked up by rebuilding the snapshot (<see cref="StaticAssets.Reload"/>), not by
+/// re-stat'ing per request. One open descriptor per file - mind RLIMIT_NOFILE.
 /// </summary>
 public sealed class AssetCache : IDisposable
 {
-    /// <summary>
-    /// A pre-opened file: its descriptor plus the size/mtime/inode captured when the snapshot was
-    /// built, used to tell whether the file on disk still matches (see <see cref="IsFresh"/>).
-    /// </summary>
-    public readonly record struct Asset(int Fd, string Path, long Length, long MtimeSec, uint MtimeNsec, ulong Ino);
+    /// <summary>A pre-opened file: its descriptor, absolute path, and length at snapshot time.</summary>
+    public readonly record struct Asset(int Fd, string Path, long Length);
 
     private readonly Dictionary<string, Asset> _assets;
     private readonly SafeFileHandle[] _handles;
@@ -62,104 +59,10 @@ public sealed class AssetCache : IDisposable
             int fd = (int)handle.DangerousGetHandle();
             string key = "/" + Path.GetRelativePath(RootDir, path).Replace('\\', '/');
 
-            // Freshness baseline: a request later re-statx's this path and reads the cached fd only
-            // while size + mtime + inode still match.
-            TryStat(path, out long length, out long mtimeSec, out uint mtimeNsec, out ulong ino);
-
-            _assets[key] = new Asset(fd, path, length, mtimeSec, mtimeNsec, ino);
+            _assets[key] = new Asset(fd, path, RandomAccess.GetLength(handle));
         }
 
         _handles = handles.ToArray();
-    }
-
-    // --- Revalidation (statx) -------------------------------------------------------------------
-    // The cached descriptor is read only while the file on disk still matches what was captured (size
-    // + mtime + inode), so an in-place edit or an atomic rename is picked up live instead of serving
-    // a stale inode. On a mismatch the caller reopens the path (see TryOpenCurrent).
-
-    private const int  AT_FDCWD          = -100;
-    private const uint STATX_BASIC_STATS = 0x000007ffU;
-
-    [DllImport("libc", EntryPoint = "statx", SetLastError = true)]
-    private static extern unsafe int statx(int dirfd, [MarshalAs(UnmanagedType.LPUTF8Str)] string path, int flags, uint mask, byte* buf);
-
-    /// <summary>
-    /// statx a path into (size, mtime, inode). False when the file can't be stat'd (e.g. deleted).
-    /// Offsets are from <c>struct statx</c> (linux/stat.h): ino @32, size @40, mtime.sec @112,
-    /// mtime.nsec @120.
-    /// </summary>
-    internal static unsafe bool TryStat(string path, out long size, out long mtimeSec, out uint mtimeNsec, out ulong ino)
-    {
-        byte* buf = stackalloc byte[256];
-        if (statx(AT_FDCWD, path, 0, STATX_BASIC_STATS, buf) != 0)
-        {
-            size = 0; mtimeSec = 0; mtimeNsec = 0; ino = 0;
-            return false;
-        }
-
-        ino       = *(ulong*)(buf + 32);
-        size      = (long)*(ulong*)(buf + 40);
-        mtimeSec  = *(long*)(buf + 112);
-        mtimeNsec = *(uint*)(buf + 120);
-        return true;
-    }
-
-    /// <summary>
-    /// True when <paramref name="asset"/> still matches the file on disk (size + mtime + inode).
-    /// <paramref name="exists"/> is false when the file is gone; <paramref name="currentSize"/> is the
-    /// live size, used to frame a response when serving a changed file.
-    /// </summary>
-    public static bool IsFresh(in Asset asset, out bool exists, out long currentSize)
-    {
-        exists = TryStat(asset.Path, out currentSize, out long ms, out uint mn, out ulong ino);
-        return exists
-            && currentSize == asset.Length
-            && ms == asset.MtimeSec
-            && mn == asset.MtimeNsec
-            && ino == asset.Ino;
-    }
-
-    /// <summary>
-    /// The descriptor and length to read for the CURRENT contents of <paramref name="asset"/>, so a
-    /// caller gets live data without tracking changes itself: the cached fd when the file is
-    /// unchanged, or a freshly opened one when it changed on disk (an edit or atomic rename). When
-    /// <paramref name="reopened"/> is non-null the returned fd is fresh and the caller must dispose it
-    /// after reading; when it's null the fd is the snapshot's shared descriptor (do not close it).
-    /// Returns false when the file is gone.
-    /// </summary>
-    public static bool TryOpenCurrent(in Asset asset, out int fd, out long length, out SafeFileHandle? reopened)
-    {
-        if (IsFresh(asset, out bool exists, out long currentSize))
-        {
-            fd = asset.Fd;
-            length = asset.Length;
-            reopened = null;
-            return true;
-        }
-
-        if (!exists)
-        {
-            fd = 0;
-            length = 0;
-            reopened = null;
-            return false;
-        }
-
-        try
-        {
-            reopened = File.OpenHandle(asset.Path, FileMode.Open, FileAccess.Read, FileShare.Read);
-        }
-        catch
-        {
-            fd = 0;
-            length = 0;
-            reopened = null;
-            return false;
-        }
-
-        fd = (int)reopened.DangerousGetHandle();
-        length = currentSize;
-        return true;
     }
 
     /// <summary>Look up a pre-opened asset by URL path; false if there's no such file.</summary>

--- a/src/clients/ioxide.file/AssetCache.cs
+++ b/src/clients/ioxide.file/AssetCache.cs
@@ -1,5 +1,4 @@
 using System.Buffers;
-using System.Buffers.Text;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Win32.SafeHandles;
@@ -7,26 +6,22 @@ using Microsoft.Win32.SafeHandles;
 namespace ioxide.file;
 
 /// <summary>
-/// An immutable snapshot of a static-asset directory, keyed by URL path. Small files
-/// (≤ maxCachedFileBytes) get their entire HTTP response precomputed in native memory - the hot
-/// path serves them with no file I/O, no header formatting, no allocation. Large files keep a
-/// descriptor and are read off the ring. Deploys swap whole snapshots via
+/// An immutable snapshot of a directory, keyed by URL path: one open descriptor plus size/mtime/inode
+/// per file, opened once and shared across reactors (reads are positional off the ring, so nothing is
+/// locked). No bytes are cached and no HTTP is spoken - a caller looks a path up, reads the current
+/// file data off the ring, and frames it however it likes. Deploys swap whole snapshots via
 /// <see cref="StaticAssets.Reload"/>. One open descriptor per file - mind RLIMIT_NOFILE.
 /// </summary>
 public sealed class AssetCache : IDisposable
 {
-    public const int DefaultMaxCachedFileBytes = 256 * 1024;
-
     /// <summary>
-    /// A pre-opened asset. <see cref="Response"/> is non-zero when the complete HTTP response is
-    /// precomputed in native memory (<see cref="ResponseLength"/> bytes - send it as-is);
-    /// otherwise read <see cref="Fd"/> positionally off the ring and build the response.
+    /// A pre-opened file: its descriptor plus the size/mtime/inode captured when the snapshot was
+    /// built, used to tell whether the file on disk still matches (see <see cref="IsFresh"/>).
     /// </summary>
-    public readonly record struct Asset(int Fd, string Path, long Length, nint Response, int ResponseLength, long MtimeSec, uint MtimeNsec, ulong Ino);
+    public readonly record struct Asset(int Fd, string Path, long Length, long MtimeSec, uint MtimeNsec, ulong Ino);
 
     private readonly Dictionary<string, Asset> _assets;
     private readonly SafeFileHandle[] _handles;
-    private readonly nint[] _responses;
     private int _disposed;
     private int _refs = 1;   // the "live" reference held by StaticAssets; leases add/drop more
 
@@ -36,7 +31,7 @@ public sealed class AssetCache : IDisposable
     /// <summary>How many files were opened.</summary>
     public int Count => _assets.Count;
 
-    public AssetCache(string rootDir, int maxCachedFileBytes = DefaultMaxCachedFileBytes)
+    public AssetCache(string rootDir)
     {
         RootDir = Path.GetFullPath(rootDir);
 
@@ -47,7 +42,6 @@ public sealed class AssetCache : IDisposable
 
         _assets = new Dictionary<string, Asset>(StringComparer.Ordinal);
         var handles = new List<SafeFileHandle>();
-        var responses = new List<nint>();
 
         // Open every file under the root, keyed by its URL path relative to the root. The managed
         // handle is held for the cache's lifetime so the raw fd stays valid.
@@ -65,35 +59,23 @@ public sealed class AssetCache : IDisposable
             SafeFileHandle handle = File.OpenHandle(path, FileMode.Open, FileAccess.Read, FileShare.Read);
             handles.Add(handle);
 
-            long length = RandomAccess.GetLength(handle);
-
-            nint response = 0;
-            int responseLength = 0;
-            if (length <= maxCachedFileBytes)
-            {
-                (response, responseLength) = BuildResponse(handle, (int)length, path);
-                responses.Add(response);
-            }
-
             int fd = (int)handle.DangerousGetHandle();
             string key = "/" + Path.GetRelativePath(RootDir, path).Replace('\\', '/');
 
-            // Freshness baseline: a request later re-statx's this path and serves the baked response
-            // only while size + mtime + inode still match.
-            TryStat(path, out _, out long mtimeSec, out uint mtimeNsec, out ulong ino);
+            // Freshness baseline: a request later re-statx's this path and reads the cached fd only
+            // while size + mtime + inode still match.
+            TryStat(path, out long length, out long mtimeSec, out uint mtimeNsec, out ulong ino);
 
-            _assets[key] = new Asset(fd, path, length, response, responseLength, mtimeSec, mtimeNsec, ino);
+            _assets[key] = new Asset(fd, path, length, mtimeSec, mtimeNsec, ino);
         }
 
         _handles = handles.ToArray();
-        _responses = responses.ToArray();
     }
 
     // --- Revalidation (statx) -------------------------------------------------------------------
-    // A baked response is served only while the file on disk still matches what was baked (size +
-    // mtime + inode), so an in-place edit or an atomic rename is picked up live instead of serving
-    // stale RAM. The baked block is never mutated here (the cache is shared across reactors) - it
-    // only re-bakes on Reload().
+    // The cached descriptor is read only while the file on disk still matches what was captured (size
+    // + mtime + inode), so an in-place edit or an atomic rename is picked up live instead of serving
+    // a stale inode. On a mismatch the caller reopens the path (see TryOpenCurrent).
 
     private const int  AT_FDCWD          = -100;
     private const uint STATX_BASIC_STATS = 0x000007ffU;
@@ -124,8 +106,8 @@ public sealed class AssetCache : IDisposable
 
     /// <summary>
     /// True when <paramref name="asset"/> still matches the file on disk (size + mtime + inode).
-    /// <paramref name="exists"/> is false when the file is gone; <paramref name="currentSize"/> is
-    /// the live size, used to frame the response when serving a changed file.
+    /// <paramref name="exists"/> is false when the file is gone; <paramref name="currentSize"/> is the
+    /// live size, used to frame a response when serving a changed file.
     /// </summary>
     public static bool IsFresh(in Asset asset, out bool exists, out long currentSize)
     {
@@ -137,70 +119,48 @@ public sealed class AssetCache : IDisposable
             && ino == asset.Ino;
     }
 
-    // Bake "HTTP/1.1 200 OK ..." + body into one contiguous native block. The body is read first
-    // so a file truncated under us still yields a consistent Content-Length.
-    private static unsafe (nint Response, int Length) BuildResponse(SafeFileHandle handle, int bodyLength, string path)
+    /// <summary>
+    /// The descriptor and length to read for the CURRENT contents of <paramref name="asset"/>, so a
+    /// caller gets live data without tracking changes itself: the cached fd when the file is
+    /// unchanged, or a freshly opened one when it changed on disk (an edit or atomic rename). When
+    /// <paramref name="reopened"/> is non-null the returned fd is fresh and the caller must dispose it
+    /// after reading; when it's null the fd is the snapshot's shared descriptor (do not close it).
+    /// Returns false when the file is gone.
+    /// </summary>
+    public static bool TryOpenCurrent(in Asset asset, out int fd, out long length, out SafeFileHandle? reopened)
     {
-        nint scratch = (nint)NativeMemory.Alloc((nuint)Math.Max(bodyLength, 1));
-        int read = 0;
-        while (read < bodyLength)
+        if (IsFresh(asset, out bool exists, out long currentSize))
         {
-            int n = RandomAccess.Read(handle, new Span<byte>((void*)(scratch + read), bodyLength - read), read);
-            if (n <= 0)
-            {
-                break;
-            }
-            read += n;
+            fd = asset.Fd;
+            length = asset.Length;
+            reopened = null;
+            return true;
         }
 
-        Span<byte> header = stackalloc byte[256];
-        int h = WriteResponseHeader(header, path, read);
+        if (!exists)
+        {
+            fd = 0;
+            length = 0;
+            reopened = null;
+            return false;
+        }
 
-        nint response = (nint)NativeMemory.Alloc((nuint)(h + read));
-        header[..h].CopyTo(new Span<byte>((void*)response, h));
-        Buffer.MemoryCopy((void*)scratch, (void*)(response + h), read, read);
-        NativeMemory.Free((void*)scratch);
+        try
+        {
+            reopened = File.OpenHandle(asset.Path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        }
+        catch
+        {
+            fd = 0;
+            length = 0;
+            reopened = null;
+            return false;
+        }
 
-        return (response, h + read);
+        fd = (int)reopened.DangerousGetHandle();
+        length = currentSize;
+        return true;
     }
-
-    /// <summary>
-    /// Write the 200 response header for <paramref name="path"/> into
-    /// <paramref name="destination"/> (≥256 bytes); returns the bytes written. The one place
-    /// asset headers are formatted - snapshot baking and ring-read serving both use it.
-    /// </summary>
-    public static int WriteResponseHeader(Span<byte> destination, string path, int bodyLength)
-    {
-        int h = 0;
-        h += Copy(destination[h..], "HTTP/1.1 200 OK\r\nContent-Type: "u8);
-        h += Copy(destination[h..], MimeFor(path));
-        h += Copy(destination[h..], "\r\nContent-Length: "u8);
-        Utf8Formatter.TryFormat(bodyLength, destination[h..], out int digits);
-        h += digits;
-        h += Copy(destination[h..], "\r\n\r\n"u8);
-        return h;
-    }
-
-    private static int Copy(Span<byte> destination, ReadOnlySpan<byte> source)
-    {
-        source.CopyTo(destination);
-        return source.Length;
-    }
-
-    private static ReadOnlySpan<byte> MimeFor(string path) => System.IO.Path.GetExtension(path) switch
-    {
-        ".html"  => "text/html"u8,
-        ".css"   => "text/css"u8,
-        ".js"    => "application/javascript"u8,
-        ".json"  => "application/json"u8,
-        ".svg"   => "image/svg+xml"u8,
-        ".png"   => "image/png"u8,
-        ".webp"  => "image/webp"u8,
-        ".woff2" => "font/woff2"u8,
-        ".txt"   => "text/plain"u8,
-        ".bin"   => "application/octet-stream"u8,
-        _        => "application/octet-stream"u8
-    };
 
     /// <summary>Look up a pre-opened asset by URL path; false if there's no such file.</summary>
     public bool TryGet(string urlPath, out Asset asset) => _assets.TryGetValue(urlPath, out asset);
@@ -258,7 +218,7 @@ public sealed class AssetCache : IDisposable
     /// <summary>Drops the "live" reference; the snapshot frees once all outstanding leases release too.</summary>
     public void Dispose() => Release();
 
-    private unsafe void DisposeCore()
+    private void DisposeCore()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
         {
@@ -268,11 +228,6 @@ public sealed class AssetCache : IDisposable
         foreach (SafeFileHandle handle in _handles)
         {
             handle.Dispose();
-        }
-
-        foreach (nint response in _responses)
-        {
-            NativeMemory.Free((void*)response);
         }
 
         _assets.Clear();

--- a/src/clients/ioxide.file/StaticAssets.cs
+++ b/src/clients/ioxide.file/StaticAssets.cs
@@ -7,24 +7,22 @@ namespace ioxide.file;
 /// </summary>
 /// <remarks>
 /// To serve safely across a reload, take a <see cref="Lease"/> with <see cref="Acquire"/> and hold
-/// it for the whole request (lookup → ring read → send): the old snapshot's descriptors and baked
-/// responses are freed only once every lease on it is released, so an in-flight read can never hit a
-/// closed fd or freed memory. The bare <see cref="TryGet(string, out AssetCache.Asset)"/> overloads
-/// don't hold a lease and are only safe when <see cref="Reload"/> is never called concurrently.
+/// it for the whole request (lookup → ring read → send): the old snapshot's descriptors are freed
+/// only once every lease on it is released, so an in-flight read can never hit a closed fd. The bare
+/// <see cref="TryGet(string, out AssetCache.Asset)"/> overloads don't hold a lease and are only safe
+/// when <see cref="Reload"/> is never called concurrently.
 /// </remarks>
 public sealed class StaticAssets : IDisposable
 {
     private readonly string _root;
-    private readonly int _maxCachedFileBytes;
     private readonly object _reloadLock = new();
 
     private AssetCache _cache;   // swapped atomically by Reload(), read with Volatile
 
-    public StaticAssets(string rootDir, int maxCachedFileBytes = AssetCache.DefaultMaxCachedFileBytes)
+    public StaticAssets(string rootDir)
     {
         _root = rootDir;
-        _maxCachedFileBytes = maxCachedFileBytes;
-        _cache = new AssetCache(rootDir, maxCachedFileBytes);
+        _cache = new AssetCache(rootDir);
     }
 
     public int Count => Volatile.Read(ref _cache).Count;
@@ -33,8 +31,8 @@ public sealed class StaticAssets : IDisposable
 
     /// <summary>
     /// Lease the live snapshot for the duration of a request. The snapshot it points at stays alive
-    /// (descriptors open, baked responses mapped) until the lease is disposed, even across a
-    /// concurrent <see cref="Reload"/>. Dispose it when the response has been fully sent.
+    /// (descriptors open) until the lease is disposed, even across a concurrent <see cref="Reload"/>.
+    /// Dispose it when the response has been fully sent.
     /// </summary>
     public Lease Acquire()
     {
@@ -69,7 +67,7 @@ public sealed class StaticAssets : IDisposable
             AssetCache fresh;
             try
             {
-                fresh = new AssetCache(_root, _maxCachedFileBytes);
+                fresh = new AssetCache(_root);
             }
             catch (Exception e)
             {

--- a/src/clients/ioxide.file/ioxide.file.csproj
+++ b/src/clients/ioxide.file/ioxide.file.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.file</RootNamespace>
 
     <PackageId>ioxide.file</PackageId>
-    <Version>0.4.166</Version>
+    <Version>0.4.167</Version>
     <Authors>MDA2AV</Authors>
     <Description>File serving for the ioxide io_uring runtime: immutable asset snapshots with baked responses, pooled positional ring reads, atomic reloads.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.file/ioxide.file.csproj
+++ b/src/clients/ioxide.file/ioxide.file.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.file</RootNamespace>
 
     <PackageId>ioxide.file</PackageId>
-    <Version>0.4.165</Version>
+    <Version>0.4.166</Version>
     <Authors>MDA2AV</Authors>
     <Description>File serving for the ioxide io_uring runtime: immutable asset snapshots with baked responses, pooled positional ring reads, atomic reloads.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
+++ b/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.httpclient</RootNamespace>
 
     <PackageId>ioxide.httpclient</PackageId>
-    <Version>0.4.166</Version>
+    <Version>0.4.167</Version>
     <Authors>MDA2AV</Authors>
     <Description>The ring-native HTTP client for the ioxide io_uring runtime: HTTP/1.1, HTTP/2 and HTTP/3 behind one API, with the protocol chosen per origin via Alt-Svc. One package - the h1 parser, the nghttp2 and nghttp3 bridges, client-side TLS (SNI, ALPN and certificate verification) for https:// origins, and the negotiating client - sharing one set of message types. Every response resumes the awaiting handler inline on its own reactor thread.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
+++ b/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.httpclient</RootNamespace>
 
     <PackageId>ioxide.httpclient</PackageId>
-    <Version>0.4.165</Version>
+    <Version>0.4.166</Version>
     <Authors>MDA2AV</Authors>
     <Description>The ring-native HTTP client for the ioxide io_uring runtime: HTTP/1.1, HTTP/2 and HTTP/3 behind one API, with the protocol chosen per origin via Alt-Svc. One package - the h1 parser, the nghttp2 and nghttp3 bridges, client-side TLS (SNI, ALPN and certificate verification) for https:// origins, and the negotiating client - sharing one set of message types. Every response resumes the awaiting handler inline on its own reactor thread.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.pg/ioxide.pg.csproj
+++ b/src/clients/ioxide.pg/ioxide.pg.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.pg</RootNamespace>
 
     <PackageId>ioxide.pg</PackageId>
-    <Version>0.4.165</Version>
+    <Version>0.4.166</Version>
     <Authors>MDA2AV</Authors>
     <Description>Postgres driver for the ioxide io_uring runtime: pooled ring-native connections per reactor, ring-native connect and handshake, inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.pg/ioxide.pg.csproj
+++ b/src/clients/ioxide.pg/ioxide.pg.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.pg</RootNamespace>
 
     <PackageId>ioxide.pg</PackageId>
-    <Version>0.4.166</Version>
+    <Version>0.4.167</Version>
     <Authors>MDA2AV</Authors>
     <Description>Postgres driver for the ioxide io_uring runtime: pooled ring-native connections per reactor, ring-native connect and handshake, inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.redis/ioxide.redis.csproj
+++ b/src/clients/ioxide.redis/ioxide.redis.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.redis</RootNamespace>
 
     <PackageId>ioxide.redis</PackageId>
-    <Version>0.4.165</Version>
+    <Version>0.4.166</Version>
     <Authors>MDA2AV</Authors>
     <Description>Redis client for the ioxide io_uring runtime: pooled ring-native connections per reactor, full RESP2 protocol, a generic command API plus typed helpers (strings, keys, hashes, lists, sets, sorted sets, pub/sub, transactions, scripting), and pipelining. Inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.redis/ioxide.redis.csproj
+++ b/src/clients/ioxide.redis/ioxide.redis.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.redis</RootNamespace>
 
     <PackageId>ioxide.redis</PackageId>
-    <Version>0.4.166</Version>
+    <Version>0.4.167</Version>
     <Authors>MDA2AV</Authors>
     <Description>Redis client for the ioxide io_uring runtime: pooled ring-native connections per reactor, full RESP2 protocol, a generic command API plus typed helpers (strings, keys, hashes, lists, sets, sorted sets, pub/sub, transactions, scripting), and pipelining. Inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ioxide/Connection/Tcp/TcpConnection.FileRead.cs
+++ b/src/ioxide/Connection/Tcp/TcpConnection.FileRead.cs
@@ -1,0 +1,56 @@
+namespace ioxide;
+
+/// <summary>
+/// The connection's file-read facet: read a file descriptor straight into the write slab, so a static
+/// file needs no intermediate buffer and no copy - the bytes land exactly where the next send picks
+/// them up. IORING_OP_READ on this connection's reactor, resumed inline. One read in flight per
+/// connection at a time (reuses a single <see cref="RingOpSource"/>, like the flush facet).
+/// </summary>
+public sealed unsafe partial class TcpConnection
+{
+    private readonly RingOpSource _fileRead = new();
+
+    /// <summary>
+    /// Read up to <paramref name="len"/> bytes of <paramref name="fileFd"/> from
+    /// <paramref name="fileOffset"/> straight into the write slab at the current tail, via
+    /// IORING_OP_READ on this connection's reactor. Returns the bytes read (0 at end of file, a
+    /// negative errno on error). Grows the slab if it can't hold <paramref name="len"/>.
+    ///
+    /// The bytes are placed but NOT yet part of the pending write - call <see cref="AdvanceWrite"/>
+    /// with the result to commit them before <c>FlushAsync</c>. Framing a header first (with a known
+    /// Content-Length) then reading the body after it sends header + body in one flush.
+    ///
+    /// <b>Cleartext only.</b> The bytes go on the wire as read, so this is for a plain connection. A
+    /// TLS connection must read into a buffer and encrypt (<c>TlsSession.Write</c>) - the wire carries
+    /// ciphertext, not the file's plaintext.
+    /// </summary>
+    public ValueTask<int> ReadFileAsync(int fileFd, int len, long fileOffset)
+    {
+        if (Volatile.Read(ref _closed) == 1)
+        {
+            return new ValueTask<int>(0);
+        }
+
+        if (WriteTail + len > _writeSlabSize)
+        {
+            GrowWriteSlab(WriteTail + len);   // reallocs WriteBuffer; recompute the destination after
+        }
+
+        ValueTask<int> pending = _fileRead.Prepare();
+        _reactor.SubmitRead(fileFd, (nint)(WriteBuffer + WriteTail), len, fileOffset, _fileRead);
+        return pending;
+    }
+
+    /// <summary>
+    /// Commit <paramref name="n"/> bytes just read by <see cref="ReadFileAsync"/> into the write slab,
+    /// so the next <c>FlushAsync</c> sends them. Pass the read's return value; a non-positive result
+    /// (EOF or error) advances nothing.
+    /// </summary>
+    public void AdvanceWrite(int n)
+    {
+        if (n > 0)
+        {
+            WriteTail += n;
+        }
+    }
+}

--- a/src/ioxide/ioxide.csproj
+++ b/src/ioxide/ioxide.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide</RootNamespace>
 
     <PackageId>ioxide</PackageId>
-    <Version>0.4.166</Version>
+    <Version>0.4.167</Version>
     <Authors>MDA2AV</Authors>
     <Description>A shared-nothing io_uring runtime for .NET: one ring per reactor thread, inline completions, zero native dependencies. The engine - reactor, connection, and the IRingHost client seam. Includes TLS termination: the OpenSSL handshake driven over the ring, then kernel TLS (kTLS) transmit offload, so handlers keep writing plaintext. TLS needs OpenSSL 3 and the Linux tls module; nothing else does, and neither is loaded unless you use it.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ioxide/ioxide.csproj
+++ b/src/ioxide/ioxide.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide</RootNamespace>
 
     <PackageId>ioxide</PackageId>
-    <Version>0.4.165</Version>
+    <Version>0.4.166</Version>
     <Authors>MDA2AV</Authors>
     <Description>A shared-nothing io_uring runtime for .NET: one ring per reactor thread, inline completions, zero native dependencies. The engine - reactor, connection, and the IRingHost client seam. Includes TLS termination: the OpenSSL handshake driven over the ring, then kernel TLS (kTLS) transmit offload, so handlers keep writing plaintext. TLS needs OpenSSL 3 and the Linux tls module; nothing else does, and neither is loaded unless you use it.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http2/ioxide.http2.csproj
+++ b/src/protocols/ioxide.http2/ioxide.http2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http2</RootNamespace>
 
     <PackageId>ioxide.http2</PackageId>
-    <Version>0.4.165</Version>
+    <Version>0.4.166</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure-C# HTTP/2 for the ioxide io_uring runtime: framing, HPACK (static and dynamic tables, Huffman) and flow control, with zero native code. A drop-in alternative to ioxide.nghttp2 for deployments that would rather not ship a native library - same connection shape, same request and response types.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http2/ioxide.http2.csproj
+++ b/src/protocols/ioxide.http2/ioxide.http2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http2</RootNamespace>
 
     <PackageId>ioxide.http2</PackageId>
-    <Version>0.4.166</Version>
+    <Version>0.4.167</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure-C# HTTP/2 for the ioxide io_uring runtime: framing, HPACK (static and dynamic tables, Huffman) and flow control, with zero native code. A drop-in alternative to ioxide.nghttp2 for deployments that would rather not ship a native library - same connection shape, same request and response types.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http3/ioxide.http3.csproj
+++ b/src/protocols/ioxide.http3/ioxide.http3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http3</RootNamespace>
 
     <PackageId>ioxide.http3</PackageId>
-    <Version>0.4.166</Version>
+    <Version>0.4.167</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure C# HTTP/3 for the ioxide io_uring runtime: frame parsing, QPACK (static table + Huffman) and request dispatch with zero native dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, drop-in alternative to ioxide.nghttp3.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http3/ioxide.http3.csproj
+++ b/src/protocols/ioxide.http3/ioxide.http3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http3</RootNamespace>
 
     <PackageId>ioxide.http3</PackageId>
-    <Version>0.4.165</Version>
+    <Version>0.4.166</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure C# HTTP/3 for the ioxide io_uring runtime: frame parsing, QPACK (static table + Huffman) and request dispatch with zero native dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, drop-in alternative to ioxide.nghttp3.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
+++ b/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp2</RootNamespace>
 
     <PackageId>ioxide.nghttp2</PackageId>
-    <Version>0.4.166</Version>
+    <Version>0.4.167</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/2 for the ioxide io_uring runtime: framing, HPACK and flow control from nghttp2, statically linked behind a small shim with no external dependencies beyond libc. Serves HTTP/2 over any TcpConnection - h2c with prior knowledge, or h2 over TLS via ALPN - and backs the HTTP/2 client in ioxide.httpclient from the same session code. nghttp2 is sans-I/O, so ioxide keeps the ring and the loop.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
+++ b/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp2</RootNamespace>
 
     <PackageId>ioxide.nghttp2</PackageId>
-    <Version>0.4.165</Version>
+    <Version>0.4.166</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/2 for the ioxide io_uring runtime: framing, HPACK and flow control from nghttp2, statically linked behind a small shim with no external dependencies beyond libc. Serves HTTP/2 over any TcpConnection - h2c with prior knowledge, or h2 over TLS via ALPN - and backs the HTTP/2 client in ioxide.httpclient from the same session code. nghttp2 is sans-I/O, so ioxide keeps the ring and the loop.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
+++ b/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp3</RootNamespace>
 
     <PackageId>ioxide.nghttp3</PackageId>
-    <Version>0.4.165</Version>
+    <Version>0.4.166</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/3 layer for the ioxide io_uring runtime: nghttp3 (H3 + QPACK) bundled as a single self-contained native library with no external dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, no ioxide.ngtcp2 dependency.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
+++ b/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp3</RootNamespace>
 
     <PackageId>ioxide.nghttp3</PackageId>
-    <Version>0.4.166</Version>
+    <Version>0.4.167</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/3 layer for the ioxide io_uring runtime: nghttp3 (H3 + QPACK) bundled as a single self-contained native library with no external dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, no ioxide.ngtcp2 dependency.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
+++ b/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.ngtcp2</RootNamespace>
 
     <PackageId>ioxide.ngtcp2</PackageId>
-    <Version>0.4.166</Version>
+    <Version>0.4.167</Version>
     <Authors>MDA2AV</Authors>
     <Description>QUIC engine for the ioxide io_uring runtime: ngtcp2 + picotls bundled as a single self-contained native library (only system dependency: libcrypto.so.3 / OpenSSL 3.x). Plugs into the reactor's QUIC transport via QuicConnection. Server side; engine bindings in progress.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
+++ b/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.ngtcp2</RootNamespace>
 
     <PackageId>ioxide.ngtcp2</PackageId>
-    <Version>0.4.165</Version>
+    <Version>0.4.166</Version>
     <Authors>MDA2AV</Authors>
     <Description>QUIC engine for the ioxide io_uring runtime: ngtcp2 + picotls bundled as a single self-contained native library (only system dependency: libcrypto.so.3 / OpenSSL 3.x). Plugs into the reactor's QUIC transport via QuicConnection. Server side; engine bindings in progress.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
+++ b/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.Kestrel</RootNamespace>
 
     <PackageId>ioxide.Kestrel</PackageId>
-    <Version>0.4.165</Version>
+    <Version>0.4.166</Version>
     <Authors>MDA2AV</Authors>
     <Description>ASP.NET Core Kestrel transport backed by the ioxide io_uring runtime: one reactor (ring) per core, SO_REUSEPORT load-balanced, with Kestrel's HTTP request loop pinned to the reactor thread. Drop-in via UseIoxide().</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
+++ b/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.Kestrel</RootNamespace>
 
     <PackageId>ioxide.Kestrel</PackageId>
-    <Version>0.4.166</Version>
+    <Version>0.4.167</Version>
     <Authors>MDA2AV</Authors>
     <Description>ASP.NET Core Kestrel transport backed by the ioxide io_uring runtime: one reactor (ring) per core, SO_REUSEPORT load-balanced, with Kestrel's HTTP request loop pinned to the reactor thread. Drop-in via UseIoxide().</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/Ioxide.Tests.File/FileTests.cs
+++ b/tests/Ioxide.Tests.File/FileTests.cs
@@ -2,7 +2,7 @@ using ioxide.file;
 
 namespace Ioxide.Tests;
 
-/// <summary>Static assets: baked responses served off the cache, and 404 on a miss.</summary>
+/// <summary>Static assets: files read off the ring by path, and 404 on a miss.</summary>
 internal static class FileTests
 {
     public static void Register(Runner runner)

--- a/tests/Ioxide.Tests.File/FileTests.cs
+++ b/tests/Ioxide.Tests.File/FileTests.cs
@@ -31,13 +31,41 @@ internal static class FileTests
             (int status, _) = Client.Get(port, "/nope.txt");
             Assert.Equal(404, status);
         });
+
+        // The slab path drives the core TcpConnection.ReadFileAsync - read straight into the write
+        // slab, no reader pool needed.
+        runner.Test("file: serve via ReadFileAsync (slab path)", () =>
+        {
+            var assets = new StaticAssets(SampleAssets());
+            int port = TestServer.Start(Handlers.FilesSlab, r => r.AddService(assets));
+            (int status, string body) = Client.Get(port, "/hello.txt");
+            Assert.Equal(200, status);
+            Assert.Equal("hello-asset", body);
+        });
+
+        // A file larger than the base write slab forces ReadFileAsync to grow it, then the whole body
+        // still leaves in one flush - guards the grow-and-read path.
+        runner.Test("file: slab path grows the slab for a big file", () =>
+        {
+            var assets = new StaticAssets(SampleAssets());
+            int port = TestServer.Start(Handlers.FilesSlab, r => r.AddService(assets));
+            (int status, string body) = Client.Get(port, "/big.txt");
+            Assert.Equal(200, status);
+            Assert.Equal(BigAsset.Length, body.Length);
+            Assert.Equal(BigAsset, body);
+        });
     }
+
+    // Bigger than the harness write slab (16 KiB) so serving it exercises GrowWriteSlab, but under
+    // the client's 64 KiB read buffer so the whole body comes back in one shot.
+    private static readonly string BigAsset = new('x', 40_000);
 
     private static string SampleAssets()
     {
         string dir = Path.Combine(Path.GetTempPath(), "ioxide-e2e-assets");
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "hello.txt"), "hello-asset");
+        File.WriteAllText(Path.Combine(dir, "big.txt"), BigAsset);
         return dir;
     }
 }

--- a/tests/Ioxide.Tests.Harness/Handlers.cs
+++ b/tests/Ioxide.Tests.Harness/Handlers.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 using ioxide;
 using ioxide.file;
 using ioxide.tls;
@@ -103,10 +104,11 @@ public static class Handlers
 
     // redis: /incr (RESP integer), /pipe (SET+INCR+GET in one round trip), else SET then GET.
 
-    // file: serve a baked asset by path; 404 on miss.
+    // file: read the current file off the ring by path and frame a response; 404 on miss.
     public static async Task Files(Reactor r, TcpConnection conn)
     {
         StaticAssets assets = r.GetService<StaticAssets>();
+        RingPool<AssetReader> readers = r.GetService<RingPool<AssetReader>>();
 
         try
         {
@@ -117,17 +119,24 @@ public static class Handlers
 
                 using (StaticAssets.Lease lease = assets.Acquire())
                 {
-                    if (lease.TryGet(path, out AssetCache.Asset asset) && asset.Response != 0)
+                    if (lease.TryGet(path, out AssetCache.Asset asset)
+                        && AssetCache.TryOpenCurrent(asset, out int fd, out long length, out SafeFileHandle? reopened))
                     {
-                        WriteNative(conn, asset.Response, asset.ResponseLength);
+                        try
+                        {
+                            await SendAssetAsync(conn, readers, fd, (int)length);
+                        }
+                        finally
+                        {
+                            reopened?.Dispose();
+                        }
                     }
                     else
                     {
                         Wire.Write(conn, 404, "missing");
+                        await conn.FlushAsync();
                     }
                 }
-
-                await conn.FlushAsync();
 
                 if (snapshot.IsClosed)
                 {
@@ -140,6 +149,31 @@ public static class Handlers
         finally
         {
             conn.DecRef();
+        }
+    }
+
+    // Read the whole (test-sized) file off the ring into one buffer, then frame a plain response.
+    private static async Task SendAssetAsync(TcpConnection conn, RingPool<AssetReader> readers, int fd, int length)
+    {
+        AssetReader reader = await readers.RentAsync();
+        try
+        {
+            int n = await reader.ReadAsync(fd, offset: 0);
+            if (n < 0)
+            {
+                Wire.Write(conn, 500, "read-error");
+                await conn.FlushAsync();
+                return;
+            }
+
+            conn.Write(Encoding.ASCII.GetBytes(
+                $"HTTP/1.1 200 X\r\nContent-Type: text/plain\r\nContent-Length: {n}\r\n\r\n"));
+            WriteNative(conn, reader.Buffer, n);
+            await conn.FlushAsync();
+        }
+        finally
+        {
+            readers.Return(reader);
         }
     }
 
@@ -214,7 +248,7 @@ public static class Handlers
         carry.AddRange(tls.Decrypt(item.Ptr, item.Len).ToArray());
     }
 
-    // The asset cache hands back one native response block; copy it through the write slab.
+    // Copy native memory (a ring-read buffer) through the write slab.
     private static unsafe void WriteNative(TcpConnection conn, nint data, int length)
     {
         conn.Write(new ReadOnlySpan<byte>((void*)data, length));

--- a/tests/Ioxide.Tests.Harness/Handlers.cs
+++ b/tests/Ioxide.Tests.Harness/Handlers.cs
@@ -168,6 +168,51 @@ public static class Handlers
         }
     }
 
+    // file (slab path): serve the same lookup, but read the file STRAIGHT INTO the write slab via the
+    // core TcpConnection.ReadFileAsync (the cleartext fast path) - no reader buffer, no pool, header +
+    // body in one flush. This is the end-to-end coverage for that core API.
+    public static async Task FilesSlab(Reactor r, TcpConnection conn)
+    {
+        StaticAssets assets = r.GetService<StaticAssets>();
+
+        try
+        {
+            while (true)
+            {
+                RecvSnapshot snapshot = await conn.ReadAsync();
+                string path = Wire.ReadPath(conn, snapshot);
+
+                using (StaticAssets.Lease lease = assets.Acquire())
+                {
+                    if (lease.TryGet(path, out AssetCache.Asset asset))
+                    {
+                        conn.Write(Encoding.ASCII.GetBytes(
+                            $"HTTP/1.1 200 X\r\nContent-Type: text/plain\r\nContent-Length: {asset.Length}\r\n\r\n"));
+                        int n = await conn.ReadFileAsync(asset.Fd, (int)asset.Length, fileOffset: 0);
+                        conn.AdvanceWrite(n);
+                        await conn.FlushAsync();
+                    }
+                    else
+                    {
+                        Wire.Write(conn, 404, "missing");
+                        await conn.FlushAsync();
+                    }
+                }
+
+                if (snapshot.IsClosed)
+                {
+                    return;
+                }
+
+                conn.ResetRead();
+            }
+        }
+        finally
+        {
+            conn.DecRef();
+        }
+    }
+
     // tls: the OpenSSL handshake, then a fixed response written through Wire.Write - which routes
     // through TlsSession.Write, so this handler is correct under either TLS backend.
     public static async Task Tls(Reactor r, TcpConnection conn)

--- a/tests/Ioxide.Tests.Harness/Handlers.cs
+++ b/tests/Ioxide.Tests.Harness/Handlers.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using System.Runtime.InteropServices;
-using Microsoft.Win32.SafeHandles;
 using ioxide;
 using ioxide.file;
 using ioxide.tls;
@@ -119,17 +118,9 @@ public static class Handlers
 
                 using (StaticAssets.Lease lease = assets.Acquire())
                 {
-                    if (lease.TryGet(path, out AssetCache.Asset asset)
-                        && AssetCache.TryOpenCurrent(asset, out int fd, out long length, out SafeFileHandle? reopened))
+                    if (lease.TryGet(path, out AssetCache.Asset asset))
                     {
-                        try
-                        {
-                            await SendAssetAsync(conn, readers, fd, (int)length);
-                        }
-                        finally
-                        {
-                            reopened?.Dispose();
-                        }
+                        await SendAssetAsync(conn, readers, asset.Fd, (int)asset.Length);
                     }
                     else
                     {


### PR DESCRIPTION
## What

`ioxide.file` was an HTTP/1.1 responder: it baked a full `"HTTP/1.1 200 OK…"` + body per small file. That locked it to h1 (h2/h3 couldn't reuse the snapshot) and pinned file bytes in memory.

This makes it a plain **io_uring file reader**, matching the approach of its sibling `fractal`:

- Open a directory of files once, share the descriptors across reactors, read the bytes **positionally off the ring** on demand. **No HTTP, nothing cached.** The caller gets bytes and frames whatever protocol it wants.
- **Descriptors are trusted** for the snapshot's lifetime — a deploy is picked up by **`Reload()`** (SIGHUP) rebuilding the snapshot, not by a per-request `statx`. `Asset` is now just `(Fd, Path, Length)`.
- Ported the `Playground/Clients/File` sample (frames its own h1, one write+flush per ring read), the harness `Handlers.Files`, and the site file pane. All packages → **0.4.166**.

Breaking change to the published package, hence the `!`.

## Perf — benchmarked against fractal (the no-cache sibling)

Loopback, 4 reactors, `wrk -t4 -c64`, small = 4 KiB, big = 1 MiB:

| | small | big |
|---|---|---|
| **ioxide new** (this PR) | 1.10–1.14M | 15.5–16.0k |
| **fractal** | 1.19–1.27M | 15.4–16.5k |
| ioxide old (in-memory bake) | 1.31M | 13.4k |

Two things got it there from a first-cut that was ~21% behind fractal:
- **Dropped the per-request `statx`** (trust the fd) → small files 1.00M → ~1.14M.
- **One write + flush per ring read** instead of flushing every 12 KB → large files 13.3k → ~16.0k.

Result: **on par with fractal** on both (fractal a hair ahead on tiny files — a residual reactor-path difference, not caching). The ~13% under the old bake is the genuine cost of not caching, which fractal pays too. **No byte cache needed** — reading on demand is competitive.

## Test

Full solution builds; `File` 2/2, `E2E` 46/46 green.