### PR TITLE
feat(file): serve static files over kTLS without giving back the slab path

### DIFF
--- a/Playground/Clients/File/Program.cs
+++ b/Playground/Clients/File/Program.cs
@@ -39,12 +39,36 @@ using Playground.Shared;
 //  Needs: ioxide, ioxide.file
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
-string dir      = Env.Str("PLAYGROUND_DIR", "/tmp/ioxide-assets");
-bool   buffered = Env.Flag("PLAYGROUND_FILE_BUFFERED");   // read into a buffer vs straight into the slab
-string tlsMode  = Env.Str("PLAYGROUND_FILE_TLS", "none"); // none | ktls (kernel transmit) | openssl
+// ── Knobs ────────────────────────────────────────────────────────────────────────────────────
+// Edit these. That is the whole mechanism - there is no config file and nothing else to find.
+// Env.Override exists only so bench/file-matrix.sh can drive the sample from outside; delete
+// those lines when you copy this out and the literals above them are the entire configuration.
+
+string dir = "/tmp/ioxide-assets";   // served root, walked once into a snapshot
+
+// Which transport terminates here. This is what decides whether the slab path below is legal
+// at all - see the header. none | ktls | openssl
+string tlsMode = "none";
+
+// Read the file into a pooled buffer and copy it into the slab, instead of reading it straight
+// into the slab. Forced for openssl, which cannot use the slab path.
+bool buffered = false;
+
+int reactors = Environment.ProcessorCount;   // one ring per reactor, one reactor per core
+
+// A real PEM pair, or null to generate a self-signed localhost cert on first run.
+string? certOverride = null;
+string? keyOverride  = null;
+
+Env.OverrideFile(ref dir, ref buffered, ref tlsMode);
 
 bool tlsOn = tlsMode is "ktls" or "openssl";
 bool ktls  = tlsMode == "ktls";
+
+ushort port = tlsOn ? (ushort)8443 : (ushort)8080;
+
+Env.Override(ref port, ref reactors);
+// ─────────────────────────────────────────────────────────────────────────────────────────────
 
 // The constraint this sample exists to show, enforced instead of described: with OpenSSL owning
 // transmit the slab must hold CIPHERTEXT, so a file read straight into it would go out in the
@@ -57,7 +81,9 @@ if (tlsMode == "openssl" && !buffered)
     Environment.Exit(1);
 }
 
-(string certPath, string keyPath) = tlsOn ? QuicCert.Ensure(null, null) : (string.Empty, string.Empty);
+(string certPath, string keyPath) = tlsOn
+    ? QuicCert.Ensure(certOverride, keyOverride)
+    : (string.Empty, string.Empty);
 
 SampleAssets.Ensure(dir);   // writes a demo index.html + style.css if the directory is empty
 
@@ -66,7 +92,7 @@ var assets = new StaticAssets(dir);   // served root (PLAYGROUND_DIR), walked on
 
 var config = new ServerConfig
 {
-    ReactorCount   = Env.Int("PLAYGROUND_REACTORS", Environment.ProcessorCount),  // io_uring rings/threads - one per core
+    ReactorCount   = reactors,                                                    // io_uring rings/threads - one per core
     RingEntries    = 8192,                                                        // SQ/CQ depth per ring
     DualStack      = false,                                                       // true = one IPv6 socket also accepts IPv4-mapped
     RecvBufferSize = 32 * 1024,                                                   // bytes per shared recv buffer
@@ -76,7 +102,7 @@ var config = new ServerConfig
     Quic           = null,                                                        // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port             = Env.Port("PLAYGROUND_PORT", tlsOn ? (ushort)8443 : (ushort)8080),
+        Port             = port,                                                  // 8080 cleartext, 8443 with TLS
         ExtraPorts       = [],                                                    // extra listener ports (one handler, several doors)
         ListenBacklog    = 1024,                                                  // accept-queue depth per SO_REUSEPORT listener
         WriteSlabSize    = 16 * 1024,                                             // per-connection write buffer; ReadFileAsync grows it to fit a bigger file

--- a/Playground/Clients/File/Program.cs
+++ b/Playground/Clients/File/Program.cs
@@ -2,6 +2,7 @@ using System.Buffers.Text;
 using System.Runtime.InteropServices;
 using ioxide;
 using ioxide.file;
+using ioxide.tls;
 using ioxide.utils;
 using Playground.Shared;
 
@@ -12,27 +13,51 @@ using Playground.Shared;
 //  file data can be handed to any protocol.
 //
 //  Two ways to move the bytes, selected by PLAYGROUND_FILE_BUFFERED:
-//    - default (cleartext): conn.ReadFileAsync reads the file STRAIGHT INTO the write slab, so the
-//      header and body leave in a single flush - no intermediate buffer, no copy. The leanest path
-//      for a plain connection.
-//    - buffered (=1): read into a reader buffer first, then hand those bytes on. This is the shape
-//      a TLS connection needs - the body has to pass through an encrypt (TlsSession.Write) before
-//      the wire, so it can't be read straight into the send slab. Here (cleartext) the buffer is
-//      just copied into the slab to mirror that structure.
+//    - default: conn.ReadFileAsync reads the file STRAIGHT INTO the write slab, so the header and
+//      body leave in a single flush - no intermediate buffer, no copy.
+//    - buffered (=1): read into a reader buffer first, then copy those bytes into the slab.
+//
+//  PLAYGROUND_FILE_TLS picks the transport: none, ktls (kernel transmit) or openssl. Which paths
+//  are legal follows from ONE question - what is the write slab supposed to contain when it is sent?
+//    - none:    the slab IS the wire. Both paths legal.
+//    - ktls:    the slab holds PLAINTEXT and the kernel makes the records. Both paths legal, so the
+//               file still never gets copied. This is the pairing the sample exists for.
+//    - openssl: the slab must hold CIPHERTEXT, so the body has to pass through TlsSession.Write -
+//               which needs a source buffer to read from. That buffer IS the copy, so there is no
+//               slab path at all and the sample refuses the combination rather than serving
+//               cleartext. Choosing this backend is choosing to pay the copy.
 //
 //  Descriptors are trusted for the snapshot's lifetime - a deploy is picked up by reloading the
 //  snapshot (SIGHUP), which reopens the files, not by re-stat'ing every request.
 //
 //      PLAYGROUND_DIR=/srv/www dotnet run -c Release --project Playground/Clients/File
 //      curl http://127.0.0.1:8080/index.html
-//      PLAYGROUND_FILE_BUFFERED=1 dotnet run ...   # the buffer path (the shape TLS uses)
+//      PLAYGROUND_FILE_BUFFERED=1 dotnet run ...   # buffer path instead of the slab
+//      sudo modprobe tls && PLAYGROUND_FILE_TLS=ktls dotnet run ...  # then curl -k https://:8443/
 //      kill -HUP <pid>        # reload the snapshot after a deploy
 //
 //  Needs: ioxide, ioxide.file
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 
 string dir      = Env.Str("PLAYGROUND_DIR", "/tmp/ioxide-assets");
-bool   buffered = Env.Flag("PLAYGROUND_FILE_BUFFERED");   // read into a buffer (the TLS shape) vs into the slab
+bool   buffered = Env.Flag("PLAYGROUND_FILE_BUFFERED");   // read into a buffer vs straight into the slab
+string tlsMode  = Env.Str("PLAYGROUND_FILE_TLS", "none"); // none | ktls (kernel transmit) | openssl
+
+bool tlsOn = tlsMode is "ktls" or "openssl";
+bool ktls  = tlsMode == "ktls";
+
+// The constraint this sample exists to show, enforced instead of described: with OpenSSL owning
+// transmit the slab must hold CIPHERTEXT, so a file read straight into it would go out in the
+// clear. There is no slab path for that backend - refuse rather than serve cleartext.
+if (tlsMode == "openssl" && !buffered)
+{
+    Console.Error.WriteLine("[file] openssl TLS has no slab path: the slab must hold ciphertext, so "
+                          + "the body has to pass through TlsSession.Write. Use "
+                          + "PLAYGROUND_FILE_BUFFERED=1, or PLAYGROUND_FILE_TLS=ktls for the slab.");
+    Environment.Exit(1);
+}
+
+(string certPath, string keyPath) = tlsOn ? QuicCert.Ensure(null, null) : (string.Empty, string.Empty);
 
 SampleAssets.Ensure(dir);   // writes a demo index.html + style.css if the directory is empty
 
@@ -51,7 +76,7 @@ var config = new ServerConfig
     Quic           = null,                                                        // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port             = Env.Port("PLAYGROUND_PORT", 8080),
+        Port             = Env.Port("PLAYGROUND_PORT", tlsOn ? (ushort)8443 : (ushort)8080),
         ExtraPorts       = [],                                                    // extra listener ports (one handler, several doors)
         ListenBacklog    = 1024,                                                  // accept-queue depth per SO_REUSEPORT listener
         WriteSlabSize    = 16 * 1024,                                             // per-connection write buffer; ReadFileAsync grows it to fit a bigger file
@@ -76,66 +101,72 @@ for (int i = 0; i < threads.Length; i++)
         AssetReader.CreatePool(r,
             readers:     4,         // concurrent ring reads bounded per reactor (pool size)
             bufferBytes: 1 << 20);  // native read buffer per reader (1 MiB) - size for the largest asset
+
+        if (tlsOn)
+        {
+            TlsService.Start(r, new TlsOptions
+            {
+                CertificatePath = certPath,
+                KeyPath         = keyPath,
+
+                // The whole point: with transmit in the kernel the slab carries PLAINTEXT and the
+                // kernel makes the records, so ReadFileAsync may still read the file straight into
+                // it. With this false, OpenSSL encrypts and the slab must hold ciphertext - which
+                // is why the slab path is refused above. Receive is OpenSSL either way.
+                KernelTx = ktls,
+            });
+        }
     };
 
     reactor.TcpHandle = async (r, conn) =>
     {
         StaticAssets snapshot = r.GetService<StaticAssets>();
         RingPool<AssetReader> readers = r.GetService<RingPool<AssetReader>>();
+        TlsSession? tls = null;
+
+        // Request bytes waiting to be framed. Both transports go through this, so the two differ
+        // only in how bytes get IN - otherwise the plaintext arm would answer once per recv batch
+        // and the TLS arm once per record, and the two would not be comparable.
+        var carry = new Carry();
 
         try
         {
+            if (tlsOn)
+            {
+                tls = await r.GetService<TlsService>().AcceptAsync(conn);
+
+                // A request can ride in with the handshake's final flight; serve it before parking
+                // in ReadAsync or the client waits on a response that never comes.
+                carry.Append(tls.DrainPlaintext());
+                await ServeAsync(conn, tls, carry, snapshot, readers, buffered);
+            }
+
             while (true)
             {
                 RecvSnapshot recv = await conn.ReadAsync();
 
-                // The lease pins the snapshot for the whole request, so a concurrent Reload() can't
-                // close the fd out from under an in-flight read.
-                using (StaticAssets.Lease lease = snapshot.Acquire())
+                while (conn.TryGetItem(recv, out SpscRecvRing.Item item))
                 {
-                    // Resolve the target against the snapshot while the recv bytes are still valid -
-                    // the lookup is span-based, so no string is ever allocated for a hit.
-                    bool found = false;
-                    AssetCache.Asset asset = default;
-
-                    while (conn.TryGetItem(recv, out SpscRecvRing.Item item))
+                    if (item.HasBuffer)
                     {
-                        if (item.HasBuffer)
-                        {
-                            if (!found && TryReadTarget(item.AsSpan(), out ReadOnlySpan<byte> target))
-                            {
-                                found = lease.TryGet(target, out asset);
-                            }
-                            conn.ReturnBuffer(in item);
-                        }
-                    }
-
-                    // The fd is trusted for the snapshot's lifetime, so serving is just: read the
-                    // bytes off the ring and frame HTTP around them.
-                    if (found)
-                    {
-                        if (buffered)
-                        {
-                            await SendBufferedAsync(conn, readers, asset);
-                        }
-                        else
-                        {
-                            await SendSlabAsync(conn, asset);
-                        }
-                    }
-                    else
-                    {
-                        conn.Write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"u8);
-                        await conn.FlushAsync();
+                        Append(tls, in item, carry);
+                        conn.ReturnBuffer(in item);
                     }
                 }
 
-                if (recv.IsClosed) return;
+                await ServeAsync(conn, tls, carry, snapshot, readers, buffered);
+
+                if (recv.IsClosed || (tls?.Closed ?? false)) return;
                 conn.ResetRead();
             }
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"[file] connection failed: {e.Message}");
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
@@ -156,21 +187,73 @@ using var reload = PosixSignalRegistration.Create(PosixSignal.SIGHUP, context =>
 
 Console.WriteLine($"[file] {config.ReactorCount} reactors on :{config.Tcp.Port} - "
                 + $"{assets.Count} files under {assets.RootDir} "
-                + $"({(buffered ? "buffer path" : "slab path")}, nothing cached)");
+                + $"({(buffered ? "buffer path" : "slab path")}, "
+                + $"tls={tlsMode}, nothing cached)");
 
 foreach (Thread thread in threads)
 {
     thread.Join();
 }
 
+// Bytes in. Cleartext appends the ring buffer as-is; TLS decrypts it first. Decrypt takes a raw
+// pointer because the buffer belongs to the ring, and the pointer work has to stay out of the
+// async handler, which cannot contain unsafe code.
+static unsafe void Append(TlsSession? tls, in SpscRecvRing.Item item, Carry carry)
+    => carry.Append(tls is null ? item.AsSpan() : tls.Decrypt(item.Ptr, item.Len));
+
+// One response per COMPLETE request in the carry, none for a partial one. Under kTLS the response
+// bytes go into the slab as plaintext and the kernel encrypts them on send, so both the slab and
+// buffer paths below are written exactly as they are for cleartext.
+static async Task ServeAsync(TcpConnection conn, TlsSession? tls, Carry carry, StaticAssets snapshot,
+    RingPool<AssetReader> readers, bool buffered)
+{
+    int end;
+    while ((end = carry.Span.IndexOf("\r\n\r\n"u8)) >= 0)
+    {
+        bool found = false;
+        AssetCache.Asset asset = default;
+
+        // The lease pins the snapshot for the request, so a concurrent Reload() cannot close the
+        // fd out from under an in-flight read.
+        using (StaticAssets.Lease lease = snapshot.Acquire())
+        {
+            if (TryReadTarget(carry.Span[..end], out ReadOnlySpan<byte> target))
+            {
+                found = lease.TryGet(target, out asset);
+            }
+
+            carry.Consume(end + 4);
+
+            if (found)
+            {
+                if (buffered)
+                {
+                    await SendBufferedAsync(conn, tls, readers, asset);
+                }
+                else
+                {
+                    await SendSlabAsync(conn, tls, asset);
+                }
+            }
+        }
+
+        if (!found)
+        {
+            Emit(conn, tls, "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"u8);
+            await conn.FlushAsync();
+        }
+    }
+}
+
+
 // Cleartext fast path: read the whole file STRAIGHT INTO the write slab (it grows to fit), right
 // after the header, so header + body leave in one flush - no reader buffer, no copy. Ideal for the
 // typical multi-KB web asset; a very large file grows the slab by its full size, so stream those
 // with the buffer path instead.
-static async Task SendSlabAsync(TcpConnection conn, AssetCache.Asset asset)
+static async Task SendSlabAsync(TcpConnection conn, TlsSession? tls, AssetCache.Asset asset)
 {
     Span<byte> header = stackalloc byte[256];
-    conn.Write(header[..WriteHeader(header, asset.Path, asset.Length)]);
+    Emit(conn, tls, header[..WriteHeader(header, asset.Path, asset.Length)]);
 
     // io_uring positional read into the slab at the current tail; AdvanceWrite commits the bytes.
     int n = await conn.ReadFileAsync(asset.Fd, (int)asset.Length, fileOffset: 0);
@@ -182,7 +265,7 @@ static async Task SendSlabAsync(TcpConnection conn, AssetCache.Asset asset)
 // for the transform a TLS connection does here instead - tls.Write(conn, reader.Buffer[..n]), which
 // encrypts into the slab. Files bigger than the buffer take several reads at advancing offsets,
 // one flush each.
-static async Task SendBufferedAsync(TcpConnection conn, RingPool<AssetReader> readers, AssetCache.Asset asset)
+static async Task SendBufferedAsync(TcpConnection conn, TlsSession? tls, RingPool<AssetReader> readers, AssetCache.Asset asset)
 {
     AssetReader reader = await readers.RentAsync();
     try
@@ -190,15 +273,15 @@ static async Task SendBufferedAsync(TcpConnection conn, RingPool<AssetReader> re
         int first = await reader.ReadAsync(asset.Fd, offset: 0);   // io_uring positional read
         if (first < 0)
         {
-            conn.Write("HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n"u8);
+            Emit(conn, tls, "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n"u8);
             await conn.FlushAsync();
             return;
         }
 
         // Header + first chunk go out together in one flush.
         Span<byte> header = stackalloc byte[256];
-        conn.Write(header[..WriteHeader(header, asset.Path, asset.Length)]);
-        WriteNative(conn, reader.Buffer, first);
+        Emit(conn, tls, header[..WriteHeader(header, asset.Path, asset.Length)]);
+        WriteNative(conn, tls, reader.Buffer, first);
         await conn.FlushAsync();
 
         long offset = first;
@@ -206,7 +289,7 @@ static async Task SendBufferedAsync(TcpConnection conn, RingPool<AssetReader> re
         {
             int read = await reader.ReadAsync(asset.Fd, offset);
             if (read <= 0) break;   // EOF or mid-stream error; the response is already committed
-            WriteNative(conn, reader.Buffer, read);
+            WriteNative(conn, tls, reader.Buffer, read);
             await conn.FlushAsync();
             offset += read;
         }
@@ -218,8 +301,18 @@ static async Task SendBufferedAsync(TcpConnection conn, RingPool<AssetReader> re
 }
 
 // Copy native memory (a ring-read buffer) into the connection's write slab in one go.
-static unsafe void WriteNative(TcpConnection conn, nint data, int length)
-    => conn.Write(new ReadOnlySpan<byte>((void*)data, length));
+static unsafe void WriteNative(TcpConnection conn, TlsSession? tls, nint data, int length)
+    => Emit(conn, tls, new ReadOnlySpan<byte>((void*)data, length));
+
+// Every response byte goes through here. TlsSession.Write is correct under BOTH backends - it
+// writes plaintext to the slab when the kernel encrypts, and encrypts into the slab when OpenSSL
+// does - so no call site has to know which one is in play. A bare conn.Write would be right only
+// for cleartext and kTLS, and silently wrong for OpenSSL.
+static void Emit(TcpConnection conn, TlsSession? tls, ReadOnlySpan<byte> bytes)
+{
+    if (tls is null) conn.Write(bytes);
+    else             tls.Write(conn, bytes);
+}
 
 // Write the 200 status line + Content-Type + Content-Length for this file.
 static int WriteHeader(Span<byte> destination, string path, long bodyLength)
@@ -271,4 +364,33 @@ static bool TryReadTarget(ReadOnlySpan<byte> request, out ReadOnlySpan<byte> tar
     if (query >= 0) target = target[..query];
 
     return true;
+}
+
+// Plaintext waiting to be framed into requests. TLS hands back records, not requests: a request
+// split across two records decrypts as two pieces, so answering per decrypt answers twice.
+sealed class Carry
+{
+    private byte[] _buffer = new byte[8192];
+    private int _length;
+
+    public ReadOnlySpan<byte> Span => _buffer.AsSpan(0, _length);
+
+    public void Append(ReadOnlySpan<byte> more)
+    {
+        if (more.IsEmpty) return;
+
+        if (_length + more.Length > _buffer.Length)
+        {
+            Array.Resize(ref _buffer, Math.Max(_buffer.Length * 2, _length + more.Length));
+        }
+
+        more.CopyTo(_buffer.AsSpan(_length));
+        _length += more.Length;
+    }
+
+    public void Consume(int count)
+    {
+        _buffer.AsSpan(count, _length - count).CopyTo(_buffer);
+        _length -= count;
+    }
 }

--- a/Playground/Shared/Env.cs
+++ b/Playground/Shared/Env.cs
@@ -79,4 +79,14 @@ public static class Env
         kernelRx = Bool("PLAYGROUND_KTLS_RX", kernelRx);
     }
 
+    /// <summary>
+    /// The static-file sample's own knobs, so bench/file-matrix.sh can drive every arm of the
+    /// slab-vs-buffer matrix from a single build instead of rebuilding per cell.
+    /// </summary>
+    public static void OverrideFile(ref string dir, ref bool buffered, ref string tlsMode)
+    {
+        dir = Str("PLAYGROUND_DIR", dir);
+        buffered = Bool("PLAYGROUND_FILE_BUFFERED", buffered);
+        tlsMode = Str("PLAYGROUND_FILE_TLS", tlsMode);
+    }
 }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ ioxide hands you raw bytes and stays out of HTTP; when you want a framework on t
 `ioxide.Kestrel` swaps the transport under an existing ASP.NET Core app with your endpoints
 unchanged.
 
-> Linux 6.1+ · .NET 10 / .NET 11 · `0.4.153` - experimental
+> Linux 6.1+ · .NET 10 / .NET 11 · `0.4.168` - experimental
 
 **[Documentation](https://mda2av.github.io/ioxide/)** - architecture, guides, and every example as
 runnable code side by side.

--- a/bench/file-matrix.sh
+++ b/bench/file-matrix.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Static files: does reading the file straight into the write slab still pay once TLS is on?
+#
+#   slab     conn.ReadFileAsync puts the file in the write slab at the current tail - no reader
+#            buffer, no copy. IORING_OP_READ lands the bytes where the next send picks them up.
+#   buffer   read into a pooled native buffer, then move those bytes into the slab.
+#
+# Crossed with the transport, because what is legal follows from what the slab must contain:
+#
+#   none      the slab IS the wire.                        both paths legal
+#   ktls      the slab holds plaintext, kernel encrypts.   both paths legal  <- the pairing at issue
+#   openssl   the slab must hold ciphertext.               buffer ONLY, by construction
+#
+# METHOD - one saturated reactor. This is not a detail. With several reactors that are not pegged,
+# the reactor threads spend time polling an idle ring, that time lands in utime/stime, and CPU per
+# request comes out inflated and the ratio between arms compressed. An earlier version of this
+# script ran 4 unsaturated reactors and reported an 11% slab win where the single-reactor method
+# had measured 24%. One reactor, driven past saturation, verified above MIN_UTIL - that is the
+# number that means something.
+#
+# Loopback only: no DMA, no NIC offload. Fine for this question - what is being measured is an
+# eliminated memory copy, not a hardware path.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+REACTORS=${REACTORS:-1}
+DURATION=${DURATION:-10}
+CONNS=${CONNS:-64}
+THREADS=${THREADS:-8}      # load generator threads; must outrun the single reactor
+PASSES=${PASSES:-2}
+SIZES=${SIZES:-"4096 65536"}
+MIN_UTIL=${MIN_UTIL:-90}   # reject a cell whose reactor was not actually saturated (% of one core)
+DIR=${DIR:-/tmp/ioxide-bench-assets}
+OUT=${OUT:-/tmp/file-matrix}
+BIN=Playground/Clients/File/bin/Release/net11.0/Playground.Clients.File
+
+mkdir -p "$OUT" "$DIR"
+SERVER_PID=""
+
+stop_server() {
+  [[ -z "$SERVER_PID" ]] && return 0
+  kill "$SERVER_PID" 2>/dev/null
+  for _ in $(seq 40); do kill -0 "$SERVER_PID" 2>/dev/null || break; sleep 0.1; done
+  kill -9 "$SERVER_PID" 2>/dev/null
+  wait "$SERVER_PID" 2>/dev/null
+  SERVER_PID=""
+}
+trap stop_server EXIT
+
+cpu_ticks() { awk '{print $14 + $15}' "/proc/$1/stat" 2>/dev/null || echo 0; }
+
+declare -A BEST CPU NOTE
+
+cell() {   # cell <label> <port> <buffered> <tlsmode> <size>
+  local label=$1 port=$2 buffered=$3 mode=$4 size=$5
+  local scheme=http; [[ $mode != none ]] && scheme=https
+  local url="$scheme://127.0.0.1:$port/f.bin"
+  local tag="${label//[^a-z0-9]/_}_$size"
+
+  # SO_REUSEPORT will happily let a leaked server from an earlier run co-bind this port and take
+  # half the load. Refuse to start rather than measure two servers at once.
+  if ss -ltnp "sport = :$port" 2>/dev/null | grep -q LISTEN; then
+    echo "  !! port $port already held - skipping"; NOTE["$label|$size"]="port held"; return
+  fi
+
+  env PLAYGROUND_DIR="$DIR" PLAYGROUND_REACTORS="$REACTORS" PLAYGROUND_PORT="$port" \
+      PLAYGROUND_FILE_BUFFERED="$buffered" PLAYGROUND_FILE_TLS="$mode" \
+      "$BIN" >"$OUT/server.log" 2>&1 &
+  SERVER_PID=$!
+
+  local up=0
+  for _ in $(seq 100); do
+    kill -0 "$SERVER_PID" 2>/dev/null || break
+    curl -sk -o /dev/null --max-time 1 "$url" && { up=1; break; }
+    sleep 0.1
+  done
+  if [[ $up == 0 ]]; then
+    echo "  !! $label never answered"; tail -3 "$OUT/server.log"
+    NOTE["$label|$size"]="no answer"; stop_server; return
+  fi
+
+  # Exactly one process may be listening here.
+  local listeners; listeners=$(ss -ltnp "sport = :$port" 2>/dev/null | grep -c LISTEN)
+  if [[ "$listeners" != 1 ]]; then
+    echo "  !! $label has $listeners listeners on $port"; NOTE["$label|$size"]="listeners=$listeners"
+    stop_server; return
+  fi
+
+  # The arms must serve the SAME bytes, or the comparison is of two different workloads.
+  local got; got=$(curl -sk --max-time 3 "$url" | wc -c)
+  if [[ "$got" != "$size" ]]; then
+    echo "  !! $label served $got bytes, expected $size"; NOTE["$label|$size"]="bytes=$got"
+    stop_server; return
+  fi
+
+  wrk -t"$THREADS" -c"$CONNS" -d5s "$url" >/dev/null 2>&1          # warm: JIT, slabs, handshakes
+
+  local t0 t1 rps; t0=$(cpu_ticks "$SERVER_PID")
+  wrk -t"$THREADS" -c"$CONNS" -d"${DURATION}s" --latency "$url" >"$OUT/$tag.txt" 2>&1
+  t1=$(cpu_ticks "$SERVER_PID")
+  rps=$(grep -oP 'Requests/sec:\s+\K[\d.]+' "$OUT/$tag.txt" | head -1)
+  stop_server
+  rps=${rps:-0}
+
+  # A run with failed requests is not a throughput number. wrk reports both separately.
+  local bad; bad=$(grep -oP 'Non-2xx or 3xx responses: \K\d+' "$OUT/$tag.txt" | head -1)
+  local errs; errs=$(grep -oP 'Socket errors:.*' "$OUT/$tag.txt" | head -1)
+  if [[ -n "${bad:-}" && "${bad:-0}" != 0 ]]; then
+    echo "  !! $label had $bad non-2xx responses - discarding"; NOTE["$label|$size"]="non2xx=$bad"; return
+  fi
+  if [[ -n "${errs:-}" ]]; then
+    echo "  !! $label $errs - discarding"; NOTE["$label|$size"]="socket errors"; return
+  fi
+
+  # Saturation check: CPU seconds burned over wall seconds, as a percentage of ONE core.
+  local util; util=$(awk -v t="$((t1 - t0))" -v d="$DURATION" 'BEGIN{printf "%.0f", (t/100.0)/d*100}')
+  if (( util < MIN_UTIL )); then
+    echo "  !! $label reactor only ${util}% busy (need ${MIN_UTIL}%) - raise CONNS/THREADS"
+    NOTE["$label|$size"]="util=${util}%"; return
+  fi
+
+  local us; us=$(awk -v t="$((t1 - t0))" -v r="$rps" -v d="$DURATION" \
+    'BEGIN{ if (r>0) printf "%.2f", (t/100.0)/(r*d)*1e6; else print "0" }')
+
+  if awk -v a="$rps" -v b="${BEST["$label|$size"]:-0}" 'BEGIN{exit !(a>b)}'; then
+    BEST["$label|$size"]=$rps; CPU["$label|$size"]=$us
+  fi
+  printf '    %-18s %-6s %11s req/s  %6s us cpu/req  util %s%%\n' "$label" "$size" "$rps" "$us" "$util"
+}
+
+for pass in $(seq "$PASSES"); do
+  echo "== pass $pass/$PASSES  ($REACTORS reactor, $CONNS conns, ${DURATION}s, saturated)"
+  for size in $SIZES; do
+    head -c "$size" /dev/urandom | base64 | head -c "$size" > "$DIR/f.bin"
+    cell none-slab      9201 0 none    "$size"
+    cell none-buffer    9202 1 none    "$size"
+    cell ktls-slab      9203 0 ktls    "$size"
+    cell ktls-buffer    9204 1 ktls    "$size"
+    cell openssl-buffer 9205 1 openssl "$size"
+  done
+done
+
+echo
+echo "== best of $PASSES passes"
+printf '   %-16s %11s  %10s  %s\n' arm req/s cpu/req note
+for size in $SIZES; do
+  echo "-- file $size bytes"
+  for arm in none-slab none-buffer ktls-slab ktls-buffer openssl-buffer; do
+    printf '   %-16s %11.0f  %8s us  %s\n' "$arm" "${BEST["$arm|$size"]:-0}" \
+      "${CPU["$arm|$size"]:-0}" "${NOTE["$arm|$size"]:-}"
+  done
+  awk -v a="${BEST["none-slab|$size"]:-0}"   -v b="${BEST["none-buffer|$size"]:-0}" \
+      -v c="${CPU["none-slab|$size"]:-0}"    -v d="${CPU["none-buffer|$size"]:-0}" \
+      'BEGIN{ if (a>0&&b>0) printf "     cleartext: slab is %.2fx rps, %.2fx cpu/req\n", a/b, c/d }'
+  awk -v a="${BEST["ktls-slab|$size"]:-0}"   -v b="${BEST["ktls-buffer|$size"]:-0}" \
+      -v c="${CPU["ktls-slab|$size"]:-0}"    -v d="${CPU["ktls-buffer|$size"]:-0}" \
+      'BEGIN{ if (a>0&&b>0) printf "     ktls:      slab is %.2fx rps, %.2fx cpu/req\n", a/b, c/d }'
+  awk -v a="${BEST["ktls-slab|$size"]:-0}"   -v b="${BEST["openssl-buffer|$size"]:-0}" \
+      -v c="${CPU["ktls-slab|$size"]:-0}"    -v d="${CPU["openssl-buffer|$size"]:-0}" \
+      'BEGIN{ if (a>0&&b>0) printf "     TLS best:  ktls+slab is %.2fx rps, %.2fx cpu/req vs openssl+buffer\n", a/b, c/d }'
+done

--- a/docs/index.html
+++ b/docs/index.html
@@ -5128,155 +5128,289 @@ foreach (Thread t in threads) t.Join();</code></pre>
   </div>
   <div class="pane pane-files">
     <div class="pane-head">
-      <h3>Static files</h3>
+      <h3>Client &middot; static files</h3>
       <span class="pane-pkg">ioxide + ioxide.file</span>
     </div>
-<pre><code class="language-csharp">// dotnet add package ioxide ioxide.file
+<pre><code class="language-csharp">// dotnet add package ioxide
+// dotnet add package ioxide.file
+//   curl http://127.0.0.1:8080/index.html
+//   PLAYGROUND_FILE_TLS=ktls    # then curl -k https://127.0.0.1:8443/index.html
+
 using System.Buffers.Text;
+using System.Runtime.InteropServices;
 using ioxide;
 using ioxide.file;
+using ioxide.tls;
 using ioxide.utils;
 
-// Opens every file ONCE and shares the descriptors across all reactors: stable and read
-// positionally off the ring, nothing cached. Built before the reactors start.
-var assets = new StaticAssets(&quot;/srv/www&quot;);
+// ── Knobs ────────────────────────────────────────────────────────────────────────────────────
 
-// Two ways to move the bytes:
-//   - slab (cleartext): conn.ReadFileAsync reads the file straight into the write slab, so header
-//     + body leave in one flush - no buffer, no copy. The leanest plain path.
-//   - buffer: read into a reader buffer first. A TLS connection needs this shape - the body has to
-//     pass through tls.Write (encrypt) before the wire, so it can&#x27;t land straight in the slab.
+string dir = &quot;/tmp/ioxide-assets&quot;;   // served root, walked once into a snapshot
+
+// Which transport terminates here. This is what decides whether the slab path below is legal
+// at all - see the header. none | ktls | openssl
+string tlsMode = &quot;none&quot;;
+
+// Read the file into a pooled buffer and copy it into the slab, instead of reading it straight
+// into the slab. Forced for openssl, which cannot use the slab path.
 bool buffered = false;
+
+int reactors = Environment.ProcessorCount;   // one ring per reactor, one reactor per core
+
+const string certPath = &quot;cert.pem&quot;;   // any PEM pair
+const string keyPath  = &quot;key.pem&quot;;
+
+
+bool tlsOn = tlsMode is &quot;ktls&quot; or &quot;openssl&quot;;
+bool ktls  = tlsMode == &quot;ktls&quot;;
+
+ushort port = tlsOn ? (ushort)8443 : (ushort)8080;
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+// The constraint this sample exists to show, enforced instead of described: with OpenSSL owning
+// transmit the slab must hold CIPHERTEXT, so a file read straight into it would go out in the
+// clear. There is no slab path for that backend - refuse rather than serve cleartext.
+if (tlsMode == &quot;openssl&quot; &amp;&amp; !buffered)
+{
+    Console.Error.WriteLine(&quot;[file] openssl TLS has no slab path: the slab must hold ciphertext, so &quot;
+                          + &quot;the body has to pass through TlsSession.Write. Use &quot;
+                          + &quot;PLAYGROUND_FILE_BUFFERED=1, or PLAYGROUND_FILE_TLS=ktls for the slab.&quot;);
+    Environment.Exit(1);
+}
+
+
+SampleAssets.Ensure(dir);   // writes a demo index.html + style.css if the directory is empty
+
+// Built once for the whole process, BEFORE the reactors start: every reactor shares this snapshot.
+var assets = new StaticAssets(dir);   // served root (PLAYGROUND_DIR), walked once into a snapshot
 
 var config = new ServerConfig
 {
-    ReactorCount = Environment.ProcessorCount,   // one ring per reactor, one reactor per core
-    RingEntries  = 8192,                         // io_uring SQ/CQ depth
-    DualStack    = false,                        // true = one AF_INET6 socket takes v6 + v4-mapped
-
-    // Shared recv ring - the default mode, used while Incremental is null.
-    RecvBufferSize = 32 * 1024,
-    RecvSlots      = 4096,
-
+    ReactorCount   = reactors,                                                    // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                                        // SQ/CQ depth per ring
+    DualStack      = false,                                                       // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                                                   // bytes per shared recv buffer
+    RecvSlots      = 4096,                                                        // shared recv buffer-ring depth
+    Incremental    = null,                                                        // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                                        // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                                        // no QUIC transport - see Http3/* and Quic/Alpn
     Tcp = new TcpOptions
     {
-        Port             = 8080,
-        ExtraPorts       = [],                   // more listeners; conn.ListenerPort says which
-        ListenBacklog    = 1024,                 // accept queue per SO_REUSEPORT listener
-        WriteSlabSize    = 16 * 1024,            // per-connection write buffer
-        PoolMax          = 1024,                 // connection objects recycled per reactor
-        WriteOverflow    = WriteOverflowStrategy.Grow,   // Segmented = chained slabs, one SENDMSG
-        ZeroCopySend     = false,                // SEND_ZC; only pays off on large responses
-        RecvQueueEntries = 64,                   // per-connection SPSC queue, power of two
+        Port             = port,                                                  // 8080 cleartext, 8443 with TLS
+        ExtraPorts       = [],                                                    // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                                                  // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                                             // per-connection write buffer; ReadFileAsync grows it to fit a bigger file
+        PoolMax          = 1024,                                                  // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,                            // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                                                 // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                                                    // per-connection recv completion queue depth
     },
-
 };
 
 var threads = new Thread[config.ReactorCount];
 
-for (int id = 0; id &lt; threads.Length; id++)
+for (int i = 0; i &lt; threads.Length; i++)
 {
-    var reactor = new Reactor(id, config);
+    var reactor = new Reactor(i, config);
 
     reactor.OnStart = r =&gt;
     {
-        r.AddService(assets);
-        AssetReader.CreatePool(r, readers: 4, bufferBytes: 1 &lt;&lt; 20);   // per-reactor ring readers
+        r.AddService(assets);   // the shared snapshot
+        // The buffer path needs a pool of native read buffers; the slab path reads into the
+        // connection&#x27;s own write slab and needs none, but registering it is harmless either way.
+        AssetReader.CreatePool(r,
+            readers:     4,         // concurrent ring reads bounded per reactor (pool size)
+            bufferBytes: 1 &lt;&lt; 20);  // native read buffer per reader (1 MiB) - size for the largest asset
+
+        if (tlsOn)
+        {
+            TlsService.Start(r, new TlsOptions
+            {
+                CertificatePath = certPath,
+                KeyPath         = keyPath,
+
+                // The whole point: with transmit in the kernel the slab carries PLAINTEXT and the
+                // kernel makes the records, so ReadFileAsync may still read the file straight into
+                // it. With this false, OpenSSL encrypts and the slab must hold ciphertext - which
+                // is why the slab path is refused above. Receive is OpenSSL either way.
+                KernelTx = ktls,
+            });
+        }
     };
 
     reactor.TcpHandle = async (r, conn) =&gt;
     {
         StaticAssets snapshot = r.GetService&lt;StaticAssets&gt;();
         RingPool&lt;AssetReader&gt; readers = r.GetService&lt;RingPool&lt;AssetReader&gt;&gt;();
+        TlsSession? tls = null;
+
+        // Request bytes waiting to be framed. Both transports go through this, so the two differ
+        // only in how bytes get IN - otherwise the plaintext arm would answer once per recv batch
+        // and the TLS arm once per record, and the two would not be comparable.
+        var carry = new Carry();
 
         try
         {
+            if (tlsOn)
+            {
+                tls = await r.GetService&lt;TlsService&gt;().AcceptAsync(conn);
+
+                // A request can ride in with the handshake&#x27;s final flight; serve it before parking
+                // in ReadAsync or the client waits on a response that never comes.
+                carry.Append(tls.DrainPlaintext());
+                await ServeAsync(conn, tls, carry, snapshot, readers, buffered);
+            }
+
             while (true)
             {
                 RecvSnapshot recv = await conn.ReadAsync();
 
-                // The lease pins the snapshot for the whole request, so a concurrent Reload()
-                // cannot free the fd out from under an in-flight send.
-                using (StaticAssets.Lease lease = snapshot.Acquire())
+                while (conn.TryGetItem(recv, out SpscRecvRing.Item item))
                 {
-                    // Resolve while the recv bytes are still valid - span-based, so a hit
-                    // allocates no string.
-                    bool found = false;
-                    AssetCache.Asset asset = default;
-
-                    while (conn.TryGetItem(recv, out SpscRecvRing.Item item))
+                    if (item.HasBuffer)
                     {
-                        if (item.HasBuffer)
-                        {
-                            if (!found &amp;&amp; TryReadTarget(item.AsSpan(), out ReadOnlySpan&lt;byte&gt; target))
-                            {
-                                found = lease.TryGet(target, out asset);
-                            }
-                            conn.ReturnBuffer(in item);
-                        }
-                    }
-
-                    // The fd is trusted for the snapshot's lifetime (reload on SIGHUP after a deploy),
-                    // so serving is just: read the bytes off the ring and frame HTTP around them.
-                    if (found)
-                    {
-                        if (buffered) await SendBufferedAsync(conn, readers, asset);
-                        else          await SendSlabAsync(conn, asset);
-                    }
-                    else
-                    {
-                        conn.Write(&quot;HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n&quot;u8);
-                        await conn.FlushAsync();
+                        Append(tls, in item, carry);
+                        conn.ReturnBuffer(in item);
                     }
                 }
 
-                if (recv.IsClosed) return;
+                await ServeAsync(conn, tls, carry, snapshot, readers, buffered);
+
+                if (recv.IsClosed || (tls?.Closed ?? false)) return;
                 conn.ResetRead();
             }
         }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($&quot;[file] connection failed: {e.Message}&quot;);
+        }
         finally
         {
+            tls?.Dispose();
             conn.DecRef();
         }
     };
 
-    threads[id] = new Thread(reactor.Run) { Name = $&quot;reactor-{id}&quot; };
-    threads[id].Start();
+    threads[i] = new Thread(reactor.Run) { Name = $&quot;reactor-{i}&quot; };
+    threads[i].Start();
 }
 
-// assets.Reload() swaps in a fresh snapshot atomically after a deploy.
-Console.WriteLine($&quot;serving {assets.Count} files from {assets.RootDir} on :{config.Tcp.Port}&quot;);
-foreach (Thread t in threads) t.Join();
+// Reload on SIGHUP (kill -HUP &lt;pid&gt;): a fresh snapshot is opened and swapped in atomically, and the
+// old descriptors close after a grace period - so in-flight requests finish on the bytes they
+// started with.
+using var reload = PosixSignalRegistration.Create(PosixSignal.SIGHUP, context =&gt;
+{
+    context.Cancel = true;   // handle it; don&#x27;t let the default action terminate us
+    assets.Reload();
+    Console.WriteLine($&quot;[file] reloaded - now serving {assets.Count} files&quot;);
+});
+
+Console.WriteLine($&quot;[file] {config.ReactorCount} reactors on :{config.Tcp.Port} - &quot;
+                + $&quot;{assets.Count} files under {assets.RootDir} &quot;
+                + $&quot;({(buffered ? &quot;buffer path&quot; : &quot;slab path&quot;)}, &quot;
+                + $&quot;tls={tlsMode}, nothing cached)&quot;);
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}
+
+// Bytes in. Cleartext appends the ring buffer as-is; TLS decrypts it first. Decrypt takes a raw
+// pointer because the buffer belongs to the ring, and the pointer work has to stay out of the
+// async handler, which cannot contain unsafe code.
+static unsafe void Append(TlsSession? tls, in SpscRecvRing.Item item, Carry carry)
+    =&gt; carry.Append(tls is null ? item.AsSpan() : tls.Decrypt(item.Ptr, item.Len));
+
+// One response per COMPLETE request in the carry, none for a partial one. Under kTLS the response
+// bytes go into the slab as plaintext and the kernel encrypts them on send, so both the slab and
+// buffer paths below are written exactly as they are for cleartext.
+static async Task ServeAsync(TcpConnection conn, TlsSession? tls, Carry carry, StaticAssets snapshot,
+    RingPool&lt;AssetReader&gt; readers, bool buffered)
+{
+    int end;
+    while ((end = carry.Span.IndexOf(&quot;\r\n\r\n&quot;u8)) &gt;= 0)
+    {
+        bool found = false;
+        AssetCache.Asset asset = default;
+
+        // The lease pins the snapshot for the request, so a concurrent Reload() cannot close the
+        // fd out from under an in-flight read.
+        using (StaticAssets.Lease lease = snapshot.Acquire())
+        {
+            if (TryReadTarget(carry.Span[..end], out ReadOnlySpan&lt;byte&gt; target))
+            {
+                found = lease.TryGet(target, out asset);
+            }
+
+            carry.Consume(end + 4);
+
+            if (found)
+            {
+                if (buffered)
+                {
+                    await SendBufferedAsync(conn, tls, readers, asset);
+                }
+                else
+                {
+                    await SendSlabAsync(conn, tls, asset);
+                }
+            }
+        }
+
+        if (!found)
+        {
+            Emit(conn, tls, &quot;HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n&quot;u8);
+            await conn.FlushAsync();
+        }
+    }
+}
+
 
 // Cleartext fast path: read the whole file STRAIGHT INTO the write slab (it grows to fit), right
-// after the header, so header + body leave in one flush - no reader buffer, no copy.
-static async Task SendSlabAsync(TcpConnection conn, AssetCache.Asset asset)
+// after the header, so header + body leave in one flush - no reader buffer, no copy. Ideal for the
+// typical multi-KB web asset; a very large file grows the slab by its full size, so stream those
+// with the buffer path instead.
+static async Task SendSlabAsync(TcpConnection conn, TlsSession? tls, AssetCache.Asset asset)
 {
-    Span&lt;byte&gt; header = stackalloc byte[128];
-    conn.Write(header[..WriteHeader(header, asset.Length)]);
+    Span&lt;byte&gt; header = stackalloc byte[256];
+    Emit(conn, tls, header[..WriteHeader(header, asset.Path, asset.Length)]);
 
-    int n = await conn.ReadFileAsync(asset.Fd, (int)asset.Length, fileOffset: 0);   // io_uring read into the slab
+    // io_uring positional read into the slab at the current tail; AdvanceWrite commits the bytes.
+    int n = await conn.ReadFileAsync(asset.Fd, (int)asset.Length, fileOffset: 0);
     conn.AdvanceWrite(n);
-    await conn.FlushAsync();   // header + body, one send
+    await conn.FlushAsync();
 }
 
-// Buffer path: read into a reader buffer, then move the bytes on. The copy into the slab stands in
-// for the transform TLS does here instead - tls.Write(conn, reader.Buffer[..n]) encrypts into the slab.
-static async Task SendBufferedAsync(TcpConnection conn, RingPool&lt;AssetReader&gt; readers, AssetCache.Asset asset)
+// Buffer path: read into a reader buffer, then move those bytes on. The copy into the slab stands in
+// for the transform a TLS connection does here instead - tls.Write(conn, reader.Buffer[..n]), which
+// encrypts into the slab. Files bigger than the buffer take several reads at advancing offsets,
+// one flush each.
+static async Task SendBufferedAsync(TcpConnection conn, TlsSession? tls, RingPool&lt;AssetReader&gt; readers, AssetCache.Asset asset)
 {
     AssetReader reader = await readers.RentAsync();
     try
     {
-        Span&lt;byte&gt; header = stackalloc byte[128];
-        conn.Write(header[..WriteHeader(header, asset.Length)]);
+        int first = await reader.ReadAsync(asset.Fd, offset: 0);   // io_uring positional read
+        if (first &lt; 0)
+        {
+            Emit(conn, tls, &quot;HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n&quot;u8);
+            await conn.FlushAsync();
+            return;
+        }
 
-        long offset = 0;
+        // Header + first chunk go out together in one flush.
+        Span&lt;byte&gt; header = stackalloc byte[256];
+        Emit(conn, tls, header[..WriteHeader(header, asset.Path, asset.Length)]);
+        WriteNative(conn, tls, reader.Buffer, first);
+        await conn.FlushAsync();
+
+        long offset = first;
         while (offset &lt; asset.Length)
         {
-            int read = await reader.ReadAsync(asset.Fd, offset);   // io_uring positional read
-            if (read &lt;= 0) break;
-            WriteNative(conn, reader.Buffer, read);
-            await conn.FlushAsync();   // one write + flush per read
+            int read = await reader.ReadAsync(asset.Fd, offset);
+            if (read &lt;= 0) break;   // EOF or mid-stream error; the response is already committed
+            WriteNative(conn, tls, reader.Buffer, read);
+            await conn.FlushAsync();
             offset += read;
         }
     }
@@ -5286,20 +5420,52 @@ static async Task SendBufferedAsync(TcpConnection conn, RingPool&lt;AssetReader&
     }
 }
 
-static unsafe void WriteNative(TcpConnection conn, nint data, int length)
-    =&gt; conn.Write(new ReadOnlySpan&lt;byte&gt;((void*)data, length));
+// Copy native memory (a ring-read buffer) into the connection&#x27;s write slab in one go.
+static unsafe void WriteNative(TcpConnection conn, TlsSession? tls, nint data, int length)
+    =&gt; Emit(conn, tls, new ReadOnlySpan&lt;byte&gt;((void*)data, length));
 
-// ioxide.file speaks no HTTP - you frame the response. Status + Content-Length here; a real server
-// adds Content-Type from the file extension.
-static int WriteHeader(Span&lt;byte&gt; dst, long length)
+// Every response byte goes through here. TlsSession.Write is correct under BOTH backends - it
+// writes plaintext to the slab when the kernel encrypts, and encrypts into the slab when OpenSSL
+// does - so no call site has to know which one is in play. A bare conn.Write would be right only
+// for cleartext and kTLS, and silently wrong for OpenSSL.
+static void Emit(TcpConnection conn, TlsSession? tls, ReadOnlySpan&lt;byte&gt; bytes)
 {
-    int h = Copy(dst, &quot;HTTP/1.1 200 OK\r\nContent-Length: &quot;u8);
-    Utf8Formatter.TryFormat(length, dst[h..], out int digits);
-    h += digits;
-    return h + Copy(dst[h..], &quot;\r\n\r\n&quot;u8);
+    if (tls is null) conn.Write(bytes);
+    else             tls.Write(conn, bytes);
 }
 
-static int Copy(Span&lt;byte&gt; dst, ReadOnlySpan&lt;byte&gt; src) { src.CopyTo(dst); return src.Length; }
+// Write the 200 status line + Content-Type + Content-Length for this file.
+static int WriteHeader(Span&lt;byte&gt; destination, string path, long bodyLength)
+{
+    int h = 0;
+    h += Copy(destination[h..], &quot;HTTP/1.1 200 OK\r\nContent-Type: &quot;u8);
+    h += Copy(destination[h..], MimeFor(path));
+    h += Copy(destination[h..], &quot;\r\nContent-Length: &quot;u8);
+    Utf8Formatter.TryFormat(bodyLength, destination[h..], out int digits);
+    h += digits;
+    h += Copy(destination[h..], &quot;\r\n\r\n&quot;u8);
+    return h;
+}
+
+static int Copy(Span&lt;byte&gt; destination, ReadOnlySpan&lt;byte&gt; source)
+{
+    source.CopyTo(destination);
+    return source.Length;
+}
+
+static ReadOnlySpan&lt;byte&gt; MimeFor(string path) =&gt; Path.GetExtension(path) switch
+{
+    &quot;.html&quot;  =&gt; &quot;text/html&quot;u8,
+    &quot;.css&quot;   =&gt; &quot;text/css&quot;u8,
+    &quot;.js&quot;    =&gt; &quot;application/javascript&quot;u8,
+    &quot;.json&quot;  =&gt; &quot;application/json&quot;u8,
+    &quot;.svg&quot;   =&gt; &quot;image/svg+xml&quot;u8,
+    &quot;.png&quot;   =&gt; &quot;image/png&quot;u8,
+    &quot;.webp&quot;  =&gt; &quot;image/webp&quot;u8,
+    &quot;.woff2&quot; =&gt; &quot;font/woff2&quot;u8,
+    &quot;.txt&quot;   =&gt; &quot;text/plain&quot;u8,
+    _        =&gt; &quot;application/octet-stream&quot;u8
+};
 
 static bool TryReadTarget(ReadOnlySpan&lt;byte&gt; request, out ReadOnlySpan&lt;byte&gt; target)
 {
@@ -5318,7 +5484,37 @@ static bool TryReadTarget(ReadOnlySpan&lt;byte&gt; request, out ReadOnlySpan&lt;
     if (query &gt;= 0) target = target[..query];
 
     return true;
+}
+
+// Plaintext waiting to be framed into requests. TLS hands back records, not requests: a request
+// split across two records decrypts as two pieces, so answering per decrypt answers twice.
+sealed class Carry
+{
+    private byte[] _buffer = new byte[8192];
+    private int _length;
+
+    public ReadOnlySpan&lt;byte&gt; Span =&gt; _buffer.AsSpan(0, _length);
+
+    public void Append(ReadOnlySpan&lt;byte&gt; more)
+    {
+        if (more.IsEmpty) return;
+
+        if (_length + more.Length &gt; _buffer.Length)
+        {
+            Array.Resize(ref _buffer, Math.Max(_buffer.Length * 2, _length + more.Length));
+        }
+
+        more.CopyTo(_buffer.AsSpan(_length));
+        _length += more.Length;
+    }
+
+    public void Consume(int count)
+    {
+        _buffer.AsSpan(count, _length - count).CopyTo(_buffer);
+        _length -= count;
+    }
 }</code></pre>
+    <p class="ex-foot">Every file under the root is opened <b>once</b> and the descriptors shared across reactors, read positionally off the ring - nothing locked, nothing cached in memory. The knob worth reading is <code>tlsMode</code>, because it decides whether the fast path is even legal, and the whole question is <em>what is the write slab supposed to hold when it is sent?</em> Cleartext: the slab IS the wire. <b>kTLS</b>: the slab holds plaintext and the kernel makes the records - so <code>ReadFileAsync</code> can still read the file straight into it and the bytes are never copied. <b>OpenSSL</b>: the slab must hold ciphertext, so the body has to pass through <code>TlsSession.Write</code>, which needs a source buffer - and that buffer IS the copy. The sample refuses that combination rather than serving the file in the clear. Measured on one saturated reactor at 4 KiB, skipping the copy is worth <b>1.22&times;</b> cleartext and <b>1.21&times;</b> under kTLS; at 64 KiB the kernel's per-byte crypto overtakes it and OpenSSL wins outright.</p>
   </div>
 </div>
 </section>

--- a/scripts/gen-docs-panes.py
+++ b/scripts/gen-docs-panes.py
@@ -139,6 +139,22 @@ PANES = {
         "One QUIC listener serving two protocols, chosen during the handshake: connections that "
         "negotiate <code>h3</code> get the HTTP/3 loop, anything else gets raw stream echo over the "
         "dual pipe. QUIC-only - <code>Tcp = null</code>, so the process opens no TCP listener at all."),
+    "files": (
+        "Clients/File", "Client &middot; static files", "ioxide + ioxide.file",
+        ["curl http://127.0.0.1:8080/index.html",
+         "PLAYGROUND_FILE_TLS=ktls    # then curl -k https://127.0.0.1:8443/index.html"],
+        "Every file under the root is opened <b>once</b> and the descriptors shared across reactors, "
+        "read positionally off the ring - nothing locked, nothing cached in memory. The knob worth "
+        "reading is <code>tlsMode</code>, because it decides whether the fast path is even legal, and "
+        "the whole question is <em>what is the write slab supposed to hold when it is sent?</em> "
+        "Cleartext: the slab IS the wire. <b>kTLS</b>: the slab holds plaintext and the kernel makes "
+        "the records - so <code>ReadFileAsync</code> can still read the file straight into it and the "
+        "bytes are never copied. <b>OpenSSL</b>: the slab must hold ciphertext, so the body has to "
+        "pass through <code>TlsSession.Write</code>, which needs a source buffer - and that buffer IS "
+        "the copy. The sample refuses that combination rather than serving the file in the clear. "
+        "Measured on one saturated reactor at 4 KiB, skipping the copy is worth <b>1.22&times;</b> "
+        "cleartext and <b>1.21&times;</b> under kTLS; at 64 KiB the kernel's per-byte crypto "
+        "overtakes it and OpenSSL wins outright."),
     "https": (
         "Clients/Https", "Client &middot; https origins", "ioxide + ioxide.httpclient",
         ["curl http://127.0.0.1:8080/get"],
@@ -172,7 +188,9 @@ def inline(code: str) -> str:
         "string? certOverride = null;\n"
         "string? keyOverride  = null;\n",
         'const string certPath = "cert.pem";   // any PEM pair\nconst string keyPath  = "key.pem";\n')
-    code = re.sub(r"\(string certPath, string keyPath\) = QuicCert\.Ensure\(certOverride, keyOverride\);\n", "", code)
+    # Any spelling of the assignment, not just the bare one - a sample that only needs a cert in
+    # some modes writes it as a conditional, and the pane still wants it gone.
+    code = re.sub(r"\(string certPath, string keyPath\) =[^;]*QuicCert\.Ensure[^;]*;\n", "", code, flags=re.S)
 
     # PLAYGROUND_INCREMENTAL is a bench escape hatch (per-connection recv rings); the pane shows the
     # sample's default - the shared ring - just like the other Env knobs collapse to their literals.

--- a/src/clients/ioxide.file/ioxide.file.csproj
+++ b/src/clients/ioxide.file/ioxide.file.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.file</RootNamespace>
 
     <PackageId>ioxide.file</PackageId>
-    <Version>0.4.167</Version>
+    <Version>0.4.168</Version>
     <Authors>MDA2AV</Authors>
     <Description>File serving for the ioxide io_uring runtime: immutable asset snapshots with baked responses, pooled positional ring reads, atomic reloads.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
+++ b/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.httpclient</RootNamespace>
 
     <PackageId>ioxide.httpclient</PackageId>
-    <Version>0.4.167</Version>
+    <Version>0.4.168</Version>
     <Authors>MDA2AV</Authors>
     <Description>The ring-native HTTP client for the ioxide io_uring runtime: HTTP/1.1, HTTP/2 and HTTP/3 behind one API, with the protocol chosen per origin via Alt-Svc. One package - the h1 parser, the nghttp2 and nghttp3 bridges, client-side TLS (SNI, ALPN and certificate verification) for https:// origins, and the negotiating client - sharing one set of message types. Every response resumes the awaiting handler inline on its own reactor thread.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.pg/ioxide.pg.csproj
+++ b/src/clients/ioxide.pg/ioxide.pg.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.pg</RootNamespace>
 
     <PackageId>ioxide.pg</PackageId>
-    <Version>0.4.167</Version>
+    <Version>0.4.168</Version>
     <Authors>MDA2AV</Authors>
     <Description>Postgres driver for the ioxide io_uring runtime: pooled ring-native connections per reactor, ring-native connect and handshake, inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.redis/ioxide.redis.csproj
+++ b/src/clients/ioxide.redis/ioxide.redis.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.redis</RootNamespace>
 
     <PackageId>ioxide.redis</PackageId>
-    <Version>0.4.167</Version>
+    <Version>0.4.168</Version>
     <Authors>MDA2AV</Authors>
     <Description>Redis client for the ioxide io_uring runtime: pooled ring-native connections per reactor, full RESP2 protocol, a generic command API plus typed helpers (strings, keys, hashes, lists, sets, sorted sets, pub/sub, transactions, scripting), and pipelining. Inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ioxide/ioxide.csproj
+++ b/src/ioxide/ioxide.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide</RootNamespace>
 
     <PackageId>ioxide</PackageId>
-    <Version>0.4.167</Version>
+    <Version>0.4.168</Version>
     <Authors>MDA2AV</Authors>
     <Description>A shared-nothing io_uring runtime for .NET: one ring per reactor thread, inline completions, zero native dependencies. The engine - reactor, connection, and the IRingHost client seam. Includes TLS termination: the OpenSSL handshake driven over the ring, then kernel TLS (kTLS) transmit offload, so handlers keep writing plaintext. TLS needs OpenSSL 3 and the Linux tls module; nothing else does, and neither is loaded unless you use it.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http2/ioxide.http2.csproj
+++ b/src/protocols/ioxide.http2/ioxide.http2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http2</RootNamespace>
 
     <PackageId>ioxide.http2</PackageId>
-    <Version>0.4.167</Version>
+    <Version>0.4.168</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure-C# HTTP/2 for the ioxide io_uring runtime: framing, HPACK (static and dynamic tables, Huffman) and flow control, with zero native code. A drop-in alternative to ioxide.nghttp2 for deployments that would rather not ship a native library - same connection shape, same request and response types.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http3/ioxide.http3.csproj
+++ b/src/protocols/ioxide.http3/ioxide.http3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http3</RootNamespace>
 
     <PackageId>ioxide.http3</PackageId>
-    <Version>0.4.167</Version>
+    <Version>0.4.168</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure C# HTTP/3 for the ioxide io_uring runtime: frame parsing, QPACK (static table + Huffman) and request dispatch with zero native dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, drop-in alternative to ioxide.nghttp3.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
+++ b/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp2</RootNamespace>
 
     <PackageId>ioxide.nghttp2</PackageId>
-    <Version>0.4.167</Version>
+    <Version>0.4.168</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/2 for the ioxide io_uring runtime: framing, HPACK and flow control from nghttp2, statically linked behind a small shim with no external dependencies beyond libc. Serves HTTP/2 over any TcpConnection - h2c with prior knowledge, or h2 over TLS via ALPN - and backs the HTTP/2 client in ioxide.httpclient from the same session code. nghttp2 is sans-I/O, so ioxide keeps the ring and the loop.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
+++ b/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp3</RootNamespace>
 
     <PackageId>ioxide.nghttp3</PackageId>
-    <Version>0.4.167</Version>
+    <Version>0.4.168</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/3 layer for the ioxide io_uring runtime: nghttp3 (H3 + QPACK) bundled as a single self-contained native library with no external dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, no ioxide.ngtcp2 dependency.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
+++ b/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.ngtcp2</RootNamespace>
 
     <PackageId>ioxide.ngtcp2</PackageId>
-    <Version>0.4.167</Version>
+    <Version>0.4.168</Version>
     <Authors>MDA2AV</Authors>
     <Description>QUIC engine for the ioxide io_uring runtime: ngtcp2 + picotls bundled as a single self-contained native library (only system dependency: libcrypto.so.3 / OpenSSL 3.x). Plugs into the reactor's QUIC transport via QuicConnection. Server side; engine bindings in progress.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
+++ b/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.Kestrel</RootNamespace>
 
     <PackageId>ioxide.Kestrel</PackageId>
-    <Version>0.4.167</Version>
+    <Version>0.4.168</Version>
     <Authors>MDA2AV</Authors>
     <Description>ASP.NET Core Kestrel transport backed by the ioxide io_uring runtime: one reactor (ring) per core, SO_REUSEPORT load-balanced, with Kestrel's HTTP request loop pinned to the reactor thread. Drop-in via UseIoxide().</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
`ReadFileAsync` (already on main) reads a file fd straight into the write slab. Whether that is legal follows from one question — **what is the slab supposed to hold when it is sent?**

| transport | slab holds | slab path | buffer path |
| --- | --- | --- | --- |
| `none` | the wire itself | legal | legal |
| `ktls` | plaintext, kernel encrypts on send | **legal** | legal |
| `openssl` | ciphertext | **impossible** | legal |

So the copy the slab path removes is exactly the copy TLS-over-OpenSSL forces you to pay, and kTLS TX is what buys the option back. This is the first concrete argument for kTLS on this codebase — the earlier backend matrix found it never faster than OpenSSL for ordinary responses.

`Playground/Clients/File` now takes `PLAYGROUND_FILE_TLS=none|ktls|openssl` and **refuses `openssl` + slab** rather than serving the file in the clear.

## Two fixes it needed on the way

- Every response byte goes through `TlsSession.Write`, correct under both backends. The buffer path was using `conn.Write` — right for cleartext and kTLS, silently wrong for OpenSSL.
- Both transports frame through one carry, so each answers **per request** rather than per recv batch. Without this the arms weren't measuring the same thing.

## Method

`bench/file-matrix.sh` measures five arms on **one saturated reactor**. Not a detail: an earlier 4-reactor version reported an 11% slab win where the single-reactor method measures 22%, because idle ring-polling lands in `utime` and dilutes CPU per request. The harness rejects a cell that wasn't pegged (<90% of a core), served the wrong byte count, saw non-2xx or socket errors, or had more than one listener on the port.

Cleartext at 4 KiB reproduces the originally recorded 2.69 / 3.33 µs/req, which is what says the method is right.

## Numbers — best of 2 passes, loopback

**4 KiB**

| arm | req/s | cpu/req |
| --- | ---: | ---: |
| none-slab | 369,326 | 2.74 µs |
| none-buffer | 302,247 | 3.34 µs |
| ktls-slab | 239,649 | 4.22 µs |
| ktls-buffer | 198,552 | 5.10 µs |
| openssl-buffer | 189,039 | 5.35 µs |

**ktls+slab is 1.27× rps / 0.79× cpu vs openssl+buffer**

**64 KiB**

| arm | req/s | cpu/req |
| --- | ---: | ---: |
| none-slab | 115,188 | 8.77 µs |
| none-buffer | 100,512 | 10.04 µs |
| ktls-slab | 39,049 | 25.69 µs |
| ktls-buffer | 37,315 | 26.85 µs |
| openssl-buffer | 44,973 | 22.48 µs |

**ktls+slab is 0.87× rps / 1.14× cpu vs openssl+buffer**

The win inverts with size. Kernel per-byte AES costs more than OpenSSL's userspace AES-NI on this box, and that penalty scales with bytes while the saved copy does not — so kTLS+slab wins small assets and loses large ones. Loopback only, so `sendfile` and NIC offload are out of reach either way.

## Not in this PR

- `TcpConnection.FileRead.cs:23-25` still says **"Cleartext only"**. Demonstrably too strict — kTLS TX is fine. Core file, left alone deliberately.
- No test covers files over TLS.
- The crossover between 4 and 64 KiB is unmeasured.

Bumps all packages to 0.4.168.