### PR TITLE
ci: pack ioxide.timer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Pack ioxide.redis
         run: dotnet pack src/clients/ioxide.redis/ioxide.redis.csproj --configuration Release --no-build --output ./artifacts
 
+      - name: Pack ioxide.timer
+        run: dotnet pack src/clients/ioxide.timer/ioxide.timer.csproj --configuration Release --no-build --output ./artifacts
+
       - name: Pack ioxide.Kestrel
         run: dotnet pack src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj --configuration Release --no-build --output ./artifacts
 


### PR DESCRIPTION
Follow-up to #213, which merged before this reached it.

`ioxide.timer` is in `ioxide.slnx`, so CI builds it, and it has a `PackageId` and a version. But the pack steps are one hand-written block per project, so the release shipped everything except the new package: `SubmitTimeout` went out in `ioxide` 0.7.211 and the client over it did not.

```
$ curl api.nuget.org/.../ioxide/index.json        ->  0.7.209, 0.7.210, 0.7.211
$ curl api.nuget.org/.../ioxide.timer/index.json  ->  NOT FOUND
```

One step added. Checked the rest of the tree while here: **12 packable projects, 0 without a pack step.**

The version on main is already 0.7.211 and that version does not exist for this package id, so it publishes on merge; `--skip-duplicate` covers the eleven that are already out.