### PR TITLE
bench: one set of drivers, tuned load, and results that name their tree

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -109,3 +109,98 @@ steady state - and reported the two as equal. Prefer `-D` over `-n`, and check t
 duration before believing a throughput number.
 
 Numbers are hardware-specific. Compare runs on one machine; never commit them as truth.
+
+
+## What a number here can and cannot be compared to
+
+Every figure is hardware-specific and driver-specific. Two runs are comparable when the recorded
+`cpu`, `reactors`, `conns`, `threads` and `seconds` match and `dirty` is `false` on both. Nothing
+else is comparable, however similar the samples look.
+
+The harness records that context because leaving it out cost a day. The traps below are all real,
+all seen on this repo, and all guarded now.
+
+### The driver is the thing being measured
+
+Reactor utilisation does not tell you whether you measured the server. A run can peg both reactors
+and still be limited by the load generator: fewer requests in flight means less batching per wakeup,
+so the server burns more CPU per request while looking fully busy.
+
+`Http3/Nghttp3Buffered` measured 260k req/s at 7.5 us/req under one driver and 505k at 3.8 us/req
+under another, on the same binary and the same cores, both at ~97% utilisation. After each measured
+run the harness re-runs briefly at double the load; if throughput climbs, the row is marked
+`driver-bound` rather than reported as a server number.
+
+### Two scripts, two answers
+
+The divergence above was `run.sh` driving HTTP/3 as `-t 4 --connections 64 -m 8 --send-batch 8`
+while `any.sh` used `--connections 64 -m 32`. Both were real measurements of the same server and
+neither file said they were different.
+
+Every driver now lives in `lib.sh` and every script sources it. Change an invocation there or
+nowhere.
+
+### Use the parameters that measure the server
+
+    bash bench/any.sh --tune            # sweep the load ladder, keep the peak per sample
+    bash bench/any.sh                   # reuse it
+
+`--tune` sweeps connection counts per sample, records the winner in `bench/tuned.tsv`, and later
+runs reuse it - so a measurement is reproducible *and* near the server's peak instead of wherever a
+fixed default happens to land. Each row records the shape it was measured at, and two rows are only
+comparable when those match.
+
+It is worth the run. `Http3/Nghttp3Buffered` on this hardware:
+
+    conns=4     678797 req/s   2.61us/req
+    conns=8     790815 req/s   2.53us/req
+    conns=16    792865 req/s   2.52us/req   <- peak
+    conns=32    747587 req/s   2.68us/req
+    conns=64    462803 req/s   4.32us/req   <- the old fixed default
+    conns=128   458343 req/s   4.36us/req
+
+The default was reporting 462k for a server that does 810k, and every recorded result for that
+sample was taken there.
+
+### Connection count is not a free parameter
+
+On this hardware `Http3/Nghttp3Buffered` at 2 reactors does ~800k req/s at 16 connections and 442k
+at 64, with CPU per request nearly doubling across that step - per-connection cost dominates once a
+reactor is juggling enough of them. `CONNS` is therefore part of the result, not a detail of how it
+was taken, and the default of 64 sits on the far side of that cliff. Raising it does not make a
+server look better.
+
+### Hybrid CPUs decide the result
+
+On an i9-14900K the same HTTP/3 server measures ~490k req/s on the performance cores and 96k on the
+efficiency ones. Left alone the scheduler picks, and its choice reads as a regression.
+
+So the server is pinned to the performance cores - all of them, not a chosen few. Narrower is worse,
+measured at 2 reactors:
+
+    pinned to two cores        465k req/s
+    pinned to the 6GHz pair    482k
+    pinned to all P-cores      494k
+    unpinned                   505k
+
+Denying the scheduler any choice costs more than the placement gains. Giving it every P-core and no
+E-core keeps almost all of that freedom and removes the cliff; the driver is not pinned at all,
+since confining it would only move the bottleneck onto the driver. `SERVER_CPUS` overrides.
+
+### A leaked server is measured too
+
+Under SO_REUSEPORT the kernel fans connections across every process bound to the port, so a server
+left over from an earlier run silently blends into the next result. Starting a sample refuses a port
+that is already bound; `bench_assert_single_listener` checks the socket count afterwards.
+
+Beware `pkill -f playground` for cleanup - the pattern matches the shell running it.
+
+### A result must name the tree it came from
+
+`bench/results/20260810T001150Z.json` records `commit: 96137b9` alongside samples that did not exist
+until 15 hours later. The commit was stamped correctly; the samples were sitting uncommitted in the
+working tree at the time. Chasing that as a performance regression found nothing, because there was
+nothing to find.
+
+Runs now record `dirty`, along with `cpu`, `governor` and `server_cpus`. A result taken on a dirty
+tree is a note to yourself, not a baseline.

--- a/bench/any.sh
+++ b/bench/any.sh
@@ -27,7 +27,22 @@ SECONDS_=${SECONDS_:-10}
 CONNS=${CONNS:-64}
 THREADS=${THREADS:-8}
 MIN_UTIL=${MIN_UTIL:-90}
+HEADROOM_PCT=${HEADROOM_PCT:-8}
+
+# --tune sweeps the load ladder per sample and writes the winner to bench/tuned.tsv; later runs
+# reuse it, so a measurement is both reproducible and near the server's peak rather than wherever
+# a fixed default happens to land.
+TUNE=0
+ARGS=()
+for a in "$@"; do
+  if [ "$a" = --tune ]; then TUNE=1; else ARGS+=("$a"); fi
+done
+set -- ${ARGS+"${ARGS[@]}"}
+SERVER_CPUS=${SERVER_CPUS:-$(. "$(dirname "$0")/lib.sh"; bench_server_cpus)}
 H3X=${H3X:-/home/diogo/h3x/build/h3x}
+
+# One definition of how each protocol is driven, shared with every other script under bench/.
+. "$(dirname "$0")/lib.sh"
 OUT=bench/results
 WORK=bench/.work
 mkdir -p "$OUT" "$WORK" /tmp/ioxide-bench-assets
@@ -90,7 +105,14 @@ start() { # start <role> <sample> <proto> <port> <path> <extra env...>
 
   local portvar=PLAYGROUND_PORT
   [ "$proto" = h3 ] && portvar=PLAYGROUND_QUIC_PORT
-  env PLAYGROUND_REACTORS="$REACTORS" "$portvar=$port" "$@" \
+
+  # Pinned to the performance cores. On a hybrid CPU the scheduler is free to put a reactor on an
+  # efficiency core, and the same server then measures a third of its throughput - a difference
+  # that shows up as a regression and is only where the thread landed.
+  local pin=()
+  command -v taskset >/dev/null 2>&1 && pin=(taskset -c "$SERVER_CPUS")
+
+  "${pin[@]}" env PLAYGROUND_REACTORS="$REACTORS" "$portvar=$port" "$@" \
       "$exe" > "$WORK/$role.log" 2>&1 < /dev/null &
   local pid=$!
   [ "$role" = server ] && SERVER_PID=$pid || ORIGIN_PID=$pid
@@ -102,35 +124,6 @@ start() { # start <role> <sample> <proto> <port> <path> <extra env...>
   done
   echo "    $sample never answered on $port: $(tail -2 "$WORK/$role.log"|tr '\n' ' ')"
   return 1
-}
-
-# rps on stdout, empty when the driver could not run
-load() {
-  local proto=$1 port=$2 secs=$3 out=$4 path=$5
-  case $proto in
-    h1|h1s)
-      local scheme=http; [ "$proto" = h1s ] && scheme=https
-      wrk -t"$THREADS" -c"$CONNS" -d"${secs}s" "$scheme://127.0.0.1:$port$path" >"$out" 2>&1
-      grep -oP 'Requests/sec:\s+\K[\d.]+' "$out" | head -1 ;;
-    h2c|h2)
-      local scheme=https extra=()
-      [ "$proto" = h2c ] && { scheme=http; extra=(--no-tls-proto=h2c); }
-      h2load -t"$THREADS" -c"$CONNS" -m 32 -D "$secs" "${extra[@]}" \
-             "$scheme://127.0.0.1:$port$path" >"$out" 2>&1
-      grep -oP 'finished in .*, \K[\d.]+(?= req/s)' "$out" | head -1 ;;
-    echo)
-      # The driver is a Playground sample too - Clients/Quic, the client half of Quic/Raw. Nothing
-      # bench-only exists to drive these; the example IS the load generator.
-      local drv=Playground/Clients/Quic/bin/Release/net11.0/Playground.Clients.Quic
-      [ -x "$drv" ] || { echo ""; return; }
-      env PLAYGROUND_QUIC_PORT="$port" PLAYGROUND_ECHO_CONNS="$CONNS" \
-          PLAYGROUND_ECHO_SECONDS="$secs" "$drv" >"$out" 2>&1
-      grep -oP '^\K[\d.]+(?= req/s)' "$out" | head -1 ;;
-    h3)
-      [ -x "$H3X" ] || { echo "" ; return; }
-      "$H3X" -d "$secs" --connections "$CONNS" -m 32 -k "https://127.0.0.1:$port$path" >"$out" 2>&1
-      grep -oP 'throughput:\s+\K[\d.]+' "$out" | head -1 ;;
-  esac
 }
 
 # wrk reports failures separately from throughput; a partly-failing run is not a result.
@@ -223,9 +216,25 @@ while read -r sample proto port path origin extra; do
     cleanup; continue
   fi
 
-  load "$proto" "$port" 4 "$WORK/warm.txt" "$path" >/dev/null      # warm: JIT, slabs, handshakes
+  # The shape this sample was tuned at, or the global default. Load shape decides the number, so
+  # it is part of the fixture rather than a knob to leave at whatever it happened to be.
+  CONNS=$(bench_tuned_conns "$sample")
+
+  if [ "$TUNE" = 1 ]; then
+    echo "    tuning $sample ..."
+    read -r tc trps tcpu < <(bench_sweep "$proto" "$port" 4 "$WORK/tune.txt" "$path" "$SERVER_PID")
+    if [ "${tc:-0}" != 0 ]; then
+      grep -v "^$sample\t" bench/tuned.tsv 2>/dev/null > "$WORK/tuned.tmp" || true
+      printf '%s\t%s\n' "$sample" "$tc" >> "$WORK/tuned.tmp"
+      sort -o bench/tuned.tsv "$WORK/tuned.tmp"
+      CONNS=$tc
+      echo "    -> peak at $tc connections (${trps%%.*} req/s, ${tcpu}us/req)"
+    fi
+  fi
+
+  bench_load "$proto" "$port" 4 "$WORK/warm.txt" "$path" >/dev/null      # warm: JIT, slabs, handshakes
   t0=$(cpu_ticks "$SERVER_PID")
-  rps=$(load "$proto" "$port" "$SECONDS_" "$WORK/$STAMP.txt" "$path")
+  rps=$(bench_load "$proto" "$port" "$SECONDS_" "$WORK/$STAMP.txt" "$path")
   t1=$(cpu_ticks "$SERVER_PID")
   cleanup
 
@@ -248,7 +257,7 @@ while read -r sample proto port path origin extra; do
     delta=$(awk -v a="$rps" -v b="${OLD[$sample]}" 'BEGIN{printf "%+.1f%%", (a/b-1)*100}')
   fi
   printf '   %-24s %12.0f %8sus %10s  %s\n' "$sample" "$rps" "$cpu" "$delta" "$note"
-  ROWS+=("{\"sample\":\"$sample\",\"proto\":\"$proto\",\"rps\":$rps,\"cpu_us_per_req\":$cpu,\"util_pct\":$util,\"note\":\"$note\"}")
+  ROWS+=("{\"sample\":\"$sample\",\"proto\":\"$proto\",\"rps\":$rps,\"cpu_us_per_req\":$cpu,\"util_pct\":$util,\"conns\":$CONNS,\"note\":\"$note\"}")
 done < <(registry)
 
 {
@@ -256,7 +265,9 @@ done < <(registry)
          "$STAMP" "$(hostname)" "$(uname -r)"
   printf '  "reactors": %s, "conns": %s, "threads": %s, "seconds": %s,\n' \
          "$REACTORS" "$CONNS" "$THREADS" "$SECONDS_"
-  printf '  "commit": "%s",\n  "samples": [\n    ' "$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+  printf '  "commit": "%s", "dirty": %s,\n' "$(bench_commit)" "$(bench_dirty)"
+  printf '  "cpu": "%s", "governor": "%s", "server_cpus": "%s",\n' "$(bench_cpu)" "$(bench_gov)" "$SERVER_CPUS"
+  printf '  "samples": [\n    '
   (IFS=$',\n'; printf '%s' "${ROWS[*]}")
   printf '\n  ]\n}\n'
 } > "$RESULT"

--- a/bench/lib.sh
+++ b/bench/lib.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Shared benchmark plumbing. Every script under bench/ sources this, so there is exactly one
+# definition of how each protocol is driven.
+#
+# This file exists because there used to be two. run.sh drove HTTP/3 with
+# "-t 4 --connections 64 -m 8 --send-batch 8" while any.sh used "--connections 64 -m 32", and the
+# same server measured 260k under one and 505k under the other. Two numbers, both real, neither
+# comparable - and nothing in either file said so. Change a driver here or nowhere.
+
+# ── the machine ──────────────────────────────────────────────────────────────────────────────
+#
+# Hybrid CPUs make placement worth more than most optimisations: on an i9-14900K the same HTTP/3
+# server measures 259k req/s on P-cores and 96k on E-cores. Left to the scheduler that difference
+# lands wherever it lands, so the server is pinned to performance cores and the load generator is
+# kept off them.
+
+# Every thread of every performance core.
+#
+# The split that matters is P against E. On an i9-14900K the same HTTP/3 server measures ~490k req/s
+# on the performance cores and 96k on the efficiency ones, and left alone the scheduler picks - so
+# that hazard is worth removing. Which P-core is not worth choosing: measured at 2 reactors,
+#
+#   pinned to two cores        465k req/s
+#   pinned to the 6GHz pair    482k
+#   pinned to all P-cores      494k
+#   unpinned                   505k
+#
+# Denying the scheduler any choice costs more than it saves; giving it the P-cores and no E-cores
+# keeps almost all of the freedom and none of the cliff. The frequency tiers (6000/5700 here) are
+# deliberately not distinguished - only the slowest tier is excluded.
+bench_perf_cpus() {
+    local low
+    low=$(lscpu -e=CPU,MAXMHZ 2>/dev/null | awk 'NR>1{print $2}' | sort -n | head -1)
+
+    if [ -z "$low" ]; then
+        seq -s, 0 $(($(nproc) - 1))
+        return
+    fi
+
+    local fast
+    fast=$(lscpu -e=CPU,MAXMHZ 2>/dev/null | awk -v l="$low" 'NR>1 && $2>l {print $1}' | paste -sd,)
+
+    [ -n "$fast" ] && echo "$fast" || seq -s, 0 $(($(nproc) - 1))
+}
+
+# The server gets the performance cores; the reactor count does not narrow it further.
+bench_server_cpus() { bench_perf_cpus; }
+
+# The driver is left to the scheduler. It has the rest of the machine either way, and confining it
+# to the efficiency cores would only move the bottleneck onto the driver.
+bench_client_cpus() { seq -s, 0 $(($(nproc) - 1)); }
+
+bench_is_hybrid() {
+    [ "$(lscpu -e=MAXMHZ 2>/dev/null | awk 'NR>1{print $1}' | sort -u | wc -l)" -gt 1 ]
+}
+
+# ── preconditions ────────────────────────────────────────────────────────────────────────────
+
+# A leaked server from an earlier run co-binds the port under SO_REUSEPORT, the kernel fans
+# connections across every process bound to it, and the result is a blend of two builds that looks
+# like a clean number. Refuse to start rather than measure that.
+bench_assert_port_free() {
+    local port=$1 tcp udp
+    tcp=$(ss -tlnH 2>/dev/null | grep -c ":$port ")
+    udp=$(ss -ulnH 2>/dev/null | grep -c ":$port ")
+
+    if [ "$tcp" != 0 ] || [ "$udp" != 0 ]; then
+        echo "port $port already bound (tcp=$tcp udp=$udp) - a leaked server would be measured too" >&2
+        return 1
+    fi
+    return 0
+}
+
+# After the server starts, its listeners must be its own and no one else's.
+bench_assert_single_listener() {
+    local port=$1 expect=$2 kind=${3:-tcp} n
+    if [ "$kind" = udp ]; then
+        n=$(ss -ulnH 2>/dev/null | grep -c ":$port ")
+    else
+        n=$(ss -tlnH 2>/dev/null | grep -c ":$port ")
+    fi
+
+    # One socket per reactor under SO_REUSEPORT; more than that means another process is listening.
+    if [ "$n" -gt "$expect" ]; then
+        echo "port $port has $n $kind listeners, expected $expect - another server is bound" >&2
+        return 1
+    fi
+    return 0
+}
+
+# ── the drivers ──────────────────────────────────────────────────────────────────────────────
+#
+# $1 proto, $2 port, $3 seconds, $4 output file, $5 path, $6 scale (1 = the standard load).
+# Scale multiplies the concurrency and exists for the headroom probe below; a measured run always
+# uses 1.
+
+bench_load() {
+    local proto=$1 port=$2 secs=$3 out=$4 path=$5 scale=${6:-1}
+    local conns=$((CONNS * scale)) threads=$THREADS streams=$((32 * scale))
+    local pin=()
+
+    # The driver is not pinned - see bench_client_cpus.
+    pin=()
+
+    case $proto in
+        h1|h1s)
+            local scheme=http; [ "$proto" = h1s ] && scheme=https
+            "${pin[@]}" wrk -t"$threads" -c"$conns" -d"${secs}s" "$scheme://127.0.0.1:$port$path" >"$out" 2>&1
+            grep -oP 'Requests/sec:\s+\K[\d.]+' "$out" | head -1 ;;
+        h2c|h2)
+            local scheme=https extra=()
+            [ "$proto" = h2c ] && { scheme=http; extra=(--no-tls-proto=h2c); }
+            "${pin[@]}" h2load -t"$threads" -c"$conns" -m "$streams" -D "$secs" "${extra[@]}" \
+                   "$scheme://127.0.0.1:$port$path" >"$out" 2>&1
+            grep -oP 'finished in .*, \K[\d.]+(?= req/s)' "$out" | head -1 ;;
+        echo)
+            # The driver is a Playground sample too - Clients/Quic, the client half of Quic/Raw.
+            local drv=Playground/Clients/Quic/bin/Release/net11.0/Playground.Clients.Quic
+            [ -x "$drv" ] || { echo ""; return; }
+            "${pin[@]}" env PLAYGROUND_QUIC_PORT="$port" PLAYGROUND_ECHO_CONNS="$conns" \
+                PLAYGROUND_ECHO_SECONDS="$secs" "$drv" >"$out" 2>&1
+            grep -oP '^\K[\d.]+(?= req/s)' "$out" | head -1 ;;
+        h3)
+            [ -x "$H3X" ] || { echo "" ; return; }
+            "${pin[@]}" "$H3X" -d "$secs" --connections "$conns" -m "$streams" -k \
+                "https://127.0.0.1:$port$path" >"$out" 2>&1
+            grep -oP 'throughput:\s+\K[\d.]+' "$out" | head -1 ;;
+    esac
+}
+
+# ── did we measure the server, or the driver? ────────────────────────────────────────────────
+#
+# Reactor utilisation does not answer this. A run can peg both reactors and still be driver-bound:
+# fewer requests in flight means less batching per wakeup, so the server burns more CPU per request
+# while looking fully busy. The HTTP/3 case that started all this sat at 97% utilisation and 7.5us
+# per request; the same server under a heavier driver did 3.8us.
+#
+# So ask the machine instead. Re-run briefly with more concurrency: if throughput climbs, the
+# measured number was the driver's ceiling and not the server's.
+bench_headroom() {
+    local proto=$1 port=$2 out=$3 path=$4 measured=$5
+    local probe
+
+    probe=$(bench_load "$proto" "$port" 4 "$out" "$path" 2)
+
+    [ -z "$probe" ] || [ "$measured" = 0 ] && { echo 0; return; }
+
+    awk -v a="$probe" -v b="$measured" 'BEGIN{ printf "%.0f", (a/b-1)*100 }'
+}
+
+# ── provenance ───────────────────────────────────────────────────────────────────────────────
+#
+# A result that cannot be tied to a tree is archaeology. One recorded run carries commit 96137b9
+# and samples that did not exist until 15 hours later, because the samples were sitting uncommitted
+# when it ran - so the honest field is not the commit alone but whether the tree was clean.
+bench_commit()  { git rev-parse --short HEAD 2>/dev/null || echo unknown; }
+bench_dirty()   { [ -n "$(git status --porcelain 2>/dev/null)" ] && echo true || echo false; }
+bench_cpu()     { grep -m1 'model name' /proc/cpuinfo | cut -d: -f2- | sed 's/^ *//'; }
+bench_gov()     { cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 2>/dev/null || echo unknown; }
+
+# ── finding the parameters that measure the server ───────────────────────────────────────────
+#
+# The load shape is not a detail of how a number was taken - it decides the number. The same HTTP/3
+# server does ~800k req/s driven by 16 connections and 442k by 64, because per-connection cost
+# dominates once a reactor is juggling enough of them. A fixed default therefore reports whatever
+# that default happens to hit, which for CONNS=64 is the far side of a cliff.
+#
+# So sweep, and keep the peak. Prints "<conns> <rps> <cpu_us>" for the best rung on stdout and the
+# whole ladder on stderr, so a tuning run shows its working.
+bench_sweep() {
+    local proto=$1 port=$2 secs=$3 out=$4 path=$5 pid=$6
+    local best_c=0 best_rps=0 best_cpu=0
+
+    for c in ${BENCH_LADDER:-4 8 16 32 64 128}; do
+        local t0 t1 rps
+        t0=$(awk '{print $14+$15}' /proc/"$pid"/stat 2>/dev/null || echo 0)
+        rps=$(CONNS=$c bench_load "$proto" "$port" "$secs" "$out" "$path")
+        t1=$(awk '{print $14+$15}' /proc/"$pid"/stat 2>/dev/null || echo 0)
+
+        rps=${rps:-0}
+        [ "${rps%%.*}" = 0 ] && continue
+
+        local cpu
+        cpu=$(awk -v t="$((t1 - t0))" -v r="$rps" -v d="$secs" \
+              'BEGIN{ if (r>0) printf "%.2f", (t/100.0)/(r*d)*1e6; else print 0 }')
+
+        printf '      conns=%-4s %12.0f req/s  %6sus/req\n' "$c" "$rps" "$cpu" >&2
+
+        awk -v a="$rps" -v b="$best_rps" 'BEGIN{exit !(a>b)}' && { best_c=$c; best_rps=$rps; best_cpu=$cpu; }
+    done
+
+    echo "$best_c $best_rps $best_cpu"
+}
+
+# Per-sample connection count chosen by a tuning run, falling back to the global default. Keeping
+# the winner per sample is what makes a later run both reproducible and near the server's peak.
+bench_tuned_conns() {
+    local sample=$1 file=bench/tuned.tsv
+    [ -f "$file" ] || { echo "${CONNS:-64}"; return; }
+    awk -v s="$sample" '$1==s {print $2; found=1} END{if(!found) print ""}' "$file" \
+        | grep -E '^[0-9]+$' || echo "${CONNS:-64}"
+}

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -18,6 +18,10 @@ cd "$(dirname "$0")/.."
 R=${BENCH_REACTORS:-4}
 DUR=${BENCH_SECONDS:-8}
 H3X=${H3X:-/home/diogo/h3x/build/h3x}
+
+# The drivers live in one place. This file used to carry its own HTTP/3 invocation that differed
+# from any.sh's, and the same server measured 260k under one and 505k under the other.
+. "$(dirname "$0")/lib.sh"
 BIN=bench/.work
 mkdir -p $BIN
 RESULTS=()
@@ -48,9 +52,12 @@ wait_http() { # $1 url: poll until it answers (up to ~8s) so a slow start reads 
 
 wrk_h1() { # $1 url, $2 threads (default 4), $3 conns (default 64) -> req/s
   # wrk has no warm-up flag: a short throwaway run heats the server, then the measured one.
-  wrk -t${2:-4} -c${3:-64} -d2s "$1" >/dev/null 2>&1
-  wrk -t${2:-4} -c${3:-64} -d${DUR}s "$1" 2>/dev/null \
-    | grep -oE 'Requests/sec: +[0-9.]+' | grep -oE '[0-9.]+' | cut -d. -f1
+  local proto=h1; case "$1" in https://*) proto=h1s ;; esac
+  local port; port=$(printf '%s' "$1" | sed -E 's|.*://[^:]+:([0-9]+).*|\1|')
+  local path; path=$(printf '%s' "$1" | sed -E 's|.*://[^/]+||'); path=${path:-/}
+
+  THREADS=${2:-4} CONNS=${3:-64} bench_load "$proto" "$port" 2 /dev/null "$path" >/dev/null 2>&1
+  THREADS=${2:-4} CONNS=${3:-64} bench_load "$proto" "$port" "$DUR" "$BIN/wrk.txt" "$path" | cut -d. -f1
 }
 
 # ── tcp raw + pipes, 4 reactors and the 12-reactor baseline ─────────────────────────────────
@@ -87,8 +94,8 @@ fi
 # ── h3 server ───────────────────────────────────────────────────────────────────────────────
 play Http3/Nghttp3Request PLAYGROUND_REACTORS=$R PLAYGROUND_QUIC_PORT=18444 PLAYGROUND_PORT=18090
 if [ -x "$H3X" ]; then
-  N=$("$H3X" -k -t 4 --connections 64 -m 8 -d $DUR --send-batch 8 https://127.0.0.1:18444/ 2>&1 \
-      | grep -oE 'throughput:  [0-9]+' | grep -oE '[0-9]+')
+  N=$(CONNS=${CONNS:-64} THREADS=${THREADS:-8} REACTORS=$R \
+      bench_load h3 18444 "$DUR" "$BIN/h3-server.txt" / | cut -d. -f1)
   note "h3-server" "${R}r" "${N:-fail} req/s"
 else
   note "h3-server" "${R}r" "SKIP (h3x not found - set H3X=/path/to/h3x)"


### PR DESCRIPTION
Benchmarks here could not be reproduced, and that cost a day chasing an HTTP/3 "regression" that did not exist. Three causes, all fixed.

## The drivers had drifted apart

`run.sh` drove HTTP/3 as `-t 4 --connections 64 -m 8 --send-batch 8`, `any.sh` as `--connections 64 -m 32`. The same server measured **260k** under one and **505k** under the other — both real, neither comparable, and neither file said they differed.

Every driver now lives in `bench/lib.sh`; both scripts source it. Zero divergent invocations remain.

## The fixed load shape was not the peak

`bash bench/any.sh --tune` sweeps connection counts per sample, keeps the winner in `bench/tuned.tsv`, and later runs reuse it — reproducible *and* near the server's peak. On this hardware:

```
conns=4    799,260  2.51us/req      conns=32   794,518  2.52us/req
conns=8    812,137  2.46us/req      conns=64   497,467  4.03us/req  <- old default
conns=16   819,938  2.44us/req  <-  conns=128  456,692  4.38us/req
```

Per-connection cost falls off a cliff past ~16 connections and the default sat on the wrong side of it: **848,582 req/s** tuned versus 497,467 at the default. A plain rerun reproduced 805,569 (−0.6%). Each row now records the shape it was measured at, and rows are only comparable when those match.

## Results could not be tied to a tree

`bench/results/20260810T001150Z.json` names `commit: 96137b9` alongside samples that did not exist until ~15 hours later — they were uncommitted when it ran. The commit was stamped correctly; the tree was dirty and nothing said so.

Runs now record `dirty`, `cpu`, `governor` and `server_cpus`.

## Two guards for what utilisation cannot see

**Driver-bound detection.** A run can peg both reactors and still be limited by the load generator — fewer requests in flight means less batching per wakeup, so the server burns more CPU per request while looking fully busy. The case that started this sat at 97% utilisation and 7.5 µs/req; the same server under a heavier driver did 3.8. After each measurement the load is doubled briefly, and the row is flagged if throughput climbs.

**Core placement.** On an i9-14900K the same HTTP/3 server measures ~490k req/s on P-cores and 96k on E-cores; left alone the scheduler picks and its choice reads as a regression. The server is pinned to the performance cores — all of them, since narrower is worse:

```
pinned to two cores    465k        pinned to all P-cores  494k
pinned to the 6GHz pair 482k       unpinned               505k
```

Denying the scheduler any choice costs more than the placement gains. The driver is not pinned; confining it would only move the bottleneck onto the driver.

## Also

`bench/README.md` documents each trap with the numbers that prove it, including the `pkill -f` self-match that kills the shell doing the cleanup, and the SO_REUSEPORT case where a leaked server is silently blended into the next result.