### PR TITLE
fix(nghttp3): a streamed handler that awaits anything no longer hangs

### DIFF
--- a/src/clients/ioxide.file/ioxide.file.csproj
+++ b/src/clients/ioxide.file/ioxide.file.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.file</RootNamespace>
 
     <PackageId>ioxide.file</PackageId>
-    <Version>0.4.177</Version>
+    <Version>0.4.178</Version>
     <Authors>MDA2AV</Authors>
     <Description>File serving for the ioxide io_uring runtime: immutable asset snapshots with baked responses, pooled positional ring reads, atomic reloads.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
+++ b/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.httpclient</RootNamespace>
 
     <PackageId>ioxide.httpclient</PackageId>
-    <Version>0.4.177</Version>
+    <Version>0.4.178</Version>
     <Authors>MDA2AV</Authors>
     <Description>The ring-native HTTP client for the ioxide io_uring runtime: HTTP/1.1, HTTP/2 and HTTP/3 behind one API, with the protocol chosen per origin via Alt-Svc. One package - the h1 parser, a pure-C# HTTP/2 client on ioxide.http2's framing, the nghttp3 bridge, client-side TLS (SNI, ALPN and certificate verification) for https:// origins, and the negotiating client - sharing one set of message types. Every response resumes the awaiting handler inline on its own reactor thread.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.pg/ioxide.pg.csproj
+++ b/src/clients/ioxide.pg/ioxide.pg.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.pg</RootNamespace>
 
     <PackageId>ioxide.pg</PackageId>
-    <Version>0.4.177</Version>
+    <Version>0.4.178</Version>
     <Authors>MDA2AV</Authors>
     <Description>Postgres driver for the ioxide io_uring runtime: pooled ring-native connections per reactor, ring-native connect and handshake, inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.redis/ioxide.redis.csproj
+++ b/src/clients/ioxide.redis/ioxide.redis.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.redis</RootNamespace>
 
     <PackageId>ioxide.redis</PackageId>
-    <Version>0.4.177</Version>
+    <Version>0.4.178</Version>
     <Authors>MDA2AV</Authors>
     <Description>Redis client for the ioxide io_uring runtime: pooled ring-native connections per reactor, full RESP2 protocol, a generic command API plus typed helpers (strings, keys, hashes, lists, sets, sorted sets, pub/sub, transactions, scripting), and pipelining. Inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ioxide/ioxide.csproj
+++ b/src/ioxide/ioxide.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide</RootNamespace>
 
     <PackageId>ioxide</PackageId>
-    <Version>0.4.177</Version>
+    <Version>0.4.178</Version>
     <Authors>MDA2AV</Authors>
     <Description>A shared-nothing io_uring runtime for .NET: one ring per reactor thread, inline completions, zero native dependencies. The engine - reactor, connection, and the IRingHost client seam. Includes TLS termination: the OpenSSL handshake driven over the ring, then kernel TLS (kTLS) transmit offload, so handlers keep writing plaintext. TLS needs OpenSSL 3 and the Linux tls module; nothing else does, and neither is loaded unless you use it.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http2/ioxide.http2.csproj
+++ b/src/protocols/ioxide.http2/ioxide.http2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http2</RootNamespace>
 
     <PackageId>ioxide.http2</PackageId>
-    <Version>0.4.177</Version>
+    <Version>0.4.178</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure-C# HTTP/2 for the ioxide io_uring runtime: framing, HPACK (static and dynamic tables, Huffman) and flow control, with zero native code. Serves h2c with prior knowledge and h2 over TLS by ALPN, buffered or streamed in either direction, and the same framing drives ioxide.httpclient's HTTP/2 client.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http3/ioxide.http3.csproj
+++ b/src/protocols/ioxide.http3/ioxide.http3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http3</RootNamespace>
 
     <PackageId>ioxide.http3</PackageId>
-    <Version>0.4.177</Version>
+    <Version>0.4.178</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure C# HTTP/3 for the ioxide io_uring runtime: frame parsing, QPACK (static table + Huffman) and request dispatch with zero native dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, drop-in alternative to ioxide.nghttp3.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
+++ b/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp2</RootNamespace>
 
     <PackageId>ioxide.nghttp2</PackageId>
-    <Version>0.4.177</Version>
+    <Version>0.4.178</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/2 for the ioxide io_uring runtime: framing, HPACK and flow control from nghttp2, statically linked behind a small shim with no external dependencies beyond libc. Serves HTTP/2 over any TcpConnection - h2c with prior knowledge, or h2 over TLS via ALPN - and backs the HTTP/2 client in ioxide.httpclient from the same session code. nghttp2 is sans-I/O, so ioxide keeps the ring and the loop.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp3/Connection/Nghttp3Connection.Streamed.cs
+++ b/src/protocols/ioxide.nghttp3/Connection/Nghttp3Connection.Streamed.cs
@@ -126,7 +126,44 @@ public sealed partial class Nghttp3Connection
     /// back to ReadAsync between chunks would wait for a packet that only our own output will
     /// provoke, so the response would stall after its first chunk.
     /// </summary>
+    // True while DrainStreamed is on the stack. A writer that flushes from inside it may park and
+    // be resumed by the loop; one that flushes from anywhere else has to drive the drain itself,
+    // because no loop is running to do it.
+    private bool _inStreamedDrain;
+
     private void DrainStreamed()
+    {
+        if (_inStreamedDrain)
+        {
+            return;   // already draining; the loop below picks up whatever was just staged
+        }
+
+        _inStreamedDrain = true;
+        try
+        {
+            DrainStreamedCore();
+        }
+        finally
+        {
+            _inStreamedDrain = false;
+        }
+    }
+
+    /// <summary>
+    /// Drive egress for a writer that resumed OUTSIDE the read pass - after a file read, a database
+    /// call, an upstream response. Inside the pass this does nothing, because the drain loop is
+    /// already running and will pump what was just staged; that path stays exactly as it was, which
+    /// is what keeps a one-chunk response from paying a reactor round trip it does not need.
+    /// </summary>
+    internal void PumpIfOutsidePass()
+    {
+        if (!_inStreamedDrain && !_protocolFailed)
+        {
+            DrainStreamed();
+        }
+    }
+
+    private void DrainStreamedCore()
     {
         while (!_protocolFailed)
         {
@@ -279,6 +316,16 @@ public sealed partial class Nghttp3Connection
     {
         if (IsFailed)
         {
+            return Task.CompletedTask;
+        }
+
+        // Outside the drain loop there is nobody to release a pass waiter: the loop only runs while
+        // the peer is sending, and a peer waiting for our response sends nothing. Parking here is
+        // what made a handler that awaits anything - a file read, a query, an upstream - stall on
+        // its first chunk and hang on its second. Drive the drain instead and carry on.
+        if (!_inStreamedDrain)
+        {
+            DrainStreamed();
             return Task.CompletedTask;
         }
 

--- a/src/protocols/ioxide.nghttp3/Http/Nghttp3ResponseWriter.cs
+++ b/src/protocols/ioxide.nghttp3/Http/Nghttp3ResponseWriter.cs
@@ -150,6 +150,7 @@ public sealed class Nghttp3ResponseWriter : IBufferWriter<byte>
         PromoteStagedChunk();
 
         _connection.ResumeStreamedResponse(_streamId);
+        _connection.PumpIfOutsidePass();
     }
 
     /// <summary>
@@ -182,6 +183,7 @@ public sealed class Nghttp3ResponseWriter : IBufferWriter<byte>
         // nothing to keep the handler around for.
         _completed = true;
         _connection.ResumeStreamedResponse(_streamId);
+        _connection.PumpIfOutsidePass();
     }
 
     /// <summary>

--- a/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
+++ b/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp3</RootNamespace>
 
     <PackageId>ioxide.nghttp3</PackageId>
-    <Version>0.4.177</Version>
+    <Version>0.4.178</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/3 layer for the ioxide io_uring runtime: nghttp3 (H3 + QPACK) bundled as a single self-contained native library with no external dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, no ioxide.ngtcp2 dependency.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
+++ b/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.ngtcp2</RootNamespace>
 
     <PackageId>ioxide.ngtcp2</PackageId>
-    <Version>0.4.177</Version>
+    <Version>0.4.178</Version>
     <Authors>MDA2AV</Authors>
     <Description>QUIC engine for the ioxide io_uring runtime: ngtcp2 + picotls bundled as a single self-contained native library (only system dependency: libcrypto.so.3 / OpenSSL 3.x). Plugs into the reactor's QUIC transport via QuicConnection. Server side; engine bindings in progress.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
+++ b/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.Kestrel</RootNamespace>
 
     <PackageId>ioxide.Kestrel</PackageId>
-    <Version>0.4.177</Version>
+    <Version>0.4.178</Version>
     <Authors>MDA2AV</Authors>
     <Description>ASP.NET Core Kestrel transport backed by the ioxide io_uring runtime: one reactor (ring) per core, SO_REUSEPORT load-balanced, with Kestrel's HTTP request loop pinned to the reactor thread. Drop-in via UseIoxide().</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/Ioxide.Tests.E2E/Protocols/H3Tests.cs
+++ b/tests/Ioxide.Tests.E2E/Protocols/H3Tests.cs
@@ -79,6 +79,48 @@ internal static class H3Tests
             Assert.Equal("got 600000", text);
         });
 
+        runner.Test("h3: a streamed response whose handler awaits between chunks still arrives", () =>
+        {
+            // Every other streamed test writes its chunks in a tight loop, so the handler never
+            // leaves the pass that dispatched it and DrainStreamed resumes it inline. A REAL
+            // handler awaits something first - a file read, a query, an upstream - and comes back
+            // outside that pass. There the flush used to park on a pass waiter that only inbound
+            // packets release, while the peer sat waiting for the response that would have
+            // provoked them: first chunk stalled, second hung outright.
+            (string certPath, string keyPath) = TestCert.Ensure();
+            using var engine = new QuicEngine(certPath, keyPath, cidLength: 8);
+
+            (_, int udpPort) = TestServer.StartDatagram(
+                onDatagram: null,
+                quicFactory: engine.CreateFactory(),
+                quicHandle: static (_, conn) => new Nghttp3Connection(conn).RunStreamedResponseAsync(
+                    static async (_, writer) =>
+                    {
+                        writer.WriteHeaders(new Nghttp3Response { Status = 200 });
+
+                        for (int i = 0; i < 4; i++)
+                        {
+                            // The point of the test. Task.Yield is the cheapest way to leave the
+                            // dispatch pass; a file read or a database call lands in the same place.
+                            await Task.Yield();
+
+                            "chunk"u8.CopyTo(writer.GetSpan(5));
+                            writer.Advance(5);
+                            await writer.FlushAsync();
+                        }
+
+                        await writer.CompleteAsync();
+                    }));
+
+            using var client = new H3TestClient("127.0.0.1", udpPort);
+            client.Connect();
+            Assert.True(client.CompleteHandshake(timeoutMs: 5000), "handshake did not complete");
+
+            (int status, string body) = client.Get("/streamed", timeoutMs: 10_000);
+            Assert.Equal(200, status);
+            Assert.Equal("chunkchunkchunkchunk", body);
+        });
+
         runner.Test("h3: buffered-async handler (whole body in req.Body, handler may await)", () =>
         {
             (string certPath, string keyPath) = TestCert.Ensure();


### PR DESCRIPTION
A streamed nghttp3 response whose handler `await`s anything - a file read, a query, an upstream - never reached the client. First chunk stalled, second hung.

## What was wrong

`Nghttp3ResponseWriter.FlushAsync` parks on a **pass waiter**, and pass waiters are released only by `DrainStreamed` - a loop that runs while the peer is sending. A peer waiting for our response sends nothing, so the handler waited for a pass that its own output was supposed to provoke.

```
handler awaits a file read   ->  leaves the dispatch pass
DrainStreamed sees nothing parked, returns, waits on the peer
file read completes          ->  handler writes, flushes
FlushAsync parks on a pass waiter
                             ->  nothing is left running to release it
```

Two symptoms, depending on chunk count: the first chunk **stalls** (promoted, resumed, and nothing pumps it), and the second **hangs outright** in the `while (_inFlightLength > 0)` loop waiting for the first to be taken.

## Why it survived this long

Every existing exercise of that writer returns a **fixed, in-memory response with no `await` between chunks** - the streamed tests, the Playground samples, the benchmarks, HttpArena. A handler that never leaves the pass gets resumed inline by `DrainStreamed`, exactly as designed. Nothing had tried the combination that every production handler has.

## The fix

`DrainStreamed` records that it is on the stack. A flush that finds no drain running drives one itself instead of parking.

**Inside the pass nothing changes.** The loop still resumes writers inline, and a one-chunk response still pays no reactor round trip - that was the point of the original design and the comment in `CompleteAsync` explaining it.

## The test

The regression test `await`s between chunks, which no existing test does. Disabling only the outside-pass escape:

```
FAIL  h3: a streamed response whose handler awaits between chunks still arrives:
      expected [chunkchunkchunkchunk], got []
```

An empty body - the same thing a static file server got when it read the file off io_uring mid-response, which is how this was found.

## Scope

`ioxide.nghttp3` only. The other three streamed writers were checked and are fine, because of what each waits on:

| module | flush waits on | outside-the-pass handler |
|---|---|---|
| `ioxide.nghttp3` | the read pass | **was broken** |
| `ioxide.http3` | QUIC send capacity | fine |
| `ioxide.http2` | drives its own drain | fine |
| `ioxide.nghttp2` | drives its own drain | fine |

Buffered responses were never affected, in any module.

## Release

**0.4.178** across all eleven packages - the fix is only useful to someone consuming it from NuGet.

Unit 36, Chaos 47, Http 38, E2E 47 - all 0 failed, 0 skipped.
