### PR TITLE
tests: mine nginx, haproxy and h2o for the cases our own reviews missed

### DIFF
--- a/src/ioxide/Tls/Interop/OpenSsl.cs
+++ b/src/ioxide/Tls/Interop/OpenSsl.cs
@@ -77,6 +77,14 @@ internal static unsafe partial class OpenSsl
     /// </summary>
     [LibraryImport(Ssl)] public static partial long SSL_CTX_callback_ctrl(nint ctx, int cmd, nint fp);
 
+    /// <summary>
+    /// Install the callback OpenSSL asks for a private key's passphrase. Passing none is NOT "no
+    /// password": the default is PEM_def_callback, which READS THE TERMINAL - so a server started
+    /// from a tty with an encrypted key blocks on a prompt instead of failing, and a rotation
+    /// thread would block while still serving.
+    /// </summary>
+    [LibraryImport(Ssl)] public static partial void SSL_CTX_set_default_passwd_cb(nint ctx, nint cb);
+
     /// <summary>The name the client asked for, or null when it sent no SNI extension.</summary>
     [LibraryImport(Ssl)] public static partial nint SSL_get_servername(nint ssl, int type);
 

--- a/src/ioxide/Tls/TlsService.cs
+++ b/src/ioxide/Tls/TlsService.cs
@@ -591,6 +591,17 @@ public sealed class TlsService
     /// exactly one owner and one release path.</summary>
     private static void Configure(nint ctx, TlsOptions options, TlsCertificate certificate, string what, GCHandle alpnHandle)
     {
+        // Before any key is read. OpenSSL's default passphrase callback is PEM_def_callback, which
+        // reads the TERMINAL - so an encrypted key makes Start, or ReplaceCertificates on a
+        // rotation thread while the server is still answering, block on a prompt rather than fail.
+        // TlsOptions has no passphrase, so the only correct answer is that none is available, which
+        // turns a hang into the ordinary refusal every other unusable key already gets.
+        unsafe
+        {
+            delegate* unmanaged<nint, int, int, nint, int> refuse = &NoPassphrase;
+            OpenSsl.SSL_CTX_set_default_passwd_cb(ctx, (nint)refuse);
+        }
+
 
         // OpenSSL copies a context's options onto each SSL as it is created and never re-reads
         // them, so this holds for every connection whether or not it asked for a name. TLS 1.3 has
@@ -759,6 +770,14 @@ public sealed class TlsService
     /// Runs on the reactor thread. The lookup allocates nothing: the name is compared as UTF-8
     /// bytes already in native memory, against a table built when the service started.
     /// </remarks>
+    /// <summary>
+    /// "There is no passphrase." Zero written bytes makes OpenSSL fail the key load with an
+    /// ordinary error rather than prompting on the terminal, which is what it does when no
+    /// callback is installed at all.
+    /// </summary>
+    [UnmanagedCallersOnly]
+    private static int NoPassphrase(nint buf, int size, int rwflag, nint userdata) => 0;
+
     [UnmanagedCallersOnly]
     private static unsafe int ServerNameCallback(nint ssl, nint alert, nint arg)
     {

--- a/tests/Ioxide.Tests.Harness/TestServer.cs
+++ b/tests/Ioxide.Tests.Harness/TestServer.cs
@@ -313,7 +313,14 @@ public static class TestServer
     /// kernel has the full set to load-balance across. Without that, a test racing ahead could open
     /// every connection before the later shards bound and see a false "no distribution".
     /// </summary>
-    public static int StartSharded(int reactorCount, Func<int, Reactor, TcpConnection, Task> handle)
+    /// <param name="onStart">
+    /// Run on each reactor's own thread before that shard reports ready, and handed the shard
+    /// index so a caller can keep the per-reactor object it creates. A TlsService belongs to ONE
+    /// reactor, so a test that wants to rotate certificates the way a real server must - every
+    /// reactor separately - has no other way to hold all N of them.
+    /// </param>
+    public static int StartSharded(int reactorCount, Func<int, Reactor, TcpConnection, Task> handle,
+        Action<int, Reactor>? onStart = null)
     {
         int port = ReserveFreePort();
         var config = new ServerConfig
@@ -338,7 +345,14 @@ public static class TestServer
             var reactor = new Reactor(shard, config)
             {
                 TcpHandle = (r, conn) => handle(shard, r, conn),
-                OnStart = _ => ready.Signal(),
+                OnStart = r =>
+                {
+                    // Before the signal, so a shard that is "ready" is one whose service exists.
+                    // A throw here is caught by RunGuarded and surfaced by WaitForListen, rather
+                    // than leaving the countdown to time out with nothing to say.
+                    onStart?.Invoke(shard, r);
+                    ready.Signal();
+                },
             };
 
             var thread = new Thread(RunGuarded(reactor, port))

--- a/tests/Ioxide.Tests.Tls/KeyAndPostureReportingTests.cs
+++ b/tests/Ioxide.Tests.Tls/KeyAndPostureReportingTests.cs
@@ -1,0 +1,159 @@
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography;
+using System.Text;
+using ioxide;
+using ioxide.tls;
+
+namespace Ioxide.Tests;
+
+/// <summary>
+/// Two things a server must not get wrong about its own key and its own handshake.
+/// </summary>
+/// <remarks>
+/// From nginx's <c>ssl_password_file.t</c> and <c>ssl.t</c>. The first exists because nginx needed
+/// somewhere to put passphrase handling; ioxide has no such API, which makes the question "what
+/// happens when someone hands it an encrypted key anyway" rather than "does the feature work". The
+/// second is the pair of accessors <c>ioxide.Kestrel</c> maps into ASP.NET's
+/// <c>ITlsHandshakeFeature</c>, which applications make authorization decisions on and which
+/// nothing tested.
+/// </remarks>
+internal static class KeyAndPostureReportingTests
+{
+    public static void Register(Runner runner)
+    {
+        runner.Test("key: an encrypted private key is refused, and does not go looking for a passphrase", () =>
+        {
+            // OpenSSL's PEM readers take a password callback; passing none does not mean "no
+            // password", it means PEM_def_callback - which reads the passphrase FROM THE TERMINAL.
+            // On a server started from a tty that is not an error path, it is a hang, and on a
+            // rotation thread it would be a hang while still serving. There is no passphrase option
+            // on TlsOptions, so the only correct outcome is a prompt refusal naming the key.
+            //
+            // The deadline is the assertion here. A test that merely catches the throw would also
+            // pass on a build that blocks, because the runner's watchdog would kill the suite
+            // rather than this test.
+            string dir = Path.Combine(Path.GetTempPath(), "ioxide-encrypted-key");
+            Directory.CreateDirectory(dir);
+            string certPath = Path.Combine(dir, "enc.crt");
+            string keyPath = Path.Combine(dir, "enc.key");
+
+            (string plainCert, _) = TestCert.Ensure();
+            File.Copy(plainCert, certPath, overwrite: true);
+
+            using (var rsa = RSA.Create(2048))
+            {
+                File.WriteAllText(keyPath, rsa.ExportEncryptedPkcs8PrivateKeyPem(
+                    "correct horse battery staple",
+                    new PbeParameters(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA256, 10_000)));
+            }
+
+            var options = new TlsOptions { CertificatePath = certPath, KeyPath = keyPath };
+
+            long started = Environment.TickCount64;
+            Exception? refusal = null;
+            try
+            {
+                TestServer.Start(Handlers.TlsSendFirst, r => TlsService.Start(r, options));
+            }
+            catch (Exception e)
+            {
+                refusal = e;
+            }
+            long elapsed = Environment.TickCount64 - started;
+
+            Assert.True(refusal is not null, "an encrypted private key was accepted, and there is no way to supply its passphrase");
+            Assert.True(elapsed < 20_000,
+                $"the refusal took {elapsed} ms, which is long enough to be a prompt rather than a decision");
+            Assert.True(refusal!.Message.Contains("enc.key", StringComparison.Ordinal)
+                        || refusal.Message.Contains("KeyPath", StringComparison.Ordinal)
+                        || refusal.Message.Contains("key", StringComparison.OrdinalIgnoreCase),
+                $"the refusal should name the key rather than the library that produced it: {refusal.Message}");
+        });
+
+        runner.Test("posture: the protocol and ciphersuite the handler reads are the ones negotiated", () =>
+        {
+            // TlsSession.NegotiatedProtocolVersion and NegotiatedCipherSuiteId had no test anywhere,
+            // and ioxide.Kestrel maps both into ITlsHandshakeFeature - so a wrong constant there
+            // reports TLS 1.2 as 1.3 to every ASP.NET app on the port and nothing would notice.
+            // Driven twice, against a client pinned to each version, because a pair of constants
+            // can only be shown to be READ rather than assumed by making the answer change.
+            (string certPath, string keyPath) = TestCert.Ensure();
+
+            int port = TestServer.Start(EchoPosture, r => TlsService.Start(r, new TlsOptions
+            {
+                CertificatePath = certPath,
+                KeyPath = keyPath,
+            }));
+
+            // The accessor reports OpenSSL's WIRE value, and ioxide.Kestrel maps it - 0x0304 to
+            // Tls13, 0x0303 to Tls12. Both halves are asserted here: that the session reports the
+            // version the client actually negotiated, and that Kestrel's mapping of it is right,
+            // since an inverted table there would misreport every connection with nothing to catch it.
+            (string thirteen, SslProtocols clientThirteen, TlsCipherSuite suiteThirteen) = Ask(port, SslProtocols.Tls13);
+            Assert.Equal(SslProtocols.Tls13, clientThirteen);
+            Assert.Equal(0x0304, int.Parse(thirteen.Split('|')[0]));
+            Assert.Equal((int)suiteThirteen, int.Parse(thirteen.Split('|')[1]));
+
+            (string twelve, SslProtocols clientTwelve, TlsCipherSuite suiteTwelve) = Ask(port, SslProtocols.Tls12);
+            Assert.Equal(SslProtocols.Tls12, clientTwelve);
+            Assert.Equal(0x0303, int.Parse(twelve.Split('|')[0]));
+            Assert.Equal((int)suiteTwelve, int.Parse(twelve.Split('|')[1]));
+
+            // And the two really are different, so neither assertion above is satisfied by a
+            // constant that happens to match one of them.
+            Assert.True(thirteen != twelve, "both handshakes reported the same posture");
+        });
+    }
+
+    /// <summary>Answers with what the SESSION says the handshake settled on.</summary>
+    private static async Task EchoPosture(Reactor reactor, TcpConnection connection)
+    {
+        TlsSession? tls = null;
+        try
+        {
+            tls = await reactor.GetService<TlsService>().AcceptAsync(connection);
+
+            string body = $"{tls.NegotiatedProtocolVersion}|{tls.NegotiatedCipherSuiteId}";
+            byte[] response = Encoding.ASCII.GetBytes(
+                $"HTTP/1.1 200 OK\r\nContent-Length: {body.Length}\r\n\r\n{body}");
+
+            tls.Write(connection, response);
+            await connection.FlushAsync();
+
+            // Read once so the client's close is observed rather than raced.
+            await connection.ReadAsync();
+        }
+        catch
+        {
+            // A client pinned to a version the port refuses lands here; the test reads the failure
+            // from its own side.
+        }
+        finally
+        {
+            tls?.Dispose();
+            connection.DecRef();
+        }
+    }
+
+    private static (string Reported, SslProtocols Negotiated, TlsCipherSuite Suite) Ask(int port, SslProtocols protocols)
+    {
+        using var socket = new TcpClient();
+        socket.Connect("127.0.0.1", port);
+        socket.ReceiveTimeout = 6_000;
+        socket.SendTimeout = 6_000;
+
+        using var ssl = new SslStream(socket.GetStream(), false, (_, _, _, _) => true);
+        ssl.AuthenticateAsClient(new SslClientAuthenticationOptions
+        {
+            TargetHost = "localhost",
+            EnabledSslProtocols = protocols,
+        });
+
+        (int status, string body) = Client.ReadResponse(ssl);
+        Assert.Equal(200, status);
+
+        return (body, ssl.SslProtocol, ssl.NegotiatedCipherSuite);
+    }
+}

--- a/tests/Ioxide.Tests.Tls/Program.cs
+++ b/tests/Ioxide.Tests.Tls/Program.cs
@@ -26,6 +26,7 @@ internal static class Program
         SniTests.Register(runner, ktls);
         SniConfigTests.Register(runner);
         RotationTests.Register(runner, ktls);
+        RotationLifecycleTests.Register(runner);
         RotationValidatingClientTests.Register(runner);
         PostureTests.Register(runner);
         FormatTests.Register(runner);

--- a/tests/Ioxide.Tests.Tls/Program.cs
+++ b/tests/Ioxide.Tests.Tls/Program.cs
@@ -27,6 +27,7 @@ internal static class Program
         SniConfigTests.Register(runner);
         RotationTests.Register(runner, ktls);
         RotationLifecycleTests.Register(runner);
+        KeyAndPostureReportingTests.Register(runner);
         RotationValidatingClientTests.Register(runner);
         PostureTests.Register(runner);
         FormatTests.Register(runner);

--- a/tests/Ioxide.Tests.Tls/RotationLifecycleTests.cs
+++ b/tests/Ioxide.Tests.Tls/RotationLifecycleTests.cs
@@ -1,0 +1,304 @@
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
+using ioxide;
+using ioxide.tls;
+
+namespace Ioxide.Tests;
+
+/// <summary>
+/// Rotation as an operation on a RUNNING server, rather than as a call that returns.
+/// </summary>
+/// <remarks>
+/// The cases here come from haproxy's <c>reg-tests/ssl</c> and nginx's <c>ssl_cache_reload.t</c>,
+/// which are worth mining because both projects ship runtime certificate replacement and their
+/// regression suites are a catalogue of the ways it goes wrong in production - including two
+/// haproxy files named after escaped bugs.
+///
+/// What separates these from <c>RotationTests</c> is time. Those establish that a rotation changes
+/// what the next handshake is served, which is the easy half; every one of them connects AFTER the
+/// call returned. These ask what happens to a connection that was already up, to a file rewritten
+/// underneath the server, and to a fleet of reactors where a rotation reached only some of them -
+/// the situations a renewal actually lands in.
+/// </remarks>
+internal static class RotationLifecycleTests
+{
+    public static void Register(Runner runner)
+    {
+        RegisterLiveConnections(runner);
+        RegisterFileShapes(runner);
+        RegisterFleet(runner);
+    }
+
+    // ---- a connection that was already up ------------------------------------------------------
+
+    private static void RegisterLiveConnections(Runner runner)
+    {
+        runner.Test("rotate: a connection established before a rotation keeps serving on what it authenticated", () =>
+        {
+            // The case the design's central promise is FOR. ReplaceCertificates keeps the contexts
+            // it replaces rather than freeing them, and says why: a handshake may be between
+            // reading a set and using what it found. Nothing tested the other half of that - a
+            // connection that finished its handshake on the old certificate and is still sending
+            // requests on it. Every existing rotation test connects after the call returned, so
+            // the retained contexts were never actually depended upon by anything.
+            (string cert, string key) = TestCert.Ensure();
+            (_, string renewed, string renewedKey) = TestCert.EnsureRenewedFromCa("rotate-live.test");
+
+            TlsService? service = null;
+            int port = TestServer.Start(Handlers.Tls, r => service = TlsService.Start(r, new TlsOptions
+            {
+                CertificatePath = cert,
+                KeyPath = key,
+            }));
+
+            using var socket = new TcpClient();
+            socket.Connect("127.0.0.1", port);
+            socket.ReceiveTimeout = 6_000;
+            socket.SendTimeout = 6_000;
+
+            X509Certificate? presented = null;
+            using var ssl = new SslStream(socket.GetStream(), false, (_, c, _, _) =>
+            {
+                presented = c;
+                return true;
+            });
+            ssl.AuthenticateAsClient("localhost");
+
+            Client.Send(ssl, "/before");
+            (int firstStatus, _) = Client.ReadResponse(ssl);
+            Assert.Equal(200, firstStatus);
+
+            string before = presented?.Subject ?? "";
+            Assert.True(before.Contains("localhost"), $"the connection should have authenticated the default certificate, got: {before}");
+
+            service!.ReplaceCertificates(new TlsCertificate { CertificatePath = renewed, KeyPath = renewedKey });
+
+            // The rotation landed - a NEW connection sees the new certificate. Without this the
+            // test below would also pass against a rotation that silently did nothing.
+            Assert.True(Client.ServerCertificateSubject(port, null).Contains("rotate-live.test"),
+                "the rotation did not take effect for new connections, so nothing was rotated across");
+
+            // And the connection that was already up is unaffected: same session, same certificate,
+            // still answering. A rotation that tore this down would be an outage per renewal.
+            Client.Send(ssl, "/after");
+            (int secondStatus, string body) = Client.ReadResponse(ssl);
+
+            Assert.Equal(200, secondStatus);
+            Assert.Equal("tls-ok", body);
+        });
+    }
+
+    // ---- the file underneath the server --------------------------------------------------------
+
+    private static void RegisterFileShapes(Runner runner)
+    {
+        runner.Test("rotate: the same paths are re-read when the files are rewritten in place", () =>
+        {
+            // How renewal actually happens. certbot writes fullchain.pem and privkey.pem to the
+            // SAME paths - often preserving the inode, and nginx's ssl_cache_reload.t goes out of
+            // its way to preserve the mtime too - then signals. Every rotation test in this repo
+            // hands ReplaceCertificates a DIFFERENT path, so nothing pins that passing the same
+            // TlsCertificate twice re-reads it. A "skip unchanged paths" optimisation would break
+            // exactly this and no test would notice.
+            (string firstCert, string firstKey) = TestCert.EnsureNamed("inplace-one.test");
+            (string secondCert, string secondKey) = TestCert.EnsureNamed("inplace-two.test");
+
+            string dir = Path.Combine(Path.GetTempPath(), "ioxide-rotate-inplace");
+            Directory.CreateDirectory(dir);
+            string livePath = Path.Combine(dir, "live.crt");
+            string liveKey = Path.Combine(dir, "live.key");
+
+            File.Copy(firstCert, livePath, overwrite: true);
+            File.Copy(firstKey, liveKey, overwrite: true);
+            DateTime stamp = new(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            File.SetLastWriteTimeUtc(livePath, stamp);
+            File.SetLastWriteTimeUtc(liveKey, stamp);
+
+            TlsService? service = null;
+            int port = TestServer.Start(Handlers.TlsSendFirst, r => service = TlsService.Start(r, new TlsOptions
+            {
+                CertificatePath = livePath,
+                KeyPath = liveKey,
+            }));
+
+            Assert.True(Client.ServerCertificateSubject(port, null).Contains("inplace-one.test"),
+                "the server should start on the first certificate");
+
+            // Rewritten in place, mtime pinned to the same value it already had.
+            File.Copy(secondCert, livePath, overwrite: true);
+            File.Copy(secondKey, liveKey, overwrite: true);
+            File.SetLastWriteTimeUtc(livePath, stamp);
+            File.SetLastWriteTimeUtc(liveKey, stamp);
+
+            // The SAME TlsCertificate values - only the bytes behind them changed.
+            service!.ReplaceCertificates(new TlsCertificate { CertificatePath = livePath, KeyPath = liveKey });
+
+            Assert.True(Client.ServerCertificateSubject(port, null).Contains("inplace-two.test"),
+                "a rotation given the same paths must re-read them: the file was rewritten in place "
+                + "and the server is still serving the certificate it started with");
+        });
+
+        runner.Test("rotate: every PEM shape that starts a service also rotates into one", () =>
+        {
+            // haproxy issue #2265: a certificate shape the STARTUP loader accepted was refused by
+            // the RUNTIME one, so a server that had booted for months could not be renewed - and
+            // the operator saw a half-applied set rather than a clean failure. ioxide is
+            // structurally immune, because BuildCertificates is the single builder for both paths,
+            // but nothing pinned that property and a fast path added to ReplaceCertificates would
+            // break it silently. FormatTests proves these shapes start; this proves they rotate.
+            (string cert, string key) = TestCert.Ensure();
+
+            TlsService? service = null;
+            int port = TestServer.Start(Handlers.TlsSendFirst, r => service = TlsService.Start(r, new TlsOptions
+            {
+                CertificatePath = cert,
+                KeyPath = key,
+            }));
+
+            foreach (TestCert.PemShape shape in Enum.GetValues<TestCert.PemShape>())
+            {
+                (string shapeCert, string shapeKey) = TestCert.EnsureServerCert(shape);
+
+                service!.ReplaceCertificates(new TlsCertificate
+                {
+                    CertificatePath = shapeCert,
+                    KeyPath = shapeKey,
+                });
+
+                // Rotated AND serving: a set that built but cannot handshake is the failure this
+                // is looking for, so the check has to reach the wire rather than stop at "no throw".
+                string subject = Client.ServerCertificateSubject(port, null);
+                Assert.True(subject.Length > 0,
+                    $"the {shape} shape rotated in but the port then served nobody");
+            }
+        });
+
+        runner.Test("rotate: a host entry whose key does not match its certificate is refused", () =>
+        {
+            // The QUIC engine refuses this at its constructor, AddHost and ReplaceCertificates
+            // alike ("rotate/quic: a key that does not match its certificate is refused"). On TCP
+            // the equivalent is reached only through the default certificate, by way of the
+            // reversed-bundle case - a host ENTRY carrying a mismatched pair was never covered,
+            // and SNI entries are built by a different function from the default.
+            (string cert, string key) = TestCert.Ensure();
+            (string alphaCert, string alphaKey) = TestCert.EnsureNamed("alpha.test");
+            (string betaCert, string betaKey) = TestCert.EnsureNamed("beta.test");
+
+            TlsService? service = null;
+            int port = TestServer.Start(Handlers.TlsSendFirst, r => service = TlsService.Start(r, new TlsOptions
+            {
+                CertificatePath = cert,
+                KeyPath = key,
+                CertificatesByHost = new Dictionary<string, TlsCertificate>
+                {
+                    ["alpha.test"] = new() { CertificatePath = alphaCert, KeyPath = alphaKey },
+                },
+            }));
+
+            Assert.True(Client.ServerCertificateSubject(port, "alpha.test").Contains("alpha.test"),
+                "the host should start on its own certificate");
+
+            // alpha's certificate against beta's key: both valid, and not a pair.
+            Assert.Throws<IOException>(
+                () => service!.ReplaceCertificates(
+                    new TlsCertificate { CertificatePath = cert, KeyPath = key },
+                    new Dictionary<string, TlsCertificate>
+                    {
+                        ["alpha.test"] = new() { CertificatePath = alphaCert, KeyPath = betaKey },
+                    }),
+                // Named by the HOST, which is the part an operator needs: a fleet rotating twenty
+                // names wants to know which entry is the bad pair, not merely that one of them is.
+                "alpha.test");
+
+            // Refused means unchanged, which is the half that keeps the check from being a way to
+            // break a running server.
+            Assert.True(Client.ServerCertificateSubject(port, "alpha.test").Contains("alpha.test"),
+                "a refused rotation must leave the host serving what it was");
+        });
+    }
+
+    // ---- more than one reactor -----------------------------------------------------------------
+
+    private static void RegisterFleet(Runner runner)
+    {
+        runner.Test("rotate: a rotation that reaches only some reactors serves two certificates at once", () =>
+        {
+            // A TlsService belongs to ONE reactor, so a server with N of them holds N services and
+            // a renewal has to visit every one. They share a port through SO_REUSEPORT, so which
+            // reactor a client lands on is the kernel's choice - and a rotation that missed some
+            // means the SAME name answers with two different certificates depending on where the
+            // connection landed, with nothing to tell the operator.
+            //
+            // This is the production shape, and until now no TLS test ran more than one reactor:
+            // every entry point in the harness pinned ReactorCount = 1. What is asserted is the
+            // consequence rather than the mechanism - both certificates observed on one port.
+            const int reactors = 4;
+
+            (string cert, string key) = TestCert.Ensure();
+            (_, string renewed, string renewedKey) = TestCert.EnsureRenewedFromCa("fleet-rotate.test");
+
+            var services = new TlsService[reactors];
+            var options = new TlsOptions { CertificatePath = cert, KeyPath = key };
+
+            int port = TestServer.StartSharded(reactors,
+                (_, r, conn) => Handlers.TlsSendFirst(r, conn),
+                (shard, r) => services[shard] = TlsService.Start(r, options));
+
+            // Rotate ONE of the four, as a renewal script that iterated the wrong collection would.
+            services[0].ReplaceCertificates(new TlsCertificate
+            {
+                CertificatePath = renewed,
+                KeyPath = renewedKey,
+            });
+
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            for (int i = 0; i < 60 && seen.Count < 2; i++)
+            {
+                string subject = Client.ServerCertificateSubject(port, null);
+                if (subject.Length > 0)
+                {
+                    seen.Add(subject.Contains("fleet-rotate.test") ? "renewed" : "original");
+                }
+            }
+
+            Assert.True(seen.Contains("original") && seen.Contains("renewed"),
+                "one port served only " + string.Join("/", seen) + " across 60 connections: a "
+                + "partial rotation should be observable as two certificates on one name, and if "
+                + "this stops being true the per-reactor model has changed");
+        });
+
+        runner.Test("control: rotating every reactor leaves only the new certificate", () =>
+        {
+            // The other half. Without this, the test above is satisfied by a fleet that always
+            // serves two certificates - which would be a far worse bug and a green test.
+            const int reactors = 4;
+
+            (string cert, string key) = TestCert.Ensure();
+            (_, string renewed, string renewedKey) = TestCert.EnsureRenewedFromCa("fleet-rotate.test");
+
+            var services = new TlsService[reactors];
+            var options = new TlsOptions { CertificatePath = cert, KeyPath = key };
+
+            int port = TestServer.StartSharded(reactors,
+                (_, r, conn) => Handlers.TlsSendFirst(r, conn),
+                (shard, r) => services[shard] = TlsService.Start(r, options));
+
+            foreach (TlsService service in services)
+            {
+                service.ReplaceCertificates(new TlsCertificate
+                {
+                    CertificatePath = renewed,
+                    KeyPath = renewedKey,
+                });
+            }
+
+            for (int i = 0; i < 40; i++)
+            {
+                string subject = Client.ServerCertificateSubject(port, null);
+                Assert.True(subject.Length == 0 || subject.Contains("fleet-rotate.test"),
+                    $"a fully rotated fleet served the old certificate on connection {i}: {subject}");
+            }
+        });
+    }
+}


### PR DESCRIPTION
Our own review rounds kept producing findings we then had to argue with — 11 of the last 31 were refuted. So this round asks a different source: the regression suites of servers that already ship what we ship. nginx has 113 TLS/h3/QUIC test files, haproxy's `reg-tests/ssl` is a catalogue of runtime certificate replacement going wrong (two files are named after escaped bugs), and h2o is picotls-based like our QUIC side. Those cases are evidence of what actually breaks in production, which an agent's opinion about our code is not.

The first two batches are here. One of them found a live defect.

## A server with an encrypted key hangs instead of failing

Porting nginx's `ssl_password_file.t` asked a question our suite never had. `TlsOptions` has no passphrase option — so what happens when someone points it at an encrypted key anyway?

It prompts. OpenSSL's PEM readers take a password callback, and passing none does not mean "there is no password", it means `PEM_def_callback` — which reads the **terminal**. With the fix removed, the suite prints

```
Enter PEM pass phrase:
```

and the server "bound its listener but never finished OnStart". It blocked there and the run had to be killed. Redirecting stdin does not help: OpenSSL's default UI opens `/dev/tty` directly.

On a server started from a terminal that is a hang rather than an error. On a rotation thread it would be a hang *while the old certificates were still being served*. The fix installs a callback reporting no passphrase available, before any key is read, which turns the prompt into the ordinary refusal every other unusable key gets: `private key '.../enc.key': error:1C800064:Provider routines::bad decrypt`.

The test asserts the refusal **and a deadline**, because a test that only caught the throw would also pass against a build that blocks — the watchdog would kill the suite rather than that test.

## Rotation as an operation on a running server

`RotationTests` establishes that a rotation changes what the *next* handshake is served. Every one of its cases connects after the call returned, which is the easy half.

- **a connection established before a rotation keeps serving on what it authenticated** — the case the design's central promise is for. `ReplaceCertificates` deliberately *keeps* the contexts it replaces, because a handshake may be between reading a set and using it. Nothing depended on that until now; no test held a connection across a rotation at all.
- **the same paths are re-read when the files are rewritten in place** — how renewal actually happens. certbot rewrites the same paths, often preserving the inode, and nginx's version pins the mtime too. Every existing test hands a *different* path, so a "skip unchanged paths" optimisation would have broken this silently.
- **every PEM shape that starts a service also rotates into one** — haproxy issue #2265, where the runtime loader accepted less than the startup loader and a server that had booted for months could not be renewed. ioxide is structurally immune because `BuildCertificates` is the single builder for both, but nothing held it to that.
- **a host entry whose key does not match its certificate is refused** — already true; what was missing was anything holding it to that, and anything pinning that the refusal names the offending **host**, which is what an operator rotating twenty names needs.

## The production shape, executed for the first time

**a rotation that reaches only some reactors serves two certificates at once**, with a control that rotates all four.

A `TlsService` belongs to one reactor. Reactors share a port through SO_REUSEPORT, so which one a client lands on is the kernel's choice — and a renewal that iterated the wrong collection leaves one name answering with two different certificates depending on where the connection landed, with nothing to tell the operator.

Until now this was unreachable: **every TLS entry point in the harness pinned `ReactorCount = 1`**, so the shape we actually ship had never been executed by a test. `StartSharded` gains an optional per-shard `OnStart`, run before that shard reports ready, which is the only way to hold all N services.

The control matters as much as the test: a fleet that *always* served two certificates would be a worse bug and a green test.

## Also

`TlsSession.NegotiatedProtocolVersion` and `NegotiatedCipherSuiteId` had no test anywhere, while `ioxide.Kestrel` maps both into `ITlsHandshakeFeature` for applications to make authorization decisions on. Driven against a client pinned to TLS 1.3 and again to TLS 1.2, so the constants are shown to be *read* rather than assumed, with Kestrel's own mapping asserted alongside.

All suites: **427 passed, 0 failed, 20 pending.**

Still to mine: the SNI family (wildcard entries that silently never match, trailing dots, IDN A-labels), the chain cases (`TRUSTED CERTIFICATE` intermediates being silently dropped), cross-host ticket resumption, and the QUIC side — which needs a sharded QUIC starter, and where migration and CID routing will land as `Pending` since neither is implemented.
