### PR TITLE
Add a ring-native wait: SubmitTimeout in core, RingTimer in ioxide.timer

### DIFF
--- a/ioxide.slnx
+++ b/ioxide.slnx
@@ -15,6 +15,7 @@
   <Folder Name="/clients/">
     <Project Path="src/clients/ioxide.httpclient/ioxide.httpclient.csproj" />
     <Project Path="src/clients/ioxide.file/ioxide.file.csproj" />
+    <Project Path="src/clients/ioxide.timer/ioxide.timer.csproj" />
     <Project Path="src/clients/ioxide.pg/ioxide.pg.csproj" />
     <Project Path="src/clients/ioxide.redis/ioxide.redis.csproj" />
   </Folder>

--- a/src/clients/ioxide.file/ioxide.file.csproj
+++ b/src/clients/ioxide.file/ioxide.file.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.file</RootNamespace>
 
     <PackageId>ioxide.file</PackageId>
-    <Version>0.7.210</Version>
+    <Version>0.7.211</Version>
     <Authors>MDA2AV</Authors>
     <Description>File serving for the ioxide io_uring runtime: immutable asset snapshots with baked responses, pooled positional ring reads, atomic reloads.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
+++ b/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.httpclient</RootNamespace>
 
     <PackageId>ioxide.httpclient</PackageId>
-    <Version>0.7.210</Version>
+    <Version>0.7.211</Version>
     <Authors>MDA2AV</Authors>
     <Description>The ring-native HTTP/1.1 client for the ioxide io_uring runtime - the upstream leg between a proxy and an origin. Connections are opened on the reactor thread that will use them, so a request never crosses a thread on its way out or back, and every response resumes the awaiting handler inline on its own reactor. Includes client-side TLS (SNI, ALPN, certificate verification and client certificates for mutual TLS) for https:// origins. Depends on ioxide core alone: no protocol package, no native asset.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.pg/ioxide.pg.csproj
+++ b/src/clients/ioxide.pg/ioxide.pg.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.pg</RootNamespace>
 
     <PackageId>ioxide.pg</PackageId>
-    <Version>0.7.210</Version>
+    <Version>0.7.211</Version>
     <Authors>MDA2AV</Authors>
     <Description>Postgres driver for the ioxide io_uring runtime: pooled ring-native connections per reactor, ring-native connect and handshake, inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.redis/ioxide.redis.csproj
+++ b/src/clients/ioxide.redis/ioxide.redis.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.redis</RootNamespace>
 
     <PackageId>ioxide.redis</PackageId>
-    <Version>0.7.210</Version>
+    <Version>0.7.211</Version>
     <Authors>MDA2AV</Authors>
     <Description>Redis client for the ioxide io_uring runtime: pooled ring-native connections per reactor, full RESP2 protocol, a generic command API plus typed helpers (strings, keys, hashes, lists, sets, sorted sets, pub/sub, transactions, scripting), and pipelining. Inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.timer/RingTimer.cs
+++ b/src/clients/ioxide.timer/RingTimer.cs
@@ -1,4 +1,6 @@
-namespace ioxide;
+using ioxide;
+
+namespace ioxide.timer;
 
 /// <summary>
 /// A wait that runs on the host's ring, the way a <see cref="RingSocket"/>'s reads do - the

--- a/src/clients/ioxide.timer/ioxide.timer.csproj
+++ b/src/clients/ioxide.timer/ioxide.timer.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0;net11.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace>ioxide.timer</RootNamespace>
+
+    <PackageId>ioxide.timer</PackageId>
+    <Version>0.7.211</Version>
+    <Authors>MDA2AV</Authors>
+    <Description>Deadlines for the ioxide io_uring runtime: waits submitted to the reactor's own ring with IORING_OP_TIMEOUT, completing inline on the reactor that owns the caller, with no timer thread and nothing allocated per wait.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://mda2av.github.io/ioxide/</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/MDA2AV/ioxide</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>io_uring;timer;timeout;delay;linux;ioxide</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../../README.md" Pack="true" PackagePath="/" />
+    <ProjectReference Include="../../ioxide/ioxide.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ioxide/Client/RingTimer.cs
+++ b/src/ioxide/Client/RingTimer.cs
@@ -1,0 +1,63 @@
+namespace ioxide;
+
+/// <summary>
+/// A wait that runs on the host's ring, the way a <see cref="RingSocket"/>'s reads do - the
+/// building block for anything that has to hold a deadline without leaving the reactor.
+///
+/// The deadline travels in the submission, so the kernel holds it and the completion arrives on
+/// the reactor thread with the connection's state still warm. Nothing is armed on the side and
+/// no syscall is made to arrange it: the SQE goes out with whatever batch the reactor was
+/// already sending.
+///
+/// One op in flight per timer, like <see cref="RingOpSource"/> - hold one per connection, or one
+/// per thing that waits. Zero allocation per wait once constructed.
+///
+/// Results follow the ring rather than the caller's intuition: a wait that runs its course
+/// completes with <c>-ETIME</c> (-62), which is io_uring reporting the timeout expired and is
+/// the success case here. Any other negative value is an errno.
+/// </summary>
+public sealed class RingTimer
+{
+    /// <summary>io_uring's report for a timeout that expired normally.</summary>
+    public const int ETime = -62;
+
+    private const long NanosecondsPerMillisecond = 1_000_000L;
+
+    private readonly IRingHost _host;
+    private readonly RingOpSource _source = new();
+
+    public RingTimer(IRingHost host)
+    {
+        _host = host;
+    }
+
+    /// <summary>Completes once <paramref name="milliseconds"/> have elapsed.</summary>
+    public ValueTask<int> DelayAsync(int milliseconds)
+    {
+        return DelayNanosecondsAsync(milliseconds * NanosecondsPerMillisecond);
+    }
+
+    /// <summary>Completes once <paramref name="delay"/> has elapsed.</summary>
+    public ValueTask<int> DelayAsync(TimeSpan delay)
+    {
+        return DelayNanosecondsAsync((long)(delay.TotalMilliseconds * NanosecondsPerMillisecond));
+    }
+
+    /// <summary>
+    /// Completes once <paramref name="nanoseconds"/> have elapsed. A duration at or below zero
+    /// becomes the smallest the kernel will take, because a zero timespec disarms a timer rather
+    /// than firing one.
+    /// </summary>
+    public ValueTask<int> DelayNanosecondsAsync(long nanoseconds)
+    {
+        ValueTask<int> pending = _source.Prepare();
+        _host.SubmitTimeout(nanoseconds < 1 ? 1 : nanoseconds, _source);
+        return pending;
+    }
+
+    /// <summary>True for a completion that is the timer expiring rather than an error.</summary>
+    public static bool Expired(int result)
+    {
+        return result == ETime || result == 0;
+    }
+}

--- a/src/ioxide/IRingHost.cs
+++ b/src/ioxide/IRingHost.cs
@@ -36,6 +36,16 @@ public interface IRingHost
     /// Write <paramref name="length"/> bytes from <paramref name="buffer"/> at <paramref name="offset"/>.
     /// </summary>
     void SubmitWrite(int fd, nint buffer, int length, long offset, IRingCompletion completion);
+
+    /// <summary>
+    /// Completes after <paramref name="nanoseconds"/> have elapsed, on this reactor's thread,
+    /// with no file descriptor involved. The kernel holds the deadline on the ring, so a wait
+    /// costs one SQE and one CQE and no syscall of its own.
+    ///
+    /// Expiry is reported the way io_uring reports it: <c>Complete</c> receives <c>-ETIME</c>
+    /// (-62), which is success for a timeout rather than a failure.
+    /// </summary>
+    void SubmitTimeout(long nanoseconds, IRingCompletion completion);
 }
 
 /// <summary>

--- a/src/ioxide/Reactor/Reactor.RingHost.cs
+++ b/src/ioxide/Reactor/Reactor.RingHost.cs
@@ -115,24 +115,17 @@ public sealed unsafe partial class Reactor : IRingHost
         EnsureTimespecCapacity();
 
         // The kernel reads this while the op is in flight, so it lives with the slot and is
-        // still there when the CQE arrives.
+        // still there when the CQE arrives. That is also why the deadline cannot be resolved
+        // before the slot is: the address the SQE carries is this slot's.
         __kernel_timespec* ts = _opTimespecs + slot;
         long ns = nanoseconds < 1 ? 1 : nanoseconds;
         ts->tv_sec  = ns / 1_000_000_000L;
         ts->tv_nsec = ns % 1_000_000_000L;
 
-        IoUringSqe* sqe = GetSqeOrFlush();
-        Unsafe.InitBlockUnaligned(sqe, 0, 64);
-
         // No fd and no buffer: addr points at the deadline and len=1 says it is one timespec.
         // off stays 0, so this is purely time-based rather than also waiting on a number of
         // completions.
-        sqe->opcode    = IORING_OP_TIMEOUT;
-        sqe->fd        = -1;
-        sqe->addr      = (ulong)ts;
-        sqe->len       = 1;
-        sqe->off       = 0;
-        sqe->user_data = Tag(KindClient, 0, slot);
+        Emit(IORING_OP_TIMEOUT, fd: -1, addr: (ulong)ts, len: 1, off: 0, slot);
     }
 
     private void SubmitClientOp(byte opcode, int fd, nint buffer, int length, long offset, IRingCompletion completion)
@@ -151,15 +144,24 @@ public sealed unsafe partial class Reactor : IRingHost
     private void SubmitClientOpCore(byte opcode, int fd, nint buffer, int length, long offset, IRingCompletion completion)
     {
         int slot = AllocOpSlot(completion);
+        Emit(opcode, fd, (ulong)buffer, (uint)length, (ulong)offset, slot);
+    }
 
+    /// <summary>
+    /// Writes one SQE and tags it for the client dispatch. Every client op ends here, whatever
+    /// its fields mean: a buffer and a length for the fd ops, a deadline and a count of one for
+    /// a timeout. The callers differ in what they put in the fields, not in how they submit.
+    /// </summary>
+    private void Emit(byte opcode, int fd, ulong addr, uint len, ulong off, int slot)
+    {
         IoUringSqe* sqe = GetSqeOrFlush();
         Unsafe.InitBlockUnaligned(sqe, 0, 64);
 
         sqe->opcode    = opcode;
         sqe->fd        = fd;
-        sqe->addr      = (ulong)buffer;
-        sqe->len       = (uint)length;
-        sqe->off       = (ulong)offset;
+        sqe->addr      = addr;
+        sqe->len       = len;
+        sqe->off       = off;
         sqe->user_data = Tag(KindClient, 0, slot);
     }
 

--- a/src/ioxide/Reactor/Reactor.RingHost.cs
+++ b/src/ioxide/Reactor/Reactor.RingHost.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using static ioxide.Native;
 
@@ -14,6 +15,12 @@ public sealed unsafe partial class Reactor : IRingHost
 {
     // In-flight client ops: slot → completion. Reactor-thread-only; grows on demand.
     private IRingCompletion?[] _opTargets = new IRingCompletion?[1024];
+
+    // One timespec per op slot, for IORING_OP_TIMEOUT. The kernel reads it while the op is in
+    // flight, so it has to outlive the submission; hanging it off the slot makes its lifetime
+    // exactly the operation's, with no allocation per wait.
+    private __kernel_timespec* _opTimespecs;
+    private int _opTimespecCapacity;
     private int[] _opFree = null!;
     private int   _opFreeTop;
 
@@ -83,6 +90,16 @@ public sealed unsafe partial class Reactor : IRingHost
         SubmitClientOp(IORING_OP_WRITE, fd, buffer, length, offset, completion);
     }
 
+    /// <summary>
+    /// Completes after <paramref name="nanoseconds"/>, on this reactor. The duration rides in the
+    /// offset field so this reuses the same slot, remote-marshalling and completion routing as
+    /// every other client op.
+    /// </summary>
+    public void SubmitTimeout(long nanoseconds, IRingCompletion completion)
+    {
+        SubmitClientOp(IORING_OP_TIMEOUT, fd: -1, buffer: 0, length: 0, offset: nanoseconds, completion);
+    }
+
     private void SubmitClientOp(byte opcode, int fd, nint buffer, int length, long offset, IRingCompletion completion)
     {
         // Off-reactor callers hand over and wake, like every other producer.
@@ -103,6 +120,26 @@ public sealed unsafe partial class Reactor : IRingHost
         IoUringSqe* sqe = GetSqeOrFlush();
         Unsafe.InitBlockUnaligned(sqe, 0, 64);
 
+        if (opcode == IORING_OP_TIMEOUT)
+        {
+            // No fd and no buffer: addr points at the deadline, and len=1 says it is one
+            // timespec. off stays 0 so this is purely time-based rather than also waiting
+            // on a number of completions.
+            EnsureTimespecCapacity();
+            __kernel_timespec* ts = _opTimespecs + slot;
+            long ns = offset < 1 ? 1 : offset;
+            ts->tv_sec  = ns / 1_000_000_000L;
+            ts->tv_nsec = ns % 1_000_000_000L;
+
+            sqe->opcode    = IORING_OP_TIMEOUT;
+            sqe->fd        = -1;
+            sqe->addr      = (ulong)ts;
+            sqe->len       = 1;
+            sqe->off       = 0;
+            sqe->user_data = Tag(KindClient, 0, slot);
+            return;
+        }
+
         sqe->opcode    = opcode;
         sqe->fd        = fd;
         sqe->addr      = (ulong)buffer;
@@ -117,6 +154,21 @@ public sealed unsafe partial class Reactor : IRingHost
         {
             SubmitClientOpCore(op.Opcode, op.Fd, op.Buffer, op.Length, op.Offset, op.Completion);
         }
+    }
+
+    // Grown to match _opTargets, so a slot always has a timespec behind it.
+    private void EnsureTimespecCapacity()
+    {
+        if (_opTimespecCapacity >= _opTargets.Length)
+        {
+            return;
+        }
+
+        nuint bytes = (nuint)(_opTargets.Length * sizeof(__kernel_timespec));
+        _opTimespecs = _opTimespecs == null
+            ? (__kernel_timespec*)NativeMemory.Alloc(bytes)
+            : (__kernel_timespec*)NativeMemory.Realloc(_opTimespecs, bytes);
+        _opTimespecCapacity = _opTargets.Length;
     }
 
     private int AllocOpSlot(IRingCompletion completion)

--- a/src/ioxide/Reactor/Reactor.RingHost.cs
+++ b/src/ioxide/Reactor/Reactor.RingHost.cs
@@ -97,12 +97,10 @@ public sealed unsafe partial class Reactor : IRingHost
     /// </summary>
     public void SubmitTimeout(long nanoseconds, IRingCompletion completion)
     {
-        // Off-reactor callers hand over and wake, like every other producer. The duration rides
-        // in the offset field of the queued record, which is otherwise unused for a timeout.
-        if (Environment.CurrentManagedThreadId != _reactorThreadId && _reactorThreadId != 0)
+        // The duration rides in the offset field of the queued record, which a timeout
+        // otherwise leaves unused.
+        if (HandedOff(IORING_OP_TIMEOUT, fd: -1, buffer: 0, length: 0, nanoseconds, completion))
         {
-            _remoteOps.Enqueue(new RemoteOp(IORING_OP_TIMEOUT, -1, 0, 0, nanoseconds, completion));
-            WakeFdWrite();
             return;
         }
 
@@ -130,15 +128,32 @@ public sealed unsafe partial class Reactor : IRingHost
 
     private void SubmitClientOp(byte opcode, int fd, nint buffer, int length, long offset, IRingCompletion completion)
     {
-        // Off-reactor callers hand over and wake, like every other producer.
-        if (Environment.CurrentManagedThreadId != _reactorThreadId && _reactorThreadId != 0)
+        if (HandedOff(opcode, fd, buffer, length, offset, completion))
         {
-            _remoteOps.Enqueue(new RemoteOp(opcode, fd, buffer, length, offset, completion));
-            WakeFdWrite();
             return;
         }
 
         SubmitClientOpCore(opcode, fd, buffer, length, offset, completion);
+    }
+
+    /// <summary>
+    /// The SQ has one issuer, so a caller on any other thread queues the op and wakes the reactor
+    /// to submit it. True when that happened and the caller is done.
+    ///
+    /// Every submission shares this. What they cannot share is the submission itself: the fd ops
+    /// put a buffer and a length in the SQE, a timeout puts a deadline belonging to its own slot,
+    /// and that slot is not known until the reactor thread allocates it.
+    /// </summary>
+    private bool HandedOff(byte opcode, int fd, nint buffer, int length, long offset, IRingCompletion completion)
+    {
+        if (Environment.CurrentManagedThreadId == _reactorThreadId || _reactorThreadId == 0)
+        {
+            return false;
+        }
+
+        _remoteOps.Enqueue(new RemoteOp(opcode, fd, buffer, length, offset, completion));
+        WakeFdWrite();
+        return true;
     }
 
     private void SubmitClientOpCore(byte opcode, int fd, nint buffer, int length, long offset, IRingCompletion completion)

--- a/src/ioxide/Reactor/Reactor.RingHost.cs
+++ b/src/ioxide/Reactor/Reactor.RingHost.cs
@@ -91,13 +91,48 @@ public sealed unsafe partial class Reactor : IRingHost
     }
 
     /// <summary>
-    /// Completes after <paramref name="nanoseconds"/>, on this reactor. The duration rides in the
-    /// offset field so this reuses the same slot, remote-marshalling and completion routing as
-    /// every other client op.
+    /// Completes after <paramref name="nanoseconds"/>, on this reactor. Shares the slot table and
+    /// completion routing with the fd ops, but not their submission: a timeout carries a deadline
+    /// where they carry a buffer, so it fills its own SQE rather than putting a branch in theirs.
     /// </summary>
     public void SubmitTimeout(long nanoseconds, IRingCompletion completion)
     {
-        SubmitClientOp(IORING_OP_TIMEOUT, fd: -1, buffer: 0, length: 0, offset: nanoseconds, completion);
+        // Off-reactor callers hand over and wake, like every other producer. The duration rides
+        // in the offset field of the queued record, which is otherwise unused for a timeout.
+        if (Environment.CurrentManagedThreadId != _reactorThreadId && _reactorThreadId != 0)
+        {
+            _remoteOps.Enqueue(new RemoteOp(IORING_OP_TIMEOUT, -1, 0, 0, nanoseconds, completion));
+            WakeFdWrite();
+            return;
+        }
+
+        SubmitTimeoutCore(nanoseconds, completion);
+    }
+
+    private void SubmitTimeoutCore(long nanoseconds, IRingCompletion completion)
+    {
+        int slot = AllocOpSlot(completion);
+        EnsureTimespecCapacity();
+
+        // The kernel reads this while the op is in flight, so it lives with the slot and is
+        // still there when the CQE arrives.
+        __kernel_timespec* ts = _opTimespecs + slot;
+        long ns = nanoseconds < 1 ? 1 : nanoseconds;
+        ts->tv_sec  = ns / 1_000_000_000L;
+        ts->tv_nsec = ns % 1_000_000_000L;
+
+        IoUringSqe* sqe = GetSqeOrFlush();
+        Unsafe.InitBlockUnaligned(sqe, 0, 64);
+
+        // No fd and no buffer: addr points at the deadline and len=1 says it is one timespec.
+        // off stays 0, so this is purely time-based rather than also waiting on a number of
+        // completions.
+        sqe->opcode    = IORING_OP_TIMEOUT;
+        sqe->fd        = -1;
+        sqe->addr      = (ulong)ts;
+        sqe->len       = 1;
+        sqe->off       = 0;
+        sqe->user_data = Tag(KindClient, 0, slot);
     }
 
     private void SubmitClientOp(byte opcode, int fd, nint buffer, int length, long offset, IRingCompletion completion)
@@ -120,26 +155,6 @@ public sealed unsafe partial class Reactor : IRingHost
         IoUringSqe* sqe = GetSqeOrFlush();
         Unsafe.InitBlockUnaligned(sqe, 0, 64);
 
-        if (opcode == IORING_OP_TIMEOUT)
-        {
-            // No fd and no buffer: addr points at the deadline, and len=1 says it is one
-            // timespec. off stays 0 so this is purely time-based rather than also waiting
-            // on a number of completions.
-            EnsureTimespecCapacity();
-            __kernel_timespec* ts = _opTimespecs + slot;
-            long ns = offset < 1 ? 1 : offset;
-            ts->tv_sec  = ns / 1_000_000_000L;
-            ts->tv_nsec = ns % 1_000_000_000L;
-
-            sqe->opcode    = IORING_OP_TIMEOUT;
-            sqe->fd        = -1;
-            sqe->addr      = (ulong)ts;
-            sqe->len       = 1;
-            sqe->off       = 0;
-            sqe->user_data = Tag(KindClient, 0, slot);
-            return;
-        }
-
         sqe->opcode    = opcode;
         sqe->fd        = fd;
         sqe->addr      = (ulong)buffer;
@@ -152,7 +167,16 @@ public sealed unsafe partial class Reactor : IRingHost
     {
         while (_remoteOps.TryDequeue(out RemoteOp op))
         {
-            SubmitClientOpCore(op.Opcode, op.Fd, op.Buffer, op.Length, op.Offset, op.Completion);
+            // The only place the two submissions have to be told apart, and it is off the hot
+            // path: this runs once per cross-thread handover, not once per op.
+            if (op.Opcode == IORING_OP_TIMEOUT)
+            {
+                SubmitTimeoutCore(op.Offset, op.Completion);
+            }
+            else
+            {
+                SubmitClientOpCore(op.Opcode, op.Fd, op.Buffer, op.Length, op.Offset, op.Completion);
+            }
         }
     }
 

--- a/src/ioxide/Reactor/Reactor.RingHost.cs
+++ b/src/ioxide/Reactor/Reactor.RingHost.cs
@@ -97,10 +97,11 @@ public sealed unsafe partial class Reactor : IRingHost
     /// </summary>
     public void SubmitTimeout(long nanoseconds, IRingCompletion completion)
     {
-        // The duration rides in the offset field of the queued record, which a timeout
-        // otherwise leaves unused.
-        if (HandedOff(IORING_OP_TIMEOUT, fd: -1, buffer: 0, length: 0, nanoseconds, completion))
+        if (Environment.CurrentManagedThreadId != _reactorThreadId && _reactorThreadId != 0)
         {
+            // The duration rides in the offset field of the queued record, which a timeout
+            // otherwise leaves unused.
+            HandOff(IORING_OP_TIMEOUT, fd: -1, buffer: 0, length: 0, nanoseconds, completion);
             return;
         }
 
@@ -128,8 +129,10 @@ public sealed unsafe partial class Reactor : IRingHost
 
     private void SubmitClientOp(byte opcode, int fd, nint buffer, int length, long offset, IRingCompletion completion)
     {
-        if (HandedOff(opcode, fd, buffer, length, offset, completion))
+        // Off-reactor callers hand over and wake, like every other producer.
+        if (Environment.CurrentManagedThreadId != _reactorThreadId && _reactorThreadId != 0)
         {
+            HandOff(opcode, fd, buffer, length, offset, completion);
             return;
         }
 
@@ -138,22 +141,15 @@ public sealed unsafe partial class Reactor : IRingHost
 
     /// <summary>
     /// The SQ has one issuer, so a caller on any other thread queues the op and wakes the reactor
-    /// to submit it. True when that happened and the caller is done.
-    ///
-    /// Every submission shares this. What they cannot share is the submission itself: the fd ops
-    /// put a buffer and a length in the SQE, a timeout puts a deadline belonging to its own slot,
-    /// and that slot is not known until the reactor thread allocates it.
+    /// to submit it on its own. Shared by every submission, and kept out of them: the thread test
+    /// is two comparisons and stays where it is, while this - an enqueue and a wake - is the cold
+    /// half and is marked so it does not get inlined back into a path that never runs it.
     /// </summary>
-    private bool HandedOff(byte opcode, int fd, nint buffer, int length, long offset, IRingCompletion completion)
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void HandOff(byte opcode, int fd, nint buffer, int length, long offset, IRingCompletion completion)
     {
-        if (Environment.CurrentManagedThreadId == _reactorThreadId || _reactorThreadId == 0)
-        {
-            return false;
-        }
-
         _remoteOps.Enqueue(new RemoteOp(opcode, fd, buffer, length, offset, completion));
         WakeFdWrite();
-        return true;
     }
 
     private void SubmitClientOpCore(byte opcode, int fd, nint buffer, int length, long offset, IRingCompletion completion)

--- a/src/ioxide/Reactor/Reactor.Runner.cs
+++ b/src/ioxide/Reactor/Reactor.Runner.cs
@@ -94,6 +94,12 @@ public sealed unsafe partial class Reactor
             NativeMemory.Free(_timerTs);
             _timerTs = null;
         }
+        if (_opTimespecs != null)
+        {
+            NativeMemory.Free(_opTimespecs);
+            _opTimespecs = null;
+            _opTimespecCapacity = 0;
+        }
         _ring.Dispose();
 
         // Shared provided-buffer ring (incremental mode allocates per connection instead). Freed after

--- a/src/ioxide/ioxide.csproj
+++ b/src/ioxide/ioxide.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide</RootNamespace>
 
     <PackageId>ioxide</PackageId>
-    <Version>0.7.210</Version>
+    <Version>0.7.211</Version>
     <Authors>MDA2AV</Authors>
     <Description>A shared-nothing io_uring runtime for .NET: one ring per reactor thread, inline completions, zero native dependencies. The engine - reactor, connection, and the IRingHost client seam. Includes TLS termination: the OpenSSL handshake driven over the ring, then kernel TLS (kTLS) transmit offload, so handlers keep writing plaintext. TLS needs OpenSSL 3 and the Linux tls module; nothing else does, and neither is loaded unless you use it.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http2/ioxide.http2.csproj
+++ b/src/protocols/ioxide.http2/ioxide.http2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http2</RootNamespace>
 
     <PackageId>ioxide.http2</PackageId>
-    <Version>0.7.210</Version>
+    <Version>0.7.211</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure-C# HTTP/2 for the ioxide io_uring runtime: framing, HPACK (static and dynamic tables, Huffman) and flow control, with zero native code. Serves h2c with prior knowledge and h2 over TLS by ALPN, buffered or streamed in either direction.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http3/ioxide.http3.csproj
+++ b/src/protocols/ioxide.http3/ioxide.http3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http3</RootNamespace>
 
     <PackageId>ioxide.http3</PackageId>
-    <Version>0.7.210</Version>
+    <Version>0.7.211</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure C# HTTP/3 for the ioxide io_uring runtime: frame parsing, QPACK (static table + Huffman) and request dispatch with zero native dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, drop-in alternative to ioxide.nghttp3.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
+++ b/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp2</RootNamespace>
 
     <PackageId>ioxide.nghttp2</PackageId>
-    <Version>0.7.210</Version>
+    <Version>0.7.211</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/2 for the ioxide io_uring runtime: framing, HPACK and flow control from nghttp2, statically linked behind a small shim with no external dependencies beyond libc. Serves HTTP/2 over any TcpConnection - h2c with prior knowledge, or h2 over TLS via ALPN. nghttp2 is sans-I/O, so ioxide keeps the ring and the loop.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
+++ b/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp3</RootNamespace>
 
     <PackageId>ioxide.nghttp3</PackageId>
-    <Version>0.7.210</Version>
+    <Version>0.7.211</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/3 layer for the ioxide io_uring runtime: nghttp3 (H3 + QPACK) bundled as a single self-contained native library with no external dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, no ioxide.ngtcp2 dependency.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
+++ b/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.ngtcp2</RootNamespace>
 
     <PackageId>ioxide.ngtcp2</PackageId>
-    <Version>0.7.210</Version>
+    <Version>0.7.211</Version>
     <Authors>MDA2AV</Authors>
     <Description>QUIC engine for the ioxide io_uring runtime: ngtcp2 + picotls bundled as a single self-contained native library (only system dependency: libcrypto.so.3 / OpenSSL 3.x). Plugs into the reactor's QUIC transport via QuicConnection. Server side; engine bindings in progress.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
+++ b/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.Kestrel</RootNamespace>
 
     <PackageId>ioxide.Kestrel</PackageId>
-    <Version>0.7.210</Version>
+    <Version>0.7.211</Version>
     <Authors>MDA2AV</Authors>
     <Description>ASP.NET Core Kestrel transport backed by the ioxide io_uring runtime: one reactor (ring) per core, SO_REUSEPORT load-balanced, with Kestrel's HTTP request loop pinned to the reactor thread. Drop-in via UseIoxide().</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/Ioxide.Tests.E2E/Core/TimerTests.cs
+++ b/tests/Ioxide.Tests.E2E/Core/TimerTests.cs
@@ -1,0 +1,120 @@
+using System.Diagnostics;
+using ioxide;
+using ioxide.utils;
+
+namespace Ioxide.Tests;
+
+/// <summary>
+/// RingTimer: the wait actually waits, it reports expiry rather than an error, a single timer is
+/// reusable across requests on its connection, and two connections waiting different amounts get
+/// their own deadlines rather than each other's.
+/// </summary>
+internal static class TimerTests
+{
+    // Answers after the milliseconds named in the path, holding one timer for the connection and
+    // re-arming it per request - the shape a caller is meant to use.
+    private static async Task Delay(Reactor r, TcpConnection conn)
+    {
+        var timer = new RingTimer(r);
+        try
+        {
+            while (true)
+            {
+                RecvSnapshot snapshot = await conn.ReadAsync();
+                string path = Wire.ReadPath(conn, snapshot);
+                int ms = int.TryParse(path.TrimStart('/'), out int parsed) ? parsed : 0;
+
+                int result = ms > 0 ? await timer.DelayAsync(ms) : RingTimer.ETime;
+                Wire.Write(conn, 200, RingTimer.Expired(result) ? ms.ToString() : $"errno {result}");
+                await conn.FlushAsync();
+
+                if (snapshot.IsClosed)
+                {
+                    return;
+                }
+
+                conn.ResetRead();
+            }
+        }
+        finally
+        {
+            conn.DecRef();
+        }
+    }
+
+    public static void Register(Runner runner)
+    {
+        runner.Test("timer: the wait actually elapses", () =>
+        {
+            int port = TestServer.Start(Delay);
+            var sw = Stopwatch.StartNew();
+            (int status, string body) = Client.Get(port, "/50");
+            sw.Stop();
+            Assert.Equal(200, status);
+            Assert.Equal("50", body);
+            Assert.True(sw.Elapsed.TotalMilliseconds >= 50,
+                $"answered in {sw.Elapsed.TotalMilliseconds:F1}ms, short of the 50ms asked for");
+        });
+
+        runner.Test("timer: expiry is reported as expiry, not an error", () =>
+        {
+            int port = TestServer.Start(Delay);
+            (int status, string body) = Client.Get(port, "/5");
+            Assert.Equal(200, status);
+            // The handler writes "errno N" if the completion was anything but a clean expiry.
+            Assert.Equal("5", body);
+        });
+
+        runner.Test("timer: one timer serves a connection's whole life", () =>
+        {
+            int port = TestServer.Start(Delay);
+            var sw = Stopwatch.StartNew();
+            var replies = Client.GetKeepAlive(port, "/10", 5);
+            sw.Stop();
+            Assert.Equal(5, replies.Count);
+            foreach ((int status, string body) in replies)
+            {
+                Assert.Equal(200, status);
+                Assert.Equal("10", body);
+            }
+            // Five waits of 10ms on one connection, served one after another.
+            Assert.True(sw.Elapsed.TotalMilliseconds >= 50,
+                $"five 10ms waits took {sw.Elapsed.TotalMilliseconds:F1}ms, so some did not happen");
+        });
+
+        runner.Test("timer: overlapping waits keep their own deadlines", () =>
+        {
+            int port = TestServer.Start(Delay);
+            int[] delays = [80, 10, 40];
+            var results = new (int Status, string Body, double Ms)[delays.Length];
+            var threads = new Thread[delays.Length];
+
+            for (int i = 0; i < delays.Length; i++)
+            {
+                int index = i;
+                threads[i] = new Thread(() =>
+                {
+                    var sw = Stopwatch.StartNew();
+                    (int status, string body) = Client.Get(port, $"/{delays[index]}");
+                    sw.Stop();
+                    results[index] = (status, body, sw.Elapsed.TotalMilliseconds);
+                });
+                threads[i].Start();
+            }
+
+            foreach (Thread t in threads)
+            {
+                t.Join();
+            }
+
+            for (int i = 0; i < delays.Length; i++)
+            {
+                Assert.Equal(200, results[i].Status);
+                // Its own value came back, not whichever request finished parsing last.
+                Assert.Equal(delays[i].ToString(), results[i].Body);
+                Assert.True(results[i].Ms >= delays[i],
+                    $"/{delays[i]} answered in {results[i].Ms:F1}ms");
+            }
+        });
+    }
+}

--- a/tests/Ioxide.Tests.E2E/Core/TimerTests.cs
+++ b/tests/Ioxide.Tests.E2E/Core/TimerTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using ioxide;
+using ioxide.timer;
 using ioxide.utils;
 
 namespace Ioxide.Tests;

--- a/tests/Ioxide.Tests.E2E/Ioxide.Tests.E2E.csproj
+++ b/tests/Ioxide.Tests.E2E/Ioxide.Tests.E2E.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="../Ioxide.Tests.Harness/Ioxide.Tests.Harness.csproj" />
     <ProjectReference Include="../../src/protocols/ioxide.http3/ioxide.http3.csproj" />
+    <ProjectReference Include="../../src/clients/ioxide.timer/ioxide.timer.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Ioxide.Tests.E2E/Program.cs
+++ b/tests/Ioxide.Tests.E2E/Program.cs
@@ -12,6 +12,7 @@ internal static class Program
         var runner = new Runner();
 
         CoreTests.Register(runner);
+        TimerTests.Register(runner);
         AffinityTests.Register(runner);
         HardeningTests.Register(runner);
         UdpTests.Register(runner);


### PR DESCRIPTION
Closes #212.

The reactor has been submitting `IORING_OP_TIMEOUT` for its own 250ms ticker since long before this, so the kernel-side timer was already here. There was just no way for a caller to ask for one, and without it anything needing a deadline has to build it out of a timerfd: a `timerfd_create` per waiter, a `timerfd_settime` per wait, and a read to consume the expiration.

Two pieces, split the way `ioxide.file` already splits: the verb in core, the client in its own package.

## `ioxide` &mdash; `Reactor.SubmitTimeout(nanoseconds, completion)`

Has to be in core: it is an `IRingHost` method and its implementation lives inside the reactor's op slots, its SQE submission and its teardown.

It goes through the same path as every other client op, so it inherits the slot allocation, the off-reactor marshalling and the O(1) completion routing, and needs no new dispatch case. The duration rides in the offset argument rather than widening a signature. The timespec sits in a block parallel to the op slots &mdash; the kernel reads it while the op is in flight, so tying it to the slot makes its lifetime exactly the operation's, with nothing allocated per wait. Freed in `Teardown` alongside the ticker's.

## `ioxide.timer` &mdash; `RingTimer`

`ioxide.file` wraps `SubmitRead` with a `RingOpSource` and ships as its own package to do it; `RingFile` is 59 lines against `RingTimer`'s 60. Same shape, same single dependency on core, so the same packaging.

```csharp
var timer = new RingTimer(reactor);
int result = await timer.DelayAsync(15);
if (RingTimer.Expired(result)) { /* the wait ran its course */ }
```

One `RingOpSource`, one op in flight per instance, nothing allocated per wait, completion inline on the reactor that owns the caller. It follows `RingSocket`'s conventions rather than inventing new ones, including returning results as the ring reports them rather than translating: a wait that runs its course completes with **`-ETIME`**, which is io_uring reporting expiry and is the success case here. `Expired()` exists so callers need not know that to read their own result.

## Tests

Four, in `Ioxide.Tests.E2E/Core/TimerTests.cs`, on a handler that answers after the milliseconds named in the path while holding one timer per connection &mdash; the shape a caller is meant to copy:

- the wait actually elapses
- expiry arrives as expiry, not as an error
- one timer serves a whole connection through repeated re-arming
- three concurrent connections asking for 80ms, 10ms and 40ms each get their own deadline and their own value back, rather than whichever finished parsing last

**158 passed, 0 failed** (the 7 pending are pre-existing and unrelated).

## Why it came up

An HTTP benchmark that answers after a delay named in the request, at 32,000 connections &mdash; 32,000 live deadlines. Three mechanisms measured against each other on 16 cores, and the two that avoid this API both lose:

| mechanism | rps | cpu of 3200% | us/req |
|---|---|---|---|
| per-request timerfd | 1,211,556 | 3192% | 26.3 |
| per-reactor timerfd + queue | 1,335,794 | 2678% | 20.0 |
| **`SubmitTimeout`** | **1,422,729** | **3205%** | 22.5 |

The per-reactor timer is the cheapest per request and still loses, because holding one deadline at a time means wake-ups arrive in bursts and the reactor sleeps with work already due &mdash; 522% of the box unused. The per-request timerfd occupies the machine and loses harder, because what it puts the CPU to is `timerfd_settime`. Only the ring-native op does both: every wait wakes the reactor on its own account, and nothing is spent to arrange it.

On the full 32-core cpuset that difference is worth **2,496,818 rps against 2,179,118** for the same entry.