### PR TITLE
playground: the nghttp3 sample for both directions streamed at once

### DIFF
--- a/Playground/Http3/Nghttp3StreamedBoth/Playground.Http3.Nghttp3StreamedBoth.csproj
+++ b/Playground/Http3/Nghttp3StreamedBoth/Playground.Http3.Nghttp3StreamedBoth.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net11.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace>Playground.Http3.Nghttp3StreamedBoth</RootNamespace>
+    <AssemblyName>Playground.Http3.Nghttp3StreamedBoth</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Shared/Playground.Shared.csproj" />
+    <ProjectReference Include="../../../src/ioxide/ioxide.csproj" />
+    <ProjectReference Include="../../../src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj" />
+    <ProjectReference Include="../../../src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Playground/Http3/Nghttp3StreamedBoth/Program.cs
+++ b/Playground/Http3/Nghttp3StreamedBoth/Program.cs
@@ -1,0 +1,190 @@
+using System.Text;
+using ioxide;
+using ioxide.nghttp3;
+using ioxide.ngtcp2;
+using Playground.Shared;
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+//  nghttp3-streamed-both - HTTP/3 on nghttp3 with BOTH directions streamed, the fourth corner
+//  the other three nghttp3 samples leave empty.
+//
+//  The request body arrives through Nghttp3Request.BodyReader, pulled a chunk at a time under
+//  flow control; the response goes out through an Nghttp3ResponseWriter, one flush at a time.
+//  One call does both: RunStreamedResponseAsync dispatches at end-of-headers, so the handler is
+//  running while the upload is still on the wire.
+//
+//  "/echo" runs the two at once - read a chunk, write a chunk - which is what a proxy does.
+//  Memory stays flat however large the exchange is, because each side blocks the other.
+//
+//  Diff it against Playground/Http3/ManagedStreamedBoth: same routes, same shape, and underneath
+//  the opposite mechanism. nghttp3 owns the framing, so it PULLS body bytes when it is ready to
+//  emit DATA - a flush here means nghttp3 has taken the chunk, not that it is on the wire.
+//
+//  No "/feed" here, unlike the managed twin: an endless response does not work on this stack -
+//  nothing reaches the wire and the reactor stops serving. Every route below is bounded.
+//
+//      dotnet run -c Release --project Playground/Http3/Nghttp3StreamedBoth
+//      curl --http3-only -k https://127.0.0.1:8443/          # chunked download
+//      curl --http3-only -k --data-binary @big.bin https://127.0.0.1:8443/upload
+//      curl --http3-only -k --data-binary @big.bin https://127.0.0.1:8443/echo    # both ways
+//
+//  Needs: ioxide, ioxide.ngtcp2, ioxide.nghttp3
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+// ── Knobs ────────────────────────────────────────────────────────────────────────────────────
+// Edit these. That is the whole mechanism - there is no config file and nothing else to find.
+
+ushort quicPort = 8443;
+int    reactors = Environment.ProcessorCount;
+
+Env.OverrideQuic(ref quicPort, ref reactors);
+
+// Chunks written per response on "/", and the size of each. Their product is never held at once.
+int chunkCount = 64;
+int chunkBytes = 16 * 1024;
+
+Env.Override(ref chunkCount, "PLAYGROUND_CHUNKS");
+Env.Override(ref chunkBytes, "PLAYGROUND_CHUNK_BYTES");
+
+// Multishot recv slots per reactor. QPACK capacity 4096 advertises a decode-side dynamic table;
+// 0 is static-only, nghttp3's default.
+int  udpRecvSlots  = 16;
+long qpackCapacity = 0;
+
+Env.OverrideH3(ref udpRecvSlots, ref qpackCapacity);
+
+// A real PEM pair, or null to generate a self-signed localhost cert on first run.
+string? certOverride = null;
+string? keyOverride  = null;
+
+Env.OverrideCert(ref certOverride, ref keyOverride);
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+(string certPath, string keyPath) = QuicCert.Ensure(certOverride, keyOverride);
+
+// The last argument bounds what one connection may retain unacknowledged, which is what keeps a
+// streamed response streaming instead of quietly buffering whole. See Playground/Http3/Nghttp3Buffered
+// for the full QUIC/h3 knob set.
+using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: ["h3"], maxSendRetentionBytes: 16L << 20);
+
+var config = new ServerConfig
+{
+    ReactorCount = reactors,
+    Tcp = null,                                        // QUIC only: no TCP listener is bound
+    Udp = new UdpOptions { RecvSlots = udpRecvSlots },
+    Quic = new QuicOptions
+    {
+        Port = quicPort,
+        LocalCidLength = 8,
+        ConnectionFactory = engine.CreateFactory(),
+        // Where a moved client's packets go when several reactors share the port. Forward costs
+        // nothing until a client actually changes address; KernelFilter has the kernel route by
+        // connection id instead, which costs a little on every packet. See /how-ioxide-does-h3.
+        Routing = QuicRouting.Forward,
+    },
+};
+
+var h3Options = new Nghttp3Options
+{
+    QpackDynamicTableCapacity = qpackCapacity,                // 0 (default) = headers stay literal
+    QpackBlockedStreams       = qpackCapacity > 0 ? 100 : 0,  // raise both together for the dynamic table
+};
+
+byte[] chunk = Encoding.ASCII.GetBytes(new string('x', chunkBytes - 1) + "\n");
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i < threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    reactor.QuicHandle = (r, conn) =>
+        new Nghttp3Connection(conn, h3Options).RunStreamedResponseAsync(async (request, writer) =>
+        {
+            bool upload = request.Path.Span.SequenceEqual("/upload"u8);
+            bool echo   = request.Path.Span.SequenceEqual("/echo"u8);
+
+            if (echo)
+            {
+                // Both directions at once, which is the shape a proxy needs: read a chunk, write
+                // a chunk, and never hold more than one. Neither side can run away from the other
+                // - ReadAsync waits on the peer, FlushAsync waits on nghttp3 - so memory stays
+                // flat however large the exchange is.
+                writer.WriteHeaders(Plain());
+
+                while (true)
+                {
+                    ReadOnlyMemory<byte> part = await request.BodyReader!.ReadAsync();
+                    if (part.IsEmpty)
+                    {
+                        break;   // end of the request body
+                    }
+
+                    part.Span.CopyTo(writer.GetSpan(part.Length));
+                    writer.Advance(part.Length);
+                    await writer.FlushAsync();
+                }
+
+                await writer.CompleteAsync();
+                return;
+            }
+
+            if (upload)
+            {
+                // Read side only: pull the body a chunk at a time rather than waiting for all of
+                // it, so memory is bound by one chunk however large the upload is. Every read
+                // credits the peer's flow-control window, which is what throttles a fast sender.
+                long total = 0;
+                while (true)
+                {
+                    ReadOnlyMemory<byte> part = await request.BodyReader!.ReadAsync();
+                    if (part.IsEmpty) break;
+                    total += part.Length;   // a real app would parse or store the chunk here
+                }
+
+                writer.WriteHeaders(Plain());
+
+                byte[] count = Encoding.ASCII.GetBytes($"{total}\n");
+                count.CopyTo(writer.GetSpan(count.Length));
+                writer.Advance(count.Length);
+                await writer.FlushAsync();
+                await writer.CompleteAsync();
+                return;
+            }
+
+            // Headers first and once: HTTP/3 puts HEADERS before DATA and there is no correcting
+            // it later. No content-length - the length is not known when they go out. A GET
+            // arrives with an already-ended body reader, so there is nothing to drain.
+            writer.WriteHeaders(Plain());
+
+            for (int n = 0; n < chunkCount; n++)
+            {
+                chunk.CopyTo(writer.GetSpan(chunk.Length));
+                writer.Advance(chunk.Length);
+
+                // Returns once nghttp3 has taken the chunk. That await IS the backpressure -
+                // nothing queues up behind a peer that has stopped reading.
+                await writer.FlushAsync();
+            }
+
+            await writer.CompleteAsync();
+        });
+
+    threads[i] = new Thread(reactor.Run) { Name = $"reactor-{i}" };
+    threads[i].Start();
+}
+
+Console.WriteLine($"[nghttp3-streamed-both] {config.ReactorCount} reactors, h3 on udp :{config.Quic!.Port}, "
+                + $"{chunkCount} x {chunkBytes}-byte chunks per response, cert {certPath}");
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}
+
+static Nghttp3Response Plain()
+{
+    var response = new Nghttp3Response { Status = 200 };
+    response.Headers.Add("content-type"u8.ToArray(), "text/plain"u8.ToArray());
+    return response;
+}

--- a/Playground/README.md
+++ b/Playground/README.md
@@ -100,6 +100,7 @@ reference implementation. QUIC itself is always ngtcp2 + picotls, bundled as one
 | [`Http3.Nghttp3Request`](Http3/Nghttp3Request/Program.cs) | 220 | HTTP/3 on nghttp3 with **streamed** dispatch, and a `SIGTERM` GOAWAY drain. | `ioxide.ngtcp2`, `ioxide.nghttp3` |
 | [`Http3.Nghttp3Buffered`](Http3/Nghttp3Buffered/Program.cs) | 205 | The same server with **buffered** dispatch - one method call is the whole difference. | `ioxide.ngtcp2`, `ioxide.nghttp3` |
 | [`Http3.Nghttp3Response`](Http3/Nghttp3Response/Program.cs) | 120 | The other direction: a response body produced over time. | `ioxide.ngtcp2`, `ioxide.nghttp3` |
+| [`Http3.Nghttp3StreamedBoth`](Http3/Nghttp3StreamedBoth/Program.cs) | 190 | Both directions at once on nghttp3 - `/echo` reads a chunk and writes a chunk. The fourth corner the other three leave empty. | `ioxide.ngtcp2`, `ioxide.nghttp3` |
 | [`Http3.Sni`](Http3/Sni/Program.cs) | 118 | A certificate per host name on QUIC, registered before the engine starts serving. | `ioxide.ngtcp2`, `ioxide.http3` |
 | [`Http3.Rotate`](Http3/Rotate/Program.cs) | 195 | Renewal on QUIC: one shared engine, so a single call covers every reactor - the contrast with `Http2/Rotate`. | `ioxide.ngtcp2`, `ioxide.http3` |
 | [`Http3.MutualTls`](Http3/MutualTls/Program.cs) | 122 | The client proves who it is during the QUIC handshake, and the handler is told which peer it got. | `ioxide.ngtcp2`, `ioxide.http3` |

--- a/bench/samples.tsv
+++ b/bench/samples.tsv
@@ -55,6 +55,7 @@ Http2/Rotate                  h2      8443  /           -                   PLAY
 Http3/Nghttp3Request          h3      8443  /           -                   -
 Http3/Nghttp3Buffered         h3      8443  /           -                   -
 Http3/Nghttp3Response         h3      8443  /           -                   PLAYGROUND_CHUNKS=8 PLAYGROUND_CHUNK_BYTES=1024
+Http3/Nghttp3StreamedBoth     h3      8443  /           -                   PLAYGROUND_CHUNKS=8 PLAYGROUND_CHUNK_BYTES=1024
 Http3/ManagedBuffered         h3      8443  /           -                   -
 Http3/ManagedStreamedBoth     h3      8443  /           -                   PLAYGROUND_CHUNKS=8 PLAYGROUND_CHUNK_BYTES=1024
 Http3/Sni                     h3      8443  /           -                   -

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -231,6 +231,7 @@ nav.top .links a.gh svg { display: block; }
 #tab-h3mtls:checked ~ .ex-menu label[for="tab-h3mtls"],
 #tab-h3cs:checked ~ .ex-menu label[for="tab-h3cs"],
 #tab-h3stream:checked ~ .ex-menu label[for="tab-h3stream"],
+#tab-h3ngboth:checked ~ .ex-menu label[for="tab-h3ngboth"],
 #tab-h3buf:checked ~ .ex-menu label[for="tab-h3buf"],
 #tab-quicalpn:checked ~ .ex-menu label[for="tab-quicalpn"],
 #tab-qclient:checked ~ .ex-menu label[for="tab-qclient"],
@@ -373,6 +374,7 @@ nav.top .links a.gh svg { display: block; }
 #tab-h3mtls:checked ~ .pane-h3mtls { display: block; }
 #tab-h3cs:checked ~ .pane-h3cs { display: block; }
 #tab-h3stream:checked ~ .pane-h3stream { display: block; }
+#tab-h3ngboth:checked ~ .pane-h3ngboth { display: block; }
 #tab-h3buf:checked ~ .pane-h3buf { display: block; }
 #tab-quicalpn:checked ~ .pane-quicalpn { display: block; }
 #tab-qclient:checked ~ .pane-qclient { display: block; }
@@ -520,6 +522,7 @@ nav.top .links a.gh svg { display: block; }
 #tab-h3mtls:checked ~ .ex-menu label[for="tab-h3mtls"],
 #tab-h3cs:checked ~ .ex-menu label[for="tab-h3cs"],
 #tab-h3stream:checked ~ .ex-menu label[for="tab-h3stream"],
+#tab-h3ngboth:checked ~ .ex-menu label[for="tab-h3ngboth"],
 #tab-h3buf:checked ~ .ex-menu label[for="tab-h3buf"],
   #tab-quicalpn:checked ~ .ex-menu label[for="tab-quicalpn"],
   #tab-qclient:checked ~ .ex-menu label[for="tab-qclient"],

--- a/docs/index.html
+++ b/docs/index.html
@@ -50,6 +50,7 @@
   <input type="radio" name="mode-tabs" id="tab-h3">
   <input type="radio" name="mode-tabs" id="tab-h3cs">
   <input type="radio" name="mode-tabs" id="tab-h3stream">
+  <input type="radio" name="mode-tabs" id="tab-h3ngboth">
   <input type="radio" name="mode-tabs" id="tab-h3csstream">
   <input type="radio" name="mode-tabs" id="tab-h3mtls">
   <input type="radio" name="mode-tabs" id="tab-h3buf">
@@ -138,6 +139,7 @@
       <label for="tab-h3buf">h3 &middot; buffered (nghttp3)</label>
       <label for="tab-h3">h3 &middot; request streamed (nghttp3)</label>
       <label for="tab-h3stream">h3 &middot; response streamed (nghttp3)</label>
+      <label for="tab-h3ngboth">h3 &middot; request + response streamed (nghttp3)</label>
     </details>
 
     <details class="ex-sect">
@@ -2534,6 +2536,172 @@ foreach (Thread thread in threads)
     thread.Join();
 }</code></pre>
     <p class="ex-foot">The response body produced OVER TIME instead of handed over whole - each flush becomes a DATA frame. That is what <code>/feed</code> demonstrates: an endless response has no final byte, so a buffered API cannot express it at all. <code>Nghttp3ResponseWriter</code> is an <code>IBufferWriter&lt;byte&gt;</code>, so a serializer or a framework's response sink writes into it unchanged, and <code>FlushAsync</code> returning only once nghttp3 has taken the chunk is what stops a producer outrunning a peer that has stopped reading. nghttp3 PULLS body bytes rather than accepting pushes, which is why this carries a resume and a drain the pure-C# writer does not need.</p>
+  </div>
+  <div class="pane pane-h3ngboth">
+    <div class="pane-head">
+      <h3>HTTP/3 &middot; request + response streamed (nghttp3)</h3>
+      <span class="pane-pkg">ioxide + ioxide.ngtcp2 + ioxide.nghttp3</span>
+    </div>
+<pre><code class="language-csharp">// dotnet add package ioxide
+// dotnet add package ioxide.ngtcp2
+// dotnet add package ioxide.nghttp3
+//   curl --http3-only -k https://127.0.0.1:8443/
+//   curl --http3-only -k --data-binary @big.bin https://127.0.0.1:8443/echo
+
+using System.Text;
+using ioxide;
+using ioxide.nghttp3;
+using ioxide.ngtcp2;
+
+// ── Knobs ────────────────────────────────────────────────────────────────────────────────────
+
+ushort quicPort = 8443;
+int    reactors = Environment.ProcessorCount;
+
+
+// Chunks written per response on &quot;/&quot;, and the size of each. Their product is never held at once.
+int chunkCount = 64;
+int chunkBytes = 16 * 1024;
+
+
+// Multishot recv slots per reactor. QPACK capacity 4096 advertises a decode-side dynamic table;
+// 0 is static-only, nghttp3&#x27;s default.
+int  udpRecvSlots  = 16;
+long qpackCapacity = 0;
+
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+const string certPath = &quot;cert.pem&quot;;   // any PEM pair
+const string keyPath  = &quot;key.pem&quot;;
+
+// The last argument bounds what one connection may retain unacknowledged, which is what keeps a
+// streamed response streaming instead of quietly buffering whole. See Playground/Http3/Nghttp3Buffered
+// for the full QUIC/h3 knob set.
+using var engine = new QuicEngine(certPath, keyPath, cidLength: 8, alpn: [&quot;h3&quot;], maxSendRetentionBytes: 16L &lt;&lt; 20);
+
+var config = new ServerConfig
+{
+    ReactorCount = reactors,
+    Tcp = null,                                        // QUIC only: no TCP listener is bound
+    Udp = new UdpOptions { RecvSlots = udpRecvSlots },
+    Quic = new QuicOptions
+    {
+        Port = quicPort,
+        LocalCidLength = 8,
+        ConnectionFactory = engine.CreateFactory(),
+        // Where a moved client&#x27;s packets go when several reactors share the port. Forward costs
+        // nothing until a client actually changes address; KernelFilter has the kernel route by
+        // connection id instead, which costs a little on every packet. See /how-ioxide-does-h3.
+        Routing = QuicRouting.Forward,
+    },
+};
+
+var h3Options = new Nghttp3Options
+{
+    QpackDynamicTableCapacity = qpackCapacity,                // 0 (default) = headers stay literal
+    QpackBlockedStreams       = qpackCapacity &gt; 0 ? 100 : 0,  // raise both together for the dynamic table
+};
+
+byte[] chunk = Encoding.ASCII.GetBytes(new string(&#x27;x&#x27;, chunkBytes - 1) + &quot;\n&quot;);
+
+var threads = new Thread[config.ReactorCount];
+
+for (int i = 0; i &lt; threads.Length; i++)
+{
+    var reactor = new Reactor(i, config);
+
+    reactor.QuicHandle = (r, conn) =&gt;
+        new Nghttp3Connection(conn, h3Options).RunStreamedResponseAsync(async (request, writer) =&gt;
+        {
+            bool upload = request.Path.Span.SequenceEqual(&quot;/upload&quot;u8);
+            bool echo   = request.Path.Span.SequenceEqual(&quot;/echo&quot;u8);
+
+            if (echo)
+            {
+                // Both directions at once, which is the shape a proxy needs: read a chunk, write
+                // a chunk, and never hold more than one. Neither side can run away from the other
+                // - ReadAsync waits on the peer, FlushAsync waits on nghttp3 - so memory stays
+                // flat however large the exchange is.
+                writer.WriteHeaders(Plain());
+
+                while (true)
+                {
+                    ReadOnlyMemory&lt;byte&gt; part = await request.BodyReader!.ReadAsync();
+                    if (part.IsEmpty)
+                    {
+                        break;   // end of the request body
+                    }
+
+                    part.Span.CopyTo(writer.GetSpan(part.Length));
+                    writer.Advance(part.Length);
+                    await writer.FlushAsync();
+                }
+
+                await writer.CompleteAsync();
+                return;
+            }
+
+            if (upload)
+            {
+                // Read side only: pull the body a chunk at a time rather than waiting for all of
+                // it, so memory is bound by one chunk however large the upload is. Every read
+                // credits the peer&#x27;s flow-control window, which is what throttles a fast sender.
+                long total = 0;
+                while (true)
+                {
+                    ReadOnlyMemory&lt;byte&gt; part = await request.BodyReader!.ReadAsync();
+                    if (part.IsEmpty) break;
+                    total += part.Length;   // a real app would parse or store the chunk here
+                }
+
+                writer.WriteHeaders(Plain());
+
+                byte[] count = Encoding.ASCII.GetBytes($&quot;{total}\n&quot;);
+                count.CopyTo(writer.GetSpan(count.Length));
+                writer.Advance(count.Length);
+                await writer.FlushAsync();
+                await writer.CompleteAsync();
+                return;
+            }
+
+            // Headers first and once: HTTP/3 puts HEADERS before DATA and there is no correcting
+            // it later. No content-length - the length is not known when they go out. A GET
+            // arrives with an already-ended body reader, so there is nothing to drain.
+            writer.WriteHeaders(Plain());
+
+            for (int n = 0; n &lt; chunkCount; n++)
+            {
+                chunk.CopyTo(writer.GetSpan(chunk.Length));
+                writer.Advance(chunk.Length);
+
+                // Returns once nghttp3 has taken the chunk. That await IS the backpressure -
+                // nothing queues up behind a peer that has stopped reading.
+                await writer.FlushAsync();
+            }
+
+            await writer.CompleteAsync();
+        });
+
+    threads[i] = new Thread(reactor.Run) { Name = $&quot;reactor-{i}&quot; };
+    threads[i].Start();
+}
+
+Console.WriteLine($&quot;[nghttp3-streamed-both] {config.ReactorCount} reactors, h3 on udp :{config.Quic!.Port}, &quot;
+                + $&quot;{chunkCount} x {chunkBytes}-byte chunks per response, cert {certPath}&quot;);
+
+foreach (Thread thread in threads)
+{
+    thread.Join();
+}
+
+static Nghttp3Response Plain()
+{
+    var response = new Nghttp3Response { Status = 200 };
+    response.Headers.Add(&quot;content-type&quot;u8.ToArray(), &quot;text/plain&quot;u8.ToArray());
+    return response;
+}</code></pre>
+    <p class="ex-foot">The fourth corner the other three nghttp3 samples leave empty: the request pulled through <code>BodyReader</code> while the response is pushed through the writer, both in one handler. One call arranges it - <code>RunStreamedResponseAsync</code> dispatches at end-of-headers, so the handler is running while the upload is still on the wire. <code>/echo</code> is the shape a proxy needs: read a chunk, write a chunk, never hold more than one, and neither side can outrun the other because <code>ReadAsync</code> waits on the peer and <code>FlushAsync</code> waits on nghttp3. Measured here on a 64 MiB echo: byte-identical out, and the server's RSS moved 51&rarr;57 MB - flat, in the sense that matters. Diff it against <label for="tab-h3csstream" class="ex-jump">the pure-C# twin</label>: same routes, opposite mechanism underneath. nghttp3 owns the framing and <b>pulls</b> body bytes when it has room to emit DATA, so a flush here means <em>nghttp3 has taken the chunk</em>, where the managed writer stages a DATA frame the moment you flush. That twin also serves an endless <code>/feed</code>; this one deliberately does not, because on this stack an endless response never reaches the wire.</p>
   </div>
   <div class="pane pane-h3csstream">
     <div class="pane-head">

--- a/ioxide.slnx
+++ b/ioxide.slnx
@@ -82,6 +82,7 @@
     <Project Path="Playground/Http3/ManagedStreamedBoth/Playground.Http3.ManagedStreamedBoth.csproj" />
     <Project Path="Playground/Http3/MutualTls/Playground.Http3.MutualTls.csproj" />
     <Project Path="Playground/Http3/Nghttp3Response/Playground.Http3.Nghttp3Response.csproj" />
+    <Project Path="Playground/Http3/Nghttp3StreamedBoth/Playground.Http3.Nghttp3StreamedBoth.csproj" />
     <Project Path="Playground/Http3/Sni/Playground.Http3.Sni.csproj" />
     <Project Path="Playground/Http3/Rotate/Playground.Http3.Rotate.csproj" />
   </Folder>

--- a/scripts/gen-docs-panes.py
+++ b/scripts/gen-docs-panes.py
@@ -239,6 +239,26 @@ PANES = {
         "<label for=\"tab-h3stream\" class=\"ex-jump\">nghttp3 &middot; streamed</label> carries a "
         "resume and a drain because nghttp3 pulls instead; this measures <b>1.32&times;</b> its "
         "throughput on the same 8&times;1&nbsp;KiB response."),
+    "h3ngboth": (
+        "Http3/Nghttp3StreamedBoth", "HTTP/3 &middot; request + response streamed (nghttp3)",
+        "ioxide + ioxide.ngtcp2 + ioxide.nghttp3",
+        ["curl --http3-only -k https://127.0.0.1:8443/",
+         "curl --http3-only -k --data-binary @big.bin https://127.0.0.1:8443/echo"],
+        "The fourth corner the other three nghttp3 samples leave empty: the request pulled through "
+        "<code>BodyReader</code> while the response is pushed through the writer, both in one "
+        "handler. One call arranges it - <code>RunStreamedResponseAsync</code> dispatches at "
+        "end-of-headers, so the handler is running while the upload is still on the wire. "
+        "<code>/echo</code> is the shape a proxy needs: read a chunk, write a chunk, never hold "
+        "more than one, and neither side can outrun the other because <code>ReadAsync</code> waits "
+        "on the peer and <code>FlushAsync</code> waits on nghttp3. Measured here on a 64 MiB echo: "
+        "byte-identical out, and the server's RSS moved 51&rarr;57 MB - flat, in the sense that "
+        "matters. Diff it against "
+        "<label for=\"tab-h3csstream\" class=\"ex-jump\">the pure-C# twin</label>: same routes, "
+        "opposite mechanism underneath. nghttp3 owns the framing and <b>pulls</b> body bytes when "
+        "it has room to emit DATA, so a flush here means <em>nghttp3 has taken the chunk</em>, "
+        "where the managed writer stages a DATA frame the moment you flush. That twin also serves "
+        "an endless <code>/feed</code>; this one deliberately does not, because on this stack an "
+        "endless response never reaches the wire."),
     "h3buf": (
         "Http3/Nghttp3Buffered", "HTTP/3 &middot; buffered (nghttp3)", "ioxide + ioxide.ngtcp2 + ioxide.nghttp3",
         ["curl --http3-only -k https://127.0.0.1:8443/"],


### PR DESCRIPTION
The nghttp3 HTTP/3 samples covered three of the four corners and not the fourth:

| | response buffered | response streamed |
| --- | --- | --- |
| **request buffered** | `Http3/Nghttp3Buffered` | `Http3/Nghttp3Response` |
| **request streamed** | `Http3/Nghttp3Request` | *(nothing)* |

The pure-C# stack has that corner as `Http3/ManagedStreamedBoth`, and its pane on the site points at the nghttp3 side for the contrast — so the thing being contrasted did not exist.

Nothing new was needed to make it work. `RunStreamedResponseAsync` already sets `_streaming`, so the request arrives through `Nghttp3Request.BodyReader` at end-of-headers while the response goes out through the writer: one call is both directions. No sample showed it.

## The sample

Same routes as the managed twin, so the two can be diffed line for line:

```
curl --http3-only -k https://127.0.0.1:8443/                                   # chunked down
curl --http3-only -k --data-binary @big.bin https://127.0.0.1:8443/upload      # pulled up
curl --http3-only -k --data-binary @big.bin https://127.0.0.1:8443/echo        # both at once
```

`/echo` is the point: read a chunk, write a chunk, never hold more than one. Neither side can outrun the other, because `ReadAsync` waits on the peer and `FlushAsync` waits on nghttp3.

Underneath, the mechanism is the opposite of the managed twin's, which is what makes having both worth it. nghttp3 owns the framing and **pulls** body bytes when it has room to emit DATA, so a flush here means *nghttp3 has taken the chunk*; the managed writer stages a DATA frame the moment you flush.

Registered in `ioxide.slnx`, `Playground/README.md` and `bench/samples.tsv`, and on the site as **h3 · request + response streamed (nghttp3)**, generated from the sample like every other pane.

## Verified

Against the running sample with a single listener asserted (no leaked co-bound servers):

| | result |
| --- | --- |
| `/` at 64 × 16 KiB | 200, full 1,048,576 bytes |
| `/upload` of 64 MiB | 200, counted 67,108,864 exactly |
| `/echo` of 64 MiB | 200, **byte-identical** round trip in 0.37 s |
| server RSS across that echo | 51 → 57 MB |
| after all of it | still serving, reactors back to idle |

## No `/feed` here, unlike the managed twin

An endless response does not work on this stack, and this is worth its own issue rather than a workaround in a sample. On the **shipped** `Http3/Nghttp3Response`, one listener, nothing else bound:

| | `/` (finite) | `/feed` (endless) | after the reader disconnects |
| --- | --- | --- | --- |
| `ioxide.nghttp3` | 200, full body | **no headers, 0 bytes, client times out** | a reactor spins at ~100% CPU, every later request fails |
| `ioxide.http3` | 200, full body | 200, `text/event-stream`, 2.1 GB in 3 s | keeps serving, back to idle |

Likely mechanism, offered as a hypothesis rather than a finding: `DrainStreamedCore` returns only when the producer stops or `PumpEgress` reports nothing moved. An endless handler keeps staging chunks that nghttp3 keeps accepting, so `produced` never goes false, the loop never hands the thread back, and the reactor never gets to send — which is also why no headers arrive. The `if (!produced) return;` guard is commented as covering exactly this case and does not fire.

That is not this sample's to solve, and not its place to repeat, so every route here is bounded. It does mean `Http3/Nghttp3Response`'s banner and its site pane currently tell you to run a request that wedges the server — worth fixing in one direction or the other, separately from this.
