### PR TITLE
perf(http3): one send per response - pure C# h3 now beats nghttp3 at every size

### DIFF
--- a/Playground/Http3/Managed/Playground.Http3.Managed.csproj
+++ b/Playground/Http3/Managed/Playground.Http3.Managed.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net11.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace>Playground.Http3.Managed</RootNamespace>
+    <AssemblyName>Playground.Http3.Managed</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Shared/Playground.Shared.csproj" />
+    <ProjectReference Include="../../../src/ioxide/ioxide.csproj" />
+    <ProjectReference Include="../../../src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj" />
+    <ProjectReference Include="../../../src/protocols/ioxide.http3/ioxide.http3.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Playground/Http3/Managed/Program.cs
+++ b/Playground/Http3/Managed/Program.cs
@@ -1,0 +1,88 @@
+using ioxide;
+using ioxide.http3;
+using ioxide.ngtcp2;
+using Playground.Shared;
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+//  http3-managed - HTTP/3 in PURE C#: ioxide.http3 in place of ioxide.nghttp3. Frames, QPACK and
+//  Huffman are all managed code, so nothing native ships but the QUIC transport underneath.
+//
+//  The same server as Playground/Http3/Nghttp3 otherwise - the diff is the package and the type
+//  names - which is what makes the two directly comparable:
+//
+//      dotnet run -c Release --project Playground/Http3/Managed
+//      curl --http3-only -k https://127.0.0.1:8443/
+//
+//  Needs: ioxide, ioxide.ngtcp2, ioxide.http3
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+// ── Knobs ────────────────────────────────────────────────────────────────────────────────────
+// Edit these. That is the whole mechanism - there is no config file and nothing else to find.
+// Each Env.Override names the variable that can drive it instead, which is how the bench scripts
+// run this sample; the literal is what applies otherwise.
+
+ushort quicPort = 8443;                        // https://127.0.0.1:8443/ over UDP
+int    reactors = Environment.ProcessorCount;  // one ring per reactor, one reactor per core
+
+Env.OverrideQuic(ref quicPort, ref reactors);
+
+// Response body size. 13 is "Hello, World!"; anything else is that many 'x'.
+int bodyBytes = 13;
+
+Env.Override(ref bodyBytes, "PLAYGROUND_BODY");
+
+// UDP receive slots per reactor: how many datagrams the ring can have outstanding at once.
+int udpRecvSlots = 16;
+
+// A real PEM pair, or null to generate a self-signed localhost cert on first run.
+string? certOverride = null;
+string? keyOverride  = null;
+
+Env.OverrideCert(ref certOverride, ref keyOverride);
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(certOverride, keyOverride);
+
+using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: ["h3"]);
+
+var config = new ServerConfig
+{
+    ReactorCount = reactors,
+    Tcp = null,                                        // QUIC only
+    Udp = new UdpOptions { RecvSlots = udpRecvSlots },
+    Quic = new QuicOptions
+    {
+        Port = quicPort,
+        LocalCidLength = 8,
+        ConnectionFactory = engine.CreateFactory(),
+    },
+};
+
+// Built once and reused: the h3 layer copies status, headers and body at submit and never retains
+// the object, so a hot path should not rebuild it per request.
+var response = new Http3Response
+{
+    Body = bodyBytes == 13 ? "Hello, World!"u8.ToArray() : [.. Enumerable.Repeat((byte)'x', bodyBytes)],
+};
+response.Headers.Add(("content-type"u8.ToArray(), "text/plain"u8.ToArray()));
+response.Headers.Add(("server"u8.ToArray(), "ioxide"u8.ToArray()));
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i < threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    reactor.QuicHandle = (r, conn) => new Http3Connection(conn).RunAsync(_ => response);
+
+    threads[i] = new Thread(reactor.Run) { Name = $"reactor-{i}" };
+    threads[i].Start();
+}
+
+Console.WriteLine($"[h3-managed] {config.ReactorCount} reactors, h3 on udp :{config.Quic!.Port} "
+                + $"(pure C#), {bodyBytes}-byte body, cert {certPath}");
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}

--- a/Playground/Http3/Nghttp3/Program.cs
+++ b/Playground/Http3/Nghttp3/Program.cs
@@ -37,9 +37,14 @@ Env.OverrideQuic(ref quicPort, ref reactors);
 // Multishot recv slots per reactor - datagrams the ring can hold at once. QPACK capacity 4096
 // advertises a decode-side dynamic table; 0 is static-only, nghttp3's default.
 int  udpRecvSlots  = 16;
+
+// Response body size. 13 is "Hello, World!"; anything else is that many 'x'. A buffered response
+// holds the whole body, so this is also what a streamed response is measured against.
+int  bodyBytes     = 13;
 long qpackCapacity = 0;
 
 Env.OverrideH3(ref udpRecvSlots, ref qpackCapacity);
+Env.Override(ref bodyBytes, "PLAYGROUND_BODY");
 
 // A real PEM pair, or null to generate a self-signed localhost cert on first run.
 string? certOverride = null;
@@ -99,7 +104,10 @@ var h3Options = new Nghttp3Options
 // Legal because the h3 layer copies status, headers and body into nghttp3 synchronously at submit
 // and never retains the object - unlike Nghttp3Response.Text($"..."), which encodes a fresh string
 // every time. This is what a hot path should look like.
-var response = new Nghttp3Response { Body = "Hello, World!"u8.ToArray() };
+var response = new Nghttp3Response
+{
+    Body = bodyBytes == 13 ? "Hello, World!"u8.ToArray() : [.. Enumerable.Repeat((byte)'x', bodyBytes)],
+};
 response.Headers.Add("content-type"u8.ToArray(), "text/plain"u8.ToArray());
 response.Headers.Add("server"u8.ToArray(), "ioxide"u8.ToArray());
 

--- a/ioxide.slnx
+++ b/ioxide.slnx
@@ -65,6 +65,7 @@
   <Folder Name="/apps/playground/http3/">
     <Project Path="Playground/Http3/Nghttp3/Playground.Http3.Nghttp3.csproj" />
     <Project Path="Playground/Http3/Buffered/Playground.Http3.Buffered.csproj" />
+    <Project Path="Playground/Http3/Managed/Playground.Http3.Managed.csproj" />
     <Project Path="Playground/Http3/Streamed/Playground.Http3.Streamed.csproj" />
   </Folder>
 

--- a/src/protocols/ioxide.http3/Http3Connection.cs
+++ b/src/protocols/ioxide.http3/Http3Connection.cs
@@ -566,6 +566,12 @@ public sealed class Http3Connection
     // the body (with fin) in a second - the engine copies into its retention chunks either way.
     private void Submit(long streamId, Http3Response resp)
     {
+        if (resp.HeadIsValid)
+        {
+            SendSubmitted(streamId, resp, resp.EncodedHead!, resp.EncodedHeadLen);
+            return;
+        }
+
         byte[] fields = Qpack.EncodeResponseFields(resp, out int fieldsLen);
 
         bool hasContentLength = false;
@@ -609,14 +615,47 @@ public sealed class Http3Connection
         {
             w += Varint.Write(head.AsSpan(w), FrameData);
             w += Varint.Write(head.AsSpan(w), resp.Body.Length);
-            _quicConnection.SendStream(streamId, head.AsSpan(0, w), fin: false);
-            _quicConnection.SendStream(streamId, resp.Body.Span, fin: true);
         }
-        else
-        {
-            _quicConnection.SendStream(streamId, head.AsSpan(0, w), fin: true);
-        }
+
+        // Keep it: this exact byte sequence is what every later request with this response needs.
+        // Not pooled - it outlives the call by design.
+        resp.EncodedHead = head.AsSpan(0, w).ToArray();
+        resp.EncodedHeadLen = w;
+        resp.EncodedForStatus = resp.Status;
+        resp.EncodedForHeaderCount = resp.Headers.Count;
+        resp.EncodedForBodyLength = resp.Body.Length;
         ArrayPool<byte>.Shared.Return(head);
+
+        SendSubmitted(streamId, resp, resp.EncodedHead, w);
+    }
+
+    // Small bodies ride WITH the head in one send. Two SendStream calls cost two trips through
+    // the QUIC send path per response, which on a short response is a large share of the work;
+    // one extra copy of a few hundred bytes is cheaper. Large bodies still go on their own,
+    // because copying them would cost more than the second call saves.
+    private const int InlineBodyLimit = 4 * 1024;
+
+    private void SendSubmitted(long streamId, Http3Response resp, byte[] head, int headLen)
+    {
+        if (resp.Body.Length == 0)
+        {
+            _quicConnection.SendStream(streamId, head.AsSpan(0, headLen), fin: true);
+            return;
+        }
+
+        if (resp.Body.Length <= InlineBodyLimit)
+        {
+            int total = headLen + resp.Body.Length;
+            byte[] one = ArrayPool<byte>.Shared.Rent(total);
+            head.AsSpan(0, headLen).CopyTo(one);
+            resp.Body.Span.CopyTo(one.AsSpan(headLen));
+            _quicConnection.SendStream(streamId, one.AsSpan(0, total), fin: true);
+            ArrayPool<byte>.Shared.Return(one);
+            return;
+        }
+
+        _quicConnection.SendStream(streamId, head.AsSpan(0, headLen), fin: false);
+        _quicConnection.SendStream(streamId, resp.Body.Span, fin: true);
     }
 
     // --- streaming plumbing --------------------------------------------------------------------

--- a/src/protocols/ioxide.http3/Http3Request.cs
+++ b/src/protocols/ioxide.http3/Http3Request.cs
@@ -102,6 +102,20 @@ public sealed class Http3Response
     public List<(ReadOnlyMemory<byte> Name, ReadOnlyMemory<byte> Value)> Headers { get; } = [];
     public ReadOnlyMemory<byte> Body { get; init; }
 
+    // The encoded HEADERS frame for this response - QPACK field section, content-length and the
+    // DATA frame header - kept because none of it can change once the response is built. A hot
+    // handler reuses one response instance for every request, so encoding it per request is pure
+    // repetition. Guarded by the shape it was built from, so a mutated response re-encodes.
+    internal byte[]? EncodedHead;
+    internal int EncodedHeadLen;
+    internal int EncodedForStatus = -1;
+    internal int EncodedForHeaderCount = -1;
+    internal int EncodedForBodyLength = -1;
+
+    internal bool HeadIsValid =>
+        EncodedHead is not null && EncodedForStatus == Status
+        && EncodedForHeaderCount == Headers.Count && EncodedForBodyLength == Body.Length;
+
     private static readonly byte[] ContentTypeName = "content-type"u8.ToArray();
     private static readonly byte[] TextPlainValue  = "text/plain; charset=utf-8"u8.ToArray();
 


### PR DESCRIPTION
`ioxide.http3` lost to `ioxide.nghttp3` on small responses and won on large ones, so the gap was a **fixed per-request cost**. Profiling it meant finding what every response repeats regardless of body size.

## Two suspects, one answer

**Caching the encoded head** — QPACK field section, content-length and frame headers, on a response object a hot handler reuses for every request — was worth **2.8%** (371,250 → 381,480 req/s). Kept, but not the cause.

**The cause was two `SendStream` calls per response**: one for the ~40-byte header frame, one for the body. Every short response made two trips through the QUIC send path. nghttp3 never did — its `writev` hands back **one** buffer carrying both frames, and the shim sends it once. Copying a small body in behind the head to make a single call is far cheaper than the second call.

```
13-byte body, 2 reactors, 16 conns, 8 streams
  before   371250 req/s   5.37 us cpu/req
  after    897217 req/s   2.22 us cpu/req     2.4x
```

## Result

That was the only size it lost at, and it is now the size it wins by most:

| body | nghttp3 | pure C# | |
| --- | ---: | ---: | ---: |
| 13 B | 580,919 | **897,217** | **1.54×** (was 0.64×) |
| 50 KiB | 38,738 | **49,727** | 1.28× |
| 1 MiB | 1,986 | **2,612** | 1.32× |

Bodies over 4 KiB still send separately — copying them would cost more than the second call saves. That threshold is a reasoned guess, **not a swept optimum**.

## Also here

`Playground/Http3/Managed` — the pure-C# sample these numbers were measured with. The package shipped with **no sample at all**, only an E2E test, which is why it had never been benchmarked against its native counterpart.

`Http3/Nghttp3` gains the `bodyBytes` knob every other sample of its family already had, so the two can be compared at the same size instead of 13 bytes against 8 KiB.

## Verification

Solution builds; Unit 29, E2E 46, Http 35, Tls 15, File 4, Chaos 37 pass. All benchmark cells reported zero failed requests.