### PR TITLE
Finish landing ioxide.timer: pack it, and give it a Playground sample

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Pack ioxide.redis
         run: dotnet pack src/clients/ioxide.redis/ioxide.redis.csproj --configuration Release --no-build --output ./artifacts
 
+      - name: Pack ioxide.timer
+        run: dotnet pack src/clients/ioxide.timer/ioxide.timer.csproj --configuration Release --no-build --output ./artifacts
+
       - name: Pack ioxide.Kestrel
         run: dotnet pack src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj --configuration Release --no-build --output ./artifacts
 

--- a/Playground/Clients/Timer/Playground.Clients.Timer.csproj
+++ b/Playground/Clients/Timer/Playground.Clients.Timer.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net11.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace>Playground.Clients.Timer</RootNamespace>
+    <AssemblyName>Playground.Clients.Timer</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Shared/Playground.Shared.csproj" />
+    <ProjectReference Include="../../../src/ioxide/ioxide.csproj" />
+    <ProjectReference Include="../../../src/clients/ioxide.timer/ioxide.timer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Playground/Clients/Timer/Program.cs
+++ b/Playground/Clients/Timer/Program.cs
@@ -1,0 +1,184 @@
+using System.Buffers.Text;
+using System.Text.Unicode;
+using ioxide;
+using ioxide.timer;
+using ioxide.utils;
+using Playground.Shared;
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+//  timer - a deadline that never leaves the ring. GET /<ms> answers after that many
+//  milliseconds, and the wait is an io_uring timeout: one submission out, one completion back,
+//  resumed inline on the reactor that took the request. Nothing is allocated per wait, and the
+//  kernel is what holds the deadline - so a connection waiting costs no timer of ours.
+//
+//      dotnet run -c Release --project Playground/Clients/Timer
+//      curl http://127.0.0.1:8080/50
+//
+//  Needs: ioxide, ioxide.timer
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+// ── Knobs ────────────────────────────────────────────────────────────────────────────────────
+// Edit these. That is the whole mechanism - there is no config file and nothing else to find.
+// Env.Override exists only so bench/run.sh can drive the sample from outside; delete those lines
+// when you copy this out and the literals above them are the entire configuration.
+
+ushort port     = 8080;                        // http://127.0.0.1:8080/
+int    reactors = Environment.ProcessorCount;  // one ring per reactor, one reactor per core
+
+Env.Override(ref port, ref reactors);
+
+// The wait when the path names no number, so plain `curl http://127.0.0.1:8080/` shows the
+// feature. A path that does name one wins, up to the ceiling - which is here because the delay
+// comes from the request, and an unbounded one would let a client hold a connection all day.
+int defaultDelayMs = 25;
+int maxDelayMs     = 60_000;
+
+// true = await Task.Delay instead of the ring, so the two are measurable against each other
+// rather than asserted. Same server, same response; only the wait changes.
+bool useTaskDelay = false;
+
+Env.Override(ref defaultDelayMs, "PLAYGROUND_DELAY_MS");
+Env.Override(ref useTaskDelay, "PLAYGROUND_TASK_DELAY");
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+var config = new ServerConfig
+{
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
+    Tcp = new TcpOptions
+    {
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
+    },
+};
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i < threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    reactor.TcpHandle = async (r, conn) =>
+    {
+        // One timer for the connection's whole life, re-armed per request. A timer carries ONE
+        // wait at a time - one request's worth on HTTP/1.1; waiting on several deadlines at
+        // once wants a timer each. The reactor is what it submits to, so the deadline rides the
+        // ring this connection already lives on.
+        var timer = new RingTimer(r);
+
+        // The body names the wait, so the response cannot be pre-encoded the way Tcp/Raw's is.
+        // Per connection rather than per request, so it still allocates nothing per answer.
+        byte[] response = new byte[128];
+
+        try
+        {
+            while (true)
+            {
+                RecvSnapshot snapshot = await conn.ReadAsync();
+
+                int ms = defaultDelayMs;
+                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                {
+                    if (item.HasBuffer)
+                    {
+                        ms = ParseDelay(item.AsSpan(), defaultDelayMs);
+                        conn.ReturnBuffer(in item);
+                    }
+                }
+
+                ms = Math.Clamp(ms, 0, maxDelayMs);
+
+                int result;
+                if (useTaskDelay)
+                {
+                    // The deadline goes to the thread-pool timer queue and the continuation is
+                    // posted back - the round trip Tcp/Hop is about.
+                    await Task.Delay(ms);
+                    result = RingTimer.ETime;
+                }
+                else
+                {
+                    // The wait rides this reactor's ring and resumes on this thread, with the
+                    // connection's state still warm.
+                    result = await timer.DelayAsync(ms);
+                }
+
+                // An expired timeout reports -ETIME, which is this call's SUCCESS - so the check
+                // is Expired(), not result >= 0. Anything else is an errno.
+                conn.Write(response.AsSpan(0, Format(response, ms, result)));
+                await conn.FlushAsync();
+
+                if (snapshot.IsClosed) return;
+                conn.ResetRead();
+            }
+        }
+        finally
+        {
+            conn.DecRef();
+        }
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $"reactor-{i}" };
+    threads[i].Start();
+}
+
+Console.WriteLine($"[timer] {config.ReactorCount} reactors on :{config.Tcp.Port} - GET /<ms> waits that long "
+                + $"({(useTaskDelay ? "Task.Delay" : "RingTimer")}, default {defaultDelayMs}ms)");
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}
+
+// "GET /50 HTTP/1.1" -> 50. The request line is in the first buffer of any request worth the
+// name, so this looks at one and does not reassemble across reads.
+static int ParseDelay(ReadOnlySpan<byte> request, int fallback)
+{
+    int afterMethod = request.IndexOf((byte)' ');
+    if (afterMethod < 0) return fallback;
+
+    ReadOnlySpan<byte> target = request[(afterMethod + 1)..];
+    int end = target.IndexOf((byte)' ');
+    if (end < 0) return fallback;
+
+    target = target[..end].TrimStart((byte)'/');
+    return Utf8Parser.TryParse(target, out int ms, out int consumed) && consumed == target.Length
+        ? ms
+        : fallback;
+}
+
+// The response, formatted into the connection's own buffer: how long the wait was, or the errno
+// if the completion was not an expiry.
+static int Format(Span<byte> destination, int ms, int result)
+{
+    Span<byte> body = stackalloc byte[24];
+    int bodyLength;
+
+    if (RingTimer.Expired(result))
+    {
+        Utf8.TryWrite(body, $"{ms}ms", out bodyLength);
+    }
+    else
+    {
+        Utf8.TryWrite(body, $"errno {result}", out bodyLength);
+    }
+
+    Utf8.TryWrite(destination,
+        $"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {bodyLength}\r\n\r\n",
+        out int headerLength);
+
+    body[..bodyLength].CopyTo(destination[headerLength..]);
+    return headerLength + bodyLength;
+}

--- a/Playground/README.md
+++ b/Playground/README.md
@@ -122,6 +122,7 @@ reference implementation. QUIC itself is always ngtcp2 + picotls, bundled as one
 | [`Clients.File`](Clients/File/Program.cs) | 422 | A static file server: every file opened ONCE, descriptors shared across reactors, read positionally off the ring. | `ioxide.file` |
 | [`Clients.Pg`](Clients/Pg/Program.cs) | 224 | A Postgres-backed server, whole: a pool per reactor, connect/query/row streaming all ring operations. | `ioxide.pg` |
 | [`Clients.Redis`](Clients/Redis/Program.cs) | 236 | A `RedisPool` per reactor; concurrent requests share connections and pipeline automatically. | `ioxide.redis` |
+| [`Clients.Timer`](Clients/Timer/Program.cs) | 184 | A deadline that stays on the ring: `GET /<ms>` answers after that long, one `IORING_OP_TIMEOUT` per wait. A knob swaps in `Task.Delay` to price the difference. | `ioxide.timer` |
 | [`Proxy.H1ToH1`](Proxy/H1ToH1/Program.cs) | 251 | A reverse proxy with TLS on BOTH hops - ioxide TLS in, `TlsClientContext` out. Read this one first. | `ioxide.httpclient` |
 | [`Proxy.H2ToH1`](Proxy/H2ToH1/Program.cs) | 217 | The classic edge: h2 over TLS in (browsers refuse h2c), h1 origin behind. | `ioxide.http2`, `ioxide.httpclient` |
 | [`Proxy.H3ToH1`](Proxy/H3ToH1/Program.cs) | 172 | An HTTP/3 front door for an h1 upstream. `Tcp = null`, so every TCP socket the process owns is an outbound one. | `ioxide.ngtcp2`, `ioxide.nghttp3`, `ioxide.httpclient` |

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ accepted the request.
 | [`ioxide.pg`](https://www.nuget.org/packages/ioxide.pg/) | Postgres. Connect, query and stream rows on the owning ring. |
 | [`ioxide.redis`](https://www.nuget.org/packages/ioxide.redis/) | Redis. RESP2, pipelining, pub/sub. |
 | [`ioxide.file`](https://www.nuget.org/packages/ioxide.file/) | Static assets. Immutable snapshots, baked responses, positional ring reads. |
+| [`ioxide.timer`](https://www.nuget.org/packages/ioxide.timer/) | Deadlines. A wait is one `IORING_OP_TIMEOUT` on the caller's own ring - no timer thread, nothing allocated per wait. |
 
 **Serving.**
 

--- a/bench/samples.tsv
+++ b/bench/samples.tsv
@@ -72,6 +72,7 @@ Clients/Pg                    h1      8080  /           -                   -
 Clients/Redis                 h1      8080  /           -                   -
 Clients/Http                  h1      8090  /           Tcp/Raw             -
 Clients/Https                 h1      8080  /           Tls/OpenSsl         PLAYGROUND_UPSTREAM_CA=/tmp/ioxide-playground-quic/quic.crt
+Clients/Timer                 h1      8080  /           -                   PLAYGROUND_DELAY_MS=0
 Clients/Quic                  driver  -     -           -                   -
 
 # proxies, and ioxide under ASP.NET

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -235,6 +235,7 @@ nav.top .links a.gh svg { display: block; }
 #tab-quicalpn:checked ~ .ex-menu label[for="tab-quicalpn"],
 #tab-qclient:checked ~ .ex-menu label[for="tab-qclient"],
 #tab-https:checked ~ .ex-menu label[for="tab-https"],
+#tab-timer:checked ~ .ex-menu label[for="tab-timer"],
 #tab-h2cs:checked ~ .ex-menu label[for="tab-h2cs"],
 #tab-h2sresp:checked ~ .ex-menu label[for="tab-h2sresp"],
 #tab-h2sreq:checked ~ .ex-menu label[for="tab-h2sreq"],
@@ -377,6 +378,7 @@ nav.top .links a.gh svg { display: block; }
 #tab-quicalpn:checked ~ .pane-quicalpn { display: block; }
 #tab-qclient:checked ~ .pane-qclient { display: block; }
 #tab-https:checked ~ .pane-https { display: block; }
+#tab-timer:checked ~ .pane-timer { display: block; }
 #tab-h2cs:checked ~ .pane-h2cs { display: block; }
 #tab-h2sresp:checked ~ .pane-h2sresp { display: block; }
 #tab-h2sreq:checked ~ .pane-h2sreq { display: block; }
@@ -524,6 +526,7 @@ nav.top .links a.gh svg { display: block; }
   #tab-quicalpn:checked ~ .ex-menu label[for="tab-quicalpn"],
   #tab-qclient:checked ~ .ex-menu label[for="tab-qclient"],
 #tab-https:checked ~ .ex-menu label[for="tab-https"],
+#tab-timer:checked ~ .ex-menu label[for="tab-timer"],
     #tab-h2cs:checked ~ .ex-menu label[for="tab-h2cs"],
 #tab-h2sresp:checked ~ .ex-menu label[for="tab-h2sresp"],
 #tab-h2sreq:checked ~ .ex-menu label[for="tab-h2sreq"],

--- a/docs/index.html
+++ b/docs/index.html
@@ -63,6 +63,7 @@
   <input type="radio" name="mode-tabs" id="tab-files">
   <input type="radio" name="mode-tabs" id="tab-qclient">
   <input type="radio" name="mode-tabs" id="tab-https">
+  <input type="radio" name="mode-tabs" id="tab-timer">
   <input type="radio" name="mode-tabs" id="tab-tlssni">
   <input type="radio" name="mode-tabs" id="tab-tlsmtls">
   <input type="radio" name="mode-tabs" id="tab-tlsmtlsktls">
@@ -161,6 +162,7 @@
       <label for="tab-files">files</label>
       <label for="tab-https">https origins</label>
       <label for="tab-qclient">quic client</label>
+      <label for="tab-timer">timers</label>
     </details>
   </nav>
 
@@ -3272,6 +3274,181 @@ async Task EchoLoop(QuicEngineConnection quic)
     }
 }</code></pre>
     <p class="ex-foot">The client half of QUIC, and the other side of <label for="tab-qraw" class="ex-jump">quic &middot; raw streams</label> - everything else here is a server. <code>QuicClientEngine.Connect</code> needs no listener at all: it asks the reactor for an outbound transport on an ephemeral port, which is why <code>Tcp</code>, <code>Udp</code> and <code>Quic</code> are all null below. The handshake, the stream and the reads ride that reactor's ring and resume inline on it, exactly as they do server-side. It doubles as the <b>load driver</b> for the echo servers - they speak no HTTP, so wrk and h2load cannot touch them - which is what makes them benchmarkable.</p>
+  </div>
+  <div class="pane pane-timer">
+    <div class="pane-head">
+      <h3>Timers &middot; a deadline on the ring</h3>
+      <span class="pane-pkg">ioxide + ioxide.timer</span>
+    </div>
+<pre><code class="language-csharp">// dotnet add package ioxide
+// dotnet add package ioxide.timer
+//   curl http://127.0.0.1:8080/50
+
+using System.Buffers.Text;
+using System.Text.Unicode;
+using ioxide;
+using ioxide.timer;
+using ioxide.utils;
+
+// ── Knobs ────────────────────────────────────────────────────────────────────────────────────
+
+ushort port     = 8080;                        // http://127.0.0.1:8080/
+int    reactors = Environment.ProcessorCount;  // one ring per reactor, one reactor per core
+
+
+// The wait when the path names no number, so plain `curl http://127.0.0.1:8080/` shows the
+// feature. A path that does name one wins, up to the ceiling - which is here because the delay
+// comes from the request, and an unbounded one would let a client hold a connection all day.
+int defaultDelayMs = 25;
+int maxDelayMs     = 60_000;
+
+// true = await Task.Delay instead of the ring, so the two are measurable against each other
+// rather than asserted. Same server, same response; only the wait changes.
+bool useTaskDelay = false;
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+var config = new ServerConfig
+{
+    ReactorCount   = reactors,                             // io_uring rings/threads - one per core
+    RingEntries    = 8192,                                 // SQ/CQ depth per ring
+    DualStack      = false,                                // true = one IPv6 socket also accepts IPv4-mapped
+    RecvBufferSize = 32 * 1024,                            // bytes per shared recv buffer
+    RecvSlots      = 4096,                                 // shared recv buffer-ring depth
+    Incremental    = null,                                 // per-connection recv rings (6.12+) - see Tcp/Incremental
+    Udp            = null,                                 // no raw UDP sockets (TCP-only server)
+    Quic           = null,                                 // no QUIC transport - see Http3/* and Quic/Alpn
+    Tcp = new TcpOptions
+    {
+        Port             = port,
+        ExtraPorts       = [],                             // extra listener ports (one handler, several doors)
+        ListenBacklog    = 1024,                           // accept-queue depth per SO_REUSEPORT listener
+        WriteSlabSize    = 16 * 1024,                      // per-connection write buffer before overflow kicks in
+        PoolMax          = 1024,                           // pooled connection objects kept per reactor
+        WriteOverflow    = WriteOverflowStrategy.Grow,     // Grow = realloc one slab; Segmented = chain + vectored SENDMSG
+        ZeroCopySend     = false,                          // SEND_ZC: kernel copies less, wins on large writes
+        RecvQueueEntries = 64,                             // per-connection recv completion queue depth
+    },
+};
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i &lt; threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    reactor.TcpHandle = async (r, conn) =&gt;
+    {
+        // One timer for the connection&#x27;s whole life, re-armed per request. A timer carries ONE
+        // wait at a time - one request&#x27;s worth on HTTP/1.1; waiting on several deadlines at
+        // once wants a timer each. The reactor is what it submits to, so the deadline rides the
+        // ring this connection already lives on.
+        var timer = new RingTimer(r);
+
+        // The body names the wait, so the response cannot be pre-encoded the way Tcp/Raw&#x27;s is.
+        // Per connection rather than per request, so it still allocates nothing per answer.
+        byte[] response = new byte[128];
+
+        try
+        {
+            while (true)
+            {
+                RecvSnapshot snapshot = await conn.ReadAsync();
+
+                int ms = defaultDelayMs;
+                while (conn.TryGetItem(snapshot, out SpscRecvRing.Item item))
+                {
+                    if (item.HasBuffer)
+                    {
+                        ms = ParseDelay(item.AsSpan(), defaultDelayMs);
+                        conn.ReturnBuffer(in item);
+                    }
+                }
+
+                ms = Math.Clamp(ms, 0, maxDelayMs);
+
+                int result;
+                if (useTaskDelay)
+                {
+                    // The deadline goes to the thread-pool timer queue and the continuation is
+                    // posted back - the round trip Tcp/Hop is about.
+                    await Task.Delay(ms);
+                    result = RingTimer.ETime;
+                }
+                else
+                {
+                    // The wait rides this reactor&#x27;s ring and resumes on this thread, with the
+                    // connection&#x27;s state still warm.
+                    result = await timer.DelayAsync(ms);
+                }
+
+                // An expired timeout reports -ETIME, which is this call&#x27;s SUCCESS - so the check
+                // is Expired(), not result &gt;= 0. Anything else is an errno.
+                conn.Write(response.AsSpan(0, Format(response, ms, result)));
+                await conn.FlushAsync();
+
+                if (snapshot.IsClosed) return;
+                conn.ResetRead();
+            }
+        }
+        finally
+        {
+            conn.DecRef();
+        }
+    };
+
+    threads[i] = new Thread(reactor.Run) { Name = $&quot;reactor-{i}&quot; };
+    threads[i].Start();
+}
+
+Console.WriteLine($&quot;[timer] {config.ReactorCount} reactors on :{config.Tcp.Port} - GET /&lt;ms&gt; waits that long &quot;
+                + $&quot;({(useTaskDelay ? &quot;Task.Delay&quot; : &quot;RingTimer&quot;)}, default {defaultDelayMs}ms)&quot;);
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}
+
+// &quot;GET /50 HTTP/1.1&quot; -&gt; 50. The request line is in the first buffer of any request worth the
+// name, so this looks at one and does not reassemble across reads.
+static int ParseDelay(ReadOnlySpan&lt;byte&gt; request, int fallback)
+{
+    int afterMethod = request.IndexOf((byte)&#x27; &#x27;);
+    if (afterMethod &lt; 0) return fallback;
+
+    ReadOnlySpan&lt;byte&gt; target = request[(afterMethod + 1)..];
+    int end = target.IndexOf((byte)&#x27; &#x27;);
+    if (end &lt; 0) return fallback;
+
+    target = target[..end].TrimStart((byte)&#x27;/&#x27;);
+    return Utf8Parser.TryParse(target, out int ms, out int consumed) &amp;&amp; consumed == target.Length
+        ? ms
+        : fallback;
+}
+
+// The response, formatted into the connection&#x27;s own buffer: how long the wait was, or the errno
+// if the completion was not an expiry.
+static int Format(Span&lt;byte&gt; destination, int ms, int result)
+{
+    Span&lt;byte&gt; body = stackalloc byte[24];
+    int bodyLength;
+
+    if (RingTimer.Expired(result))
+    {
+        Utf8.TryWrite(body, $&quot;{ms}ms&quot;, out bodyLength);
+    }
+    else
+    {
+        Utf8.TryWrite(body, $&quot;errno {result}&quot;, out bodyLength);
+    }
+
+    Utf8.TryWrite(destination,
+        $&quot;HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {bodyLength}\r\n\r\n&quot;,
+        out int headerLength);
+
+    body[..bodyLength].CopyTo(destination[headerLength..]);
+    return headerLength + bodyLength;
+}</code></pre>
+    <p class="ex-foot">A wait is one <code>IORING_OP_TIMEOUT</code>: the kernel holds the deadline and the completion arrives on the reactor that took the request, with the connection's state still warm. Nothing is armed on the side, no syscall of its own is made to arrange it, and nothing is allocated per wait - a <code>RingTimer</code> holds ONE <code>RingOpSource</code>, so it carries one wait at a time and belongs to one connection. Which is the point at scale: 32,000 connections waiting is 32,000 deadlines the KERNEL holds, where a timerfd each would be 32,000 descriptors and a <code>timerfd_settime</code> per wait. Expiry arrives as <b>-ETIME</b>, io_uring's normal report for a timeout rather than a failure, which is why the check is <code>RingTimer.Expired</code> and not <code>result &gt;= 0</code>. The <code>useTaskDelay</code> knob swaps in <code>Task.Delay</code> - same server, same response - so the hop it costs is measurable rather than asserted; <label for="tab-hop" class="ex-jump">leaving the reactor</label> is that hop on its own.</p>
   </div>
   <div class="pane pane-https">
     <div class="pane-head">

--- a/ioxide.slnx
+++ b/ioxide.slnx
@@ -105,6 +105,7 @@
     <Project Path="Playground/Clients/Https/Playground.Clients.Https.csproj" />
     <Project Path="Playground/Clients/Http/Playground.Clients.Http.csproj" />
     <Project Path="Playground/Clients/Quic/Playground.Clients.Quic.csproj" />
+    <Project Path="Playground/Clients/Timer/Playground.Clients.Timer.csproj" />
   </Folder>
 
 

--- a/scripts/gen-docs-panes.py
+++ b/scripts/gen-docs-panes.py
@@ -425,6 +425,23 @@ PANES = {
         "One pool per reactor, opened on the reactor thread, so a query rides the same ring that "
         "accepted the request and resumes the handler inline. The host must be an IPv4 literal - a "
         "DNS lookup would block the reactor."),
+    "timer": (
+        "Clients/Timer", "Timers &middot; a deadline on the ring", "ioxide + ioxide.timer",
+        ["curl http://127.0.0.1:8080/50"],
+        "A wait is one <code>IORING_OP_TIMEOUT</code>: the kernel holds the deadline and the "
+        "completion arrives on the reactor that took the request, with the connection's state "
+        "still warm. Nothing is armed on the side, no syscall of its own is made to arrange it, "
+        "and nothing is allocated per wait - a <code>RingTimer</code> holds ONE "
+        "<code>RingOpSource</code>, so it carries one wait at a time and belongs to one "
+        "connection. Which is the point at scale: 32,000 connections waiting is 32,000 deadlines "
+        "the KERNEL holds, where a timerfd each would be 32,000 descriptors and a "
+        "<code>timerfd_settime</code> per wait. Expiry arrives as <b>-ETIME</b>, io_uring's normal "
+        "report for a timeout rather than a failure, which is why the check is "
+        "<code>RingTimer.Expired</code> and not <code>result &gt;= 0</code>. The "
+        "<code>useTaskDelay</code> knob swaps in <code>Task.Delay</code> - same server, same "
+        "response - so the hop it costs is measurable rather than asserted; "
+        "<label for=\"tab-hop\" class=\"ex-jump\">leaving the reactor</label> is that hop on its "
+        "own."),
     "redis": (
         "Clients/Redis", "Redis", "ioxide + ioxide.redis",
         ["curl http://127.0.0.1:8080/"],


### PR DESCRIPTION
`ioxide.timer` landed in #213 but did not land completely: CI never packed it, and it has no Playground sample. Both here.

## `ci: pack ioxide.timer`

The pack steps in the release workflow are one per project and hand-written, so adding a project to `ioxide.slnx` builds it but does not ship it. That is what happened to 0.7.211 — the `SubmitTimeout` in core went out, the client over it did not. Checked the rest against the tree while there; every project carrying a `PackageId` now has a pack step.

No version change is needed: `ioxide.timer` 0.7.211 was never published, so the next release picks it up at the version its siblings already carry.

## `Playground/Clients/Timer`

Every other package has a sample that is a complete server, a row in `bench/samples.tsv`, and a pane on the site generated from that same file. A package without one is a package a reader has to learn from its doc comments.

`GET /<ms>` answers after that many milliseconds:

```
dotnet run -c Release --project Playground/Clients/Timer
curl http://127.0.0.1:8080/50     # -> 50ms, after 50ms
```

It holds **one** `RingTimer` for the connection and re-arms it per request. That is the shape a caller is meant to copy, and it carries the one constraint worth knowing: a timer holds a single `RingOpSource`, so it carries one wait at a time — something waiting on several deadlines at once wants a timer each.

It also shows the thing a caller would otherwise get wrong. An expired timeout completes with **-ETIME**, which is io_uring reporting success, so the check is `RingTimer.Expired(result)` and not `result >= 0`. The sample writes `errno N` into the body when it is anything else, so a mistake there would be visible rather than silent.

The `useTaskDelay` knob runs the same server with `Task.Delay` in place of the ring — same response, only the wait changes — so the off-reactor hop it costs is measurable rather than asserted, the way `Tcp/Hop` is runnable next to `Tcp/Raw`. The delay comes from the request, so it is clamped; an unbounded one would let a client hold a connection all day.

Registered as `h1` on `:8080` with `PLAYGROUND_DELAY_MS=0`, which prices the wait itself against `Tcp/Raw` rather than measuring a sleep. `bench/any.sh --list` reports it runnable.

## Also here

`README.md`'s client package table was missing `ioxide.timer` entirely. Added.

The site's example panes are regenerated from the samples, so `scripts/gen-docs-panes.py` gains the `timer` entry and `docs/index.html` gains the tab, the pane and its three CSS rules. Only the new pane changed — the rest were already in sync, and both generators report "already up to date" on a second run.

## Verified

Against the running sample: `/` waits the default 25ms, `/50` waits 50ms, `/200` waits 200ms, a non-numeric path falls back, the ceiling holds at 60s, and three keep-alive requests on one connection each wait their own 40ms rather than sharing a deadline. The `PLAYGROUND_TASK_DELAY=1` arm serves identically. Full solution builds clean, 0 warnings.
