### PR TITLE
http3: encode response headers against the QPACK static table

### DIFF
--- a/src/clients/ioxide.file/ioxide.file.csproj
+++ b/src/clients/ioxide.file/ioxide.file.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.file</RootNamespace>
 
     <PackageId>ioxide.file</PackageId>
-    <Version>0.4.186</Version>
+    <Version>0.4.187</Version>
     <Authors>MDA2AV</Authors>
     <Description>File serving for the ioxide io_uring runtime: immutable asset snapshots with baked responses, pooled positional ring reads, atomic reloads.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
+++ b/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.httpclient</RootNamespace>
 
     <PackageId>ioxide.httpclient</PackageId>
-    <Version>0.4.186</Version>
+    <Version>0.4.187</Version>
     <Authors>MDA2AV</Authors>
     <Description>The ring-native HTTP/1.1 client for the ioxide io_uring runtime - the upstream leg between a proxy and an origin. Connections are opened on the reactor thread that will use them, so a request never crosses a thread on its way out or back, and every response resumes the awaiting handler inline on its own reactor. Includes client-side TLS (SNI, ALPN, certificate verification and client certificates for mutual TLS) for https:// origins. Depends on ioxide core alone: no protocol package, no native asset.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.pg/ioxide.pg.csproj
+++ b/src/clients/ioxide.pg/ioxide.pg.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.pg</RootNamespace>
 
     <PackageId>ioxide.pg</PackageId>
-    <Version>0.4.186</Version>
+    <Version>0.4.187</Version>
     <Authors>MDA2AV</Authors>
     <Description>Postgres driver for the ioxide io_uring runtime: pooled ring-native connections per reactor, ring-native connect and handshake, inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.redis/ioxide.redis.csproj
+++ b/src/clients/ioxide.redis/ioxide.redis.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.redis</RootNamespace>
 
     <PackageId>ioxide.redis</PackageId>
-    <Version>0.4.186</Version>
+    <Version>0.4.187</Version>
     <Authors>MDA2AV</Authors>
     <Description>Redis client for the ioxide io_uring runtime: pooled ring-native connections per reactor, full RESP2 protocol, a generic command API plus typed helpers (strings, keys, hashes, lists, sets, sorted sets, pub/sub, transactions, scripting), and pipelining. Inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ioxide/ioxide.csproj
+++ b/src/ioxide/ioxide.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide</RootNamespace>
 
     <PackageId>ioxide</PackageId>
-    <Version>0.4.186</Version>
+    <Version>0.4.187</Version>
     <Authors>MDA2AV</Authors>
     <Description>A shared-nothing io_uring runtime for .NET: one ring per reactor thread, inline completions, zero native dependencies. The engine - reactor, connection, and the IRingHost client seam. Includes TLS termination: the OpenSSL handshake driven over the ring, then kernel TLS (kTLS) transmit offload, so handlers keep writing plaintext. TLS needs OpenSSL 3 and the Linux tls module; nothing else does, and neither is loaded unless you use it.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http2/ioxide.http2.csproj
+++ b/src/protocols/ioxide.http2/ioxide.http2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http2</RootNamespace>
 
     <PackageId>ioxide.http2</PackageId>
-    <Version>0.4.186</Version>
+    <Version>0.4.187</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure-C# HTTP/2 for the ioxide io_uring runtime: framing, HPACK (static and dynamic tables, Huffman) and flow control, with zero native code. Serves h2c with prior knowledge and h2 over TLS by ALPN, buffered or streamed in either direction.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http3/Qpack.cs
+++ b/src/protocols/ioxide.http3/Qpack.cs
@@ -217,6 +217,176 @@ internal static class Qpack
     ];
 
     /// <summary>Encode a response's field section (prefix + :status + headers) into a pooled buffer.</summary>
+    /// <summary>
+    /// The static table indexed for encoding: distinct names, each with the entries sharing it.
+    /// </summary>
+    /// <remarks>
+    /// Grouped rather than flat so a lookup rejects most candidates on length alone. Built once from
+    /// the 99 fixed entries.
+    /// </remarks>
+    private static readonly (byte[] Name, int NameIndex, (byte[] Value, int Index)[] Values)[][] StaticByLength = BuildStaticNames();
+
+    /// <summary>Longest field name in the static table, so a longer name skips the lookup entirely.</summary>
+    private static readonly int LongestStaticName = StaticByLength.Length - 1;
+
+    private static (byte[] Name, int NameIndex, (byte[] Value, int Index)[] Values)[][] BuildStaticNames()
+    {
+        var byName = new List<(byte[] Name, int NameIndex, List<(byte[] Value, int Index)> Values)>();
+
+        for (int i = 0; i < QpackStatic.Table.Length; i++)
+        {
+            (byte[] name, byte[] value) = QpackStatic.Table[i];
+
+            int at = -1;
+            for (int j = 0; j < byName.Count; j++)
+            {
+                if (byName[j].Name.AsSpan().SequenceEqual(name))
+                {
+                    at = j;
+                    break;
+                }
+            }
+
+            if (at < 0)
+            {
+                byName.Add((name, i, [(value, i)]));
+            }
+            else
+            {
+                byName[at].Values.Add((value, i));
+            }
+        }
+
+        // Bucketed by name length. A per-header linear scan of every distinct name is far too
+        // expensive at this request rate - it cost about 6% of throughput - and length alone
+        // narrows 50-odd candidates down to one or two.
+        int longest = 0;
+
+        foreach ((byte[] name, int _, List<(byte[] Value, int Index)> _) in byName)
+        {
+            longest = Math.Max(longest, name.Length);
+        }
+
+        var buckets = new List<(byte[], int, (byte[], int)[])>[longest + 1];
+
+        foreach ((byte[] name, int nameIndex, List<(byte[] Value, int Index)> values) in byName)
+        {
+            buckets[name.Length] ??= [];
+            buckets[name.Length].Add((name, nameIndex, values.ToArray()));
+        }
+
+        var result = new (byte[], int, (byte[], int)[])[longest + 1][];
+
+        for (int i = 0; i <= longest; i++)
+        {
+            result[i] = buckets[i]?.ToArray() ?? [];
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Finds a header in the static table: an exact name and value match, or failing that a name.
+    /// </summary>
+    /// <remarks>
+    /// Names match case-insensitively, so a caller holding HTTP's conventional capitalisation still
+    /// resolves - and then never writes the name at all. Values match exactly, because a field value
+    /// is case-sensitive.
+    /// </remarks>
+    private static bool TryFindStatic(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value, out int exact, out int nameIndex)
+    {
+        exact = -1;
+        nameIndex = -1;
+
+        if (name.Length > LongestStaticName)
+        {
+            return false;
+        }
+
+        foreach ((byte[] candidate, int candidateIndex, (byte[] Value, int Index)[] values) in StaticByLength[name.Length])
+        {
+            if (!EqualsIgnoreCase(candidate, name))
+            {
+                continue;
+            }
+
+            nameIndex = candidateIndex;
+
+            foreach ((byte[] entryValue, int entryIndex) in values)
+            {
+                if (entryValue.AsSpan().SequenceEqual(value))
+                {
+                    exact = entryIndex;
+                    break;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool EqualsIgnoreCase(ReadOnlySpan<byte> lowercase, ReadOnlySpan<byte> other)
+    {
+        for (int i = 0; i < lowercase.Length; i++)
+        {
+            byte c = other[i];
+
+            if (c is >= (byte)'A' and <= (byte)'Z')
+            {
+                c |= 0x20;
+            }
+
+            if (c != lowercase[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Writes one header, preferring the static table over spelling the name out.
+    /// </summary>
+    /// <remarks>
+    /// Three tiers, cheapest first: name and value both in the table cost a single byte; a known
+    /// name costs an index plus the literal value; anything else falls back to the full literal.
+    /// Unlike the dynamic table this needs nothing from the peer, so it applies to every client.
+    /// </remarks>
+    private static int WriteHeader(Span<byte> buf, ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+    {
+        if (TryFindStatic(name, value, out int exact, out int nameIndex))
+        {
+            if (exact >= 0)
+            {
+                // Indexed Field Line: 1 T=1 index(6+).
+                return WriteInt(buf, 0xC0, 6, exact);
+            }
+
+            // Literal With Name Reference: 01 N=0 T=1 nameindex(4+), then H=0 value(7+).
+            int written = WriteInt(buf, 0x50, 4, nameIndex);
+            written += WriteInt(buf[written..], 0x00, 7, value.Length);
+            value.CopyTo(buf[written..]);
+
+            return written + value.Length;
+        }
+
+        // Literal With Literal Name: 001 N=0 H=0 namelen(3+), lowercased name, H=0 value(7+).
+        int w = WriteInt(buf, 0x20, 3, name.Length);
+
+        foreach (byte b in name)
+        {
+            buf[w++] = b is >= (byte)'A' and <= (byte)'Z' ? (byte)(b | 0x20) : b;
+        }
+
+        w += WriteInt(buf[w..], 0x00, 7, value.Length);
+        value.CopyTo(buf[w..]);
+
+        return w + value.Length;
+    }
+
     public static byte[] EncodeResponseFields(Http3Response response, out int written)
     {
         int cap = 2 + 8;
@@ -258,16 +428,7 @@ internal static class Qpack
 
         foreach ((ReadOnlyMemory<byte> nameM, ReadOnlyMemory<byte> valueM) in response.Headers)
         {
-            // Literal With Literal Name: 001 N=0 H=0 namelen(3+), lowercased name, H=0 value(7+).
-            ReadOnlySpan<byte> name = nameM.Span;
-            w += WriteInt(buf.AsSpan(w), 0x20, 3, name.Length);
-            foreach (byte b in name)
-            {
-                buf[w++] = b is >= (byte)'A' and <= (byte)'Z' ? (byte)(b | 0x20) : b;
-            }
-            w += WriteInt(buf.AsSpan(w), 0x00, 7, valueM.Length);
-            valueM.Span.CopyTo(buf.AsSpan(w));
-            w += valueM.Length;
+            w += WriteHeader(buf.AsSpan(w), nameM.Span, valueM.Span);
         }
 
         written = w;

--- a/src/protocols/ioxide.http3/ioxide.http3.csproj
+++ b/src/protocols/ioxide.http3/ioxide.http3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http3</RootNamespace>
 
     <PackageId>ioxide.http3</PackageId>
-    <Version>0.4.186</Version>
+    <Version>0.4.187</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure C# HTTP/3 for the ioxide io_uring runtime: frame parsing, QPACK (static table + Huffman) and request dispatch with zero native dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, drop-in alternative to ioxide.nghttp3.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http3/ioxide.http3.csproj
+++ b/src/protocols/ioxide.http3/ioxide.http3.csproj
@@ -24,4 +24,11 @@
     <ProjectReference Include="../../ioxide/ioxide.csproj" />
   </ItemGroup>
 
+    <ItemGroup>
+        <!-- The QPACK encoder is driven directly by the unit tests: a wrong static-table index is
+             invisible from outside, since the response still decodes to the right thing on a peer
+             that happens to agree. -->
+        <InternalsVisibleTo Include="Ioxide.Tests.Unit" />
+    </ItemGroup>
+
 </Project>

--- a/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
+++ b/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp2</RootNamespace>
 
     <PackageId>ioxide.nghttp2</PackageId>
-    <Version>0.4.186</Version>
+    <Version>0.4.187</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/2 for the ioxide io_uring runtime: framing, HPACK and flow control from nghttp2, statically linked behind a small shim with no external dependencies beyond libc. Serves HTTP/2 over any TcpConnection - h2c with prior knowledge, or h2 over TLS via ALPN. nghttp2 is sans-I/O, so ioxide keeps the ring and the loop.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
+++ b/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp3</RootNamespace>
 
     <PackageId>ioxide.nghttp3</PackageId>
-    <Version>0.4.186</Version>
+    <Version>0.4.187</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/3 layer for the ioxide io_uring runtime: nghttp3 (H3 + QPACK) bundled as a single self-contained native library with no external dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, no ioxide.ngtcp2 dependency.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
+++ b/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.ngtcp2</RootNamespace>
 
     <PackageId>ioxide.ngtcp2</PackageId>
-    <Version>0.4.186</Version>
+    <Version>0.4.187</Version>
     <Authors>MDA2AV</Authors>
     <Description>QUIC engine for the ioxide io_uring runtime: ngtcp2 + picotls bundled as a single self-contained native library (only system dependency: libcrypto.so.3 / OpenSSL 3.x). Plugs into the reactor's QUIC transport via QuicConnection. Server side; engine bindings in progress.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
+++ b/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.Kestrel</RootNamespace>
 
     <PackageId>ioxide.Kestrel</PackageId>
-    <Version>0.4.186</Version>
+    <Version>0.4.187</Version>
     <Authors>MDA2AV</Authors>
     <Description>ASP.NET Core Kestrel transport backed by the ioxide io_uring runtime: one reactor (ring) per core, SO_REUSEPORT load-balanced, with Kestrel's HTTP request loop pinned to the reactor thread. Drop-in via UseIoxide().</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/Ioxide.Tests.Unit/Ioxide.Tests.Unit.csproj
+++ b/tests/Ioxide.Tests.Unit/Ioxide.Tests.Unit.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="../Ioxide.Tests.Harness/Ioxide.Tests.Harness.csproj" />
     <ProjectReference Include="../../src/clients/ioxide.httpclient/ioxide.httpclient.csproj" />
     <ProjectReference Include="../../src/protocols/ioxide.http2/ioxide.http2.csproj" />
+    <ProjectReference Include="../../src/protocols/ioxide.http3/ioxide.http3.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Ioxide.Tests.Unit/Program.cs
+++ b/tests/Ioxide.Tests.Unit/Program.cs
@@ -16,6 +16,7 @@ internal static class Program
         ResponseCapTests.Register(runner);
         Http2OutputQueueTests.Register(runner);
         Http2StreamedRequestTests.Register(runner);
+        QpackStaticEncodeTests.Register(runner);
 
         return runner.Summary();
     }

--- a/tests/Ioxide.Tests.Unit/QpackStaticEncodeTests.cs
+++ b/tests/Ioxide.Tests.Unit/QpackStaticEncodeTests.cs
@@ -1,0 +1,169 @@
+using System.Text;
+
+using ioxide.http3;
+
+namespace Ioxide.Tests;
+
+/// <summary>
+/// Response headers encoded against the QPACK static table. The encoder previously used the table
+/// for :status alone and spelled every other field name out, so a response repeated names the peer
+/// already had by index.
+///
+/// Checked by decoding what comes out rather than by asserting on bytes: an index that is off by one
+/// still produces a well-formed field section, and only a round trip catches that it names the wrong
+/// header.
+/// </summary>
+internal static class QpackStaticEncodeTests
+{
+    public static void Register(Runner runner)
+    {
+        runner.Test("qpack: a name and value both in the table cost one byte", () =>
+        {
+            (string Name, string Value, int Index)[] cases =
+            [
+                ("content-type", "text/plain", 53),
+                ("content-type", "text/html; charset=utf-8", 52),
+                ("content-type", "application/json", 46),
+                ("accept-ranges", "bytes", 32),
+                ("cache-control", "no-cache", 39),
+                ("content-encoding", "gzip", 43),
+                ("vary", "origin", 60),
+            ];
+
+            foreach ((string name, string value, int index) in cases)
+            {
+                byte[] encoded = Encode(out int written, (name, value));
+
+                // Indexed Field Line: 1 T=1 index(6+), the whole header in one byte.
+                Assert.Equal((byte)(0xc0 | index), encoded[written - 1]);
+            }
+        });
+
+        runner.Test("qpack: a known name with an unknown value references the name only", () =>
+        {
+            (string Name, string Value)[] cases =
+            [
+                ("date", "Thu, 14 Aug 2026 13:00:00 GMT"),
+                ("location", "/elsewhere"),
+                ("etag", "\"abc123\""),
+                ("last-modified", "Thu, 14 Aug 2026 00:00:00 GMT"),
+                ("server", "ioxide"),
+                ("set-cookie", "a=b"),
+                ("content-type", "application/x-custom"),
+            ];
+
+            foreach ((string name, string value) in cases)
+            {
+                byte[] encoded = Encode(out int written, (name, value));
+                string wire = Encoding.ASCII.GetString(encoded, 0, written);
+
+                // The name must not reach the wire at all - that is the entire point.
+                Assert.True(!wire.Contains(name), $"name {name} should not appear on the wire");
+                Assert.True(wire.Contains(value), $"value {value} should appear on the wire");
+
+                AssertRoundTrips(encoded, written, name, value);
+            }
+        });
+
+        runner.Test("qpack: a capitalised name still resolves against the table", () =>
+        {
+            (string Name, string Value)[] cases =
+            [
+                ("Content-Type", "text/plain"),
+                ("DATE", "Thu, 14 Aug 2026 13:00:00 GMT"),
+                ("Cache-Control", "no-cache"),
+            ];
+
+            foreach ((string name, string value) in cases)
+            {
+                byte[] encoded = Encode(out int written, (name, value));
+                string wire = Encoding.ASCII.GetString(encoded, 0, written);
+
+                Assert.True(!wire.Contains(name.ToLowerInvariant()), $"{name} should resolve, not be written");
+
+                AssertRoundTrips(encoded, written, name.ToLowerInvariant(), value);
+            }
+        });
+
+        runner.Test("qpack: a name outside the table is written out, lowercased", () =>
+        {
+            // HTTP/3 treats a capitalised field name as malformed, so the literal fallback has to
+            // lowercase whatever it writes.
+            (string Name, string Value)[] cases =
+            [
+                ("x-custom-header", "value"),
+                ("X-Custom-Header", "value"),
+                ("X-Request-ID", "r1"),
+            ];
+
+            foreach ((string name, string value) in cases)
+            {
+                byte[] encoded = Encode(out int written, (name, value));
+                string wire = Encoding.ASCII.GetString(encoded, 0, written);
+
+                Assert.True(wire.Contains(name.ToLowerInvariant()), $"{name} should be written lowercased");
+
+                AssertRoundTrips(encoded, written, name.ToLowerInvariant(), value);
+            }
+        });
+
+        runner.Test("qpack: a value is matched case-sensitively", () =>
+        {
+            // Field values are case-sensitive, so TEXT/PLAIN is not entry 53.
+            byte[] encoded = Encode(out int written, ("content-type", "TEXT/PLAIN"));
+
+            Assert.True(Encoding.ASCII.GetString(encoded, 0, written).Contains("TEXT/PLAIN"),
+                "a value differing only in case must not resolve to a static entry");
+
+            AssertRoundTrips(encoded, written, "content-type", "TEXT/PLAIN");
+        });
+
+        runner.Test("qpack: a response ioxide actually sends shrinks", () =>
+        {
+            // What Http3Response.Text produces today. The value carries a space after the semicolon,
+            // so it misses entry 54 ("text/plain;charset=utf-8") and takes the name reference.
+            byte[] encoded = Encode(out int written, ("content-type", "text/plain; charset=utf-8"));
+
+            // Prefix 2 + indexed :status 1 + name ref 2 + value length 1 + 25 value bytes. The name
+            // reference costs two bytes rather than one because content-type is index 44, past what
+            // the 4-bit prefix holds.
+            Assert.Equal(31, written);
+
+            // Spelling the name out instead costs 2 + 12 for it, so 43 in total.
+            Assert.True(written < 43, "the name should no longer be on the wire");
+        });
+    }
+
+    private static byte[] Encode(out int written, params (string Name, string Value)[] headers)
+    {
+        var response = new Http3Response { Status = 200 };
+
+        foreach ((string name, string value) in headers)
+        {
+            response.Headers.Add((Encoding.ASCII.GetBytes(name), Encoding.ASCII.GetBytes(value)));
+        }
+
+        return Qpack.EncodeResponseFields(response, out written);
+    }
+
+    private static void AssertRoundTrips(byte[] encoded, int written, string name, string value)
+    {
+        var request = new Http3Request();
+
+        Assert.True(Qpack.TryDecodeFieldSection(encoded.AsSpan(0, written), request), "the section should decode");
+
+        // Decoded fields are ranges into an arena until this materialises them.
+        request.Freeze();
+
+        foreach ((ReadOnlyMemory<byte> Name, ReadOnlyMemory<byte> Value) field in request.Headers)
+        {
+            if (Encoding.ASCII.GetString(field.Name.Span) == name)
+            {
+                Assert.Equal(value, Encoding.ASCII.GetString(field.Value.Span));
+                return;
+            }
+        }
+
+        Assert.True(false, $"decoded section did not contain {name}");
+    }
+}


### PR DESCRIPTION
## What

`Qpack.EncodeResponseFields` consulted the static table for `:status` alone. Every other field went out as **Literal With Literal Name**, spelling out a name the peer already holds by index — `content-type` cost 12 bytes on the wire on every response, forever.

Encoding is now three tiers, cheapest first:

| case | encoding | cost |
|---|---|---|
| name **and** value in the table | Indexed Field Line (`0xC0`) | 1 byte |
| name in the table | Literal With Name Reference (`0x50`) | index + literal value |
| neither | Literal With Literal Name (`0x20`) | unchanged |

Names match case-insensitively (so a caller holding conventional capitalisation resolves, and the name is never written); values match exactly, since a field value is case-sensitive.

## The lookup has to be cheap, or it costs more than it saves

Worth calling out, because the first version was a regression. A plain linear scan over the ~50 distinct static names, per header, cost **6% of throughput** — more than the bytes it saved. Bucketing by name length narrows it to one or two comparisons, and the saving flips to a gain:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| literal names (before) | 3,087,560 | 3,123,721 | 3,171,774 |
| static table, linear scan | 2,771,482 | 2,941,583 | 2,993,596 |
| **static table, bucketed** | **3,291,610** | **3,316,463** | **3,367,788** |

`h3x -t 8 --connections 8 -m 100`, buffered playground. Median **3,123,721 → 3,316,463 req/s, +6%**.

## One thing left alone deliberately

`Http3Response.Text` sends `content-type: text/plain; charset=utf-8` — with a space. Static entry 54 is `text/plain;charset=utf-8` without one, so it misses the one-byte indexed encoding and takes the name reference instead. Dropping the space would make it an exact hit, but that changes what goes on the wire, so it is not in this PR.

## Tests

`Unit 31 / E2E 51 / Chaos 47`, all passing. Notably `http3: pure-C# parser GET vs nghttp3 client` still passes, which is the check that matters — our encoder's output decoded by an independent QPACK implementation.

New unit tests reach `Qpack` via `InternalsVisibleTo` rather than by widening the public surface. They verify by **decoding what the encoder produces**: an index that is off by one still yields a well-formed field section, so only a round trip catches it naming the wrong header. Covered: exact matches, known-name-unknown-value, capitalised names, unknown names lowercased on the way out, and case-sensitive value matching.

## Not addressed

`ioxide.http3` has no QPACK dynamic table at all — SETTINGS advertise capacity 0 and blocked streams 0, and the peer's SETTINGS values are walked for framing and discarded. That is unchanged here. Measured across clients, only Chrome advertises any capacity and nothing inserts inbound, so a dynamic table would be a browser-only win; this change benefits every client instead.