### PR TITLE
http2: take the credit wait before the flush that provokes the credit

### DIFF
--- a/src/clients/ioxide.file/ioxide.file.csproj
+++ b/src/clients/ioxide.file/ioxide.file.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.file</RootNamespace>
 
     <PackageId>ioxide.file</PackageId>
-    <Version>0.13.218</Version>
+    <Version>0.13.225</Version>
     <Authors>MDA2AV</Authors>
     <Description>File serving for the ioxide io_uring runtime: immutable asset snapshots with baked responses, pooled positional ring reads, atomic reloads.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
+++ b/src/clients/ioxide.httpclient/ioxide.httpclient.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.httpclient</RootNamespace>
 
     <PackageId>ioxide.httpclient</PackageId>
-    <Version>0.13.218</Version>
+    <Version>0.13.225</Version>
     <Authors>MDA2AV</Authors>
     <Description>The ring-native HTTP/1.1 client for the ioxide io_uring runtime - the upstream leg between a proxy and an origin. Connections are opened on the reactor thread that will use them, so a request never crosses a thread on its way out or back, and every response resumes the awaiting handler inline on its own reactor. Includes client-side TLS (SNI, ALPN, certificate verification and client certificates for mutual TLS) for https:// origins. Depends on ioxide core alone: no protocol package, no native asset.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.pg/ioxide.pg.csproj
+++ b/src/clients/ioxide.pg/ioxide.pg.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.pg</RootNamespace>
 
     <PackageId>ioxide.pg</PackageId>
-    <Version>0.13.218</Version>
+    <Version>0.13.225</Version>
     <Authors>MDA2AV</Authors>
     <Description>Postgres driver for the ioxide io_uring runtime: pooled ring-native connections per reactor, ring-native connect and handshake, inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.redis/ioxide.redis.csproj
+++ b/src/clients/ioxide.redis/ioxide.redis.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.redis</RootNamespace>
 
     <PackageId>ioxide.redis</PackageId>
-    <Version>0.13.218</Version>
+    <Version>0.13.225</Version>
     <Authors>MDA2AV</Authors>
     <Description>Redis client for the ioxide io_uring runtime: pooled ring-native connections per reactor, full RESP2 protocol, a generic command API plus typed helpers (strings, keys, hashes, lists, sets, sorted sets, pub/sub, transactions, scripting), and pipelining. Inline completion resume.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/clients/ioxide.timer/ioxide.timer.csproj
+++ b/src/clients/ioxide.timer/ioxide.timer.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.timer</RootNamespace>
 
     <PackageId>ioxide.timer</PackageId>
-    <Version>0.13.218</Version>
+    <Version>0.13.225</Version>
     <Authors>MDA2AV</Authors>
     <Description>Deadlines for the ioxide io_uring runtime: waits submitted to the reactor's own ring with IORING_OP_TIMEOUT, completing inline on the reactor that owns the caller, with no timer thread and nothing allocated per wait.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/ioxide/ioxide.csproj
+++ b/src/ioxide/ioxide.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide</RootNamespace>
 
     <PackageId>ioxide</PackageId>
-    <Version>0.13.218</Version>
+    <Version>0.13.225</Version>
     <Authors>MDA2AV</Authors>
     <Description>A shared-nothing io_uring runtime for .NET: one ring per reactor thread, inline completions, zero native dependencies. The engine - reactor, connection, and the IRingHost client seam. Includes TLS termination: the OpenSSL handshake driven over the ring, then kernel TLS (kTLS) transmit offload, so handlers keep writing plaintext. TLS needs OpenSSL 3 and the Linux tls module; nothing else does, and neither is loaded unless you use it.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http2/Http2ResponseWriter.cs
+++ b/src/protocols/ioxide.http2/Http2ResponseWriter.cs
@@ -156,6 +156,13 @@ public sealed class Http2ResponseWriter : IBufferWriter<byte>
                     return;
                 }
 
+                // Take the wait BEFORE flushing. The flush below is an await, and the WINDOW_UPDATE
+                // it exists to provoke can arrive while this writer is still inside it - at which
+                // point a release has no waiter to find, is dropped, and the writer then parks on a
+                // message that has already been and gone. Registering first means that credit
+                // completes this task instead, and the await below returns at once.
+                Task credited = _connection.WaitForSendCreditAsync(_streamId);
+
                 // Everything staged so far has to REACH the peer before waiting on it to open the
                 // window. WINDOW_UPDATE is what a peer sends once it has consumed DATA, so parking
                 // with those bytes still in the connection's buffer waits for a message that the
@@ -166,7 +173,7 @@ public sealed class Http2ResponseWriter : IBufferWriter<byte>
                 _sinceRealFlush = 0;
                 await _connection.FlushOutboundAsync();
 
-                await _connection.WaitForSendCreditAsync(_streamId);
+                await credited;
                 continue;
             }
 

--- a/src/protocols/ioxide.http2/ioxide.http2.csproj
+++ b/src/protocols/ioxide.http2/ioxide.http2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http2</RootNamespace>
 
     <PackageId>ioxide.http2</PackageId>
-    <Version>0.13.218</Version>
+    <Version>0.13.225</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure-C# HTTP/2 for the ioxide io_uring runtime: framing, HPACK (static and dynamic tables, Huffman) and flow control, with zero native code. Serves h2c with prior knowledge and h2 over TLS by ALPN, buffered or streamed in either direction.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.http3/ioxide.http3.csproj
+++ b/src/protocols/ioxide.http3/ioxide.http3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.http3</RootNamespace>
 
     <PackageId>ioxide.http3</PackageId>
-    <Version>0.13.218</Version>
+    <Version>0.13.225</Version>
     <Authors>MDA2AV</Authors>
     <Description>Pure C# HTTP/3 for the ioxide io_uring runtime: frame parsing, QPACK (static table + Huffman) and request dispatch with zero native dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, drop-in alternative to ioxide.nghttp3.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
+++ b/src/protocols/ioxide.nghttp2/ioxide.nghttp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp2</RootNamespace>
 
     <PackageId>ioxide.nghttp2</PackageId>
-    <Version>0.13.218</Version>
+    <Version>0.13.225</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/2 for the ioxide io_uring runtime: framing, HPACK and flow control from nghttp2, statically linked behind a small shim with no external dependencies beyond libc. Serves HTTP/2 over any TcpConnection - h2c with prior knowledge, or h2 over TLS via ALPN. nghttp2 is sans-I/O, so ioxide keeps the ring and the loop.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
+++ b/src/protocols/ioxide.nghttp3/ioxide.nghttp3.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.nghttp3</RootNamespace>
 
     <PackageId>ioxide.nghttp3</PackageId>
-    <Version>0.13.218</Version>
+    <Version>0.13.225</Version>
     <Authors>MDA2AV</Authors>
     <Description>HTTP/3 layer for the ioxide io_uring runtime: nghttp3 (H3 + QPACK) bundled as a single self-contained native library with no external dependencies. Rides any QuicConnection via its stream read surface - engine-agnostic, no ioxide.ngtcp2 dependency.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
+++ b/src/protocols/ioxide.ngtcp2/ioxide.ngtcp2.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.ngtcp2</RootNamespace>
 
     <PackageId>ioxide.ngtcp2</PackageId>
-    <Version>0.13.218</Version>
+    <Version>0.13.225</Version>
     <Authors>MDA2AV</Authors>
     <Description>QUIC engine for the ioxide io_uring runtime: ngtcp2 + picotls bundled as a single self-contained native library (only system dependency: libcrypto.so.3 / OpenSSL 3.x). Plugs into the reactor's QUIC transport via QuicConnection. Server side; engine bindings in progress.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
+++ b/src/serving/ioxide.Kestrel/ioxide.Kestrel.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>ioxide.Kestrel</RootNamespace>
 
     <PackageId>ioxide.Kestrel</PackageId>
-    <Version>0.13.218</Version>
+    <Version>0.13.225</Version>
     <Authors>MDA2AV</Authors>
     <Description>ASP.NET Core Kestrel transport backed by the ioxide io_uring runtime: one reactor (ring) per core, SO_REUSEPORT load-balanced, with Kestrel's HTTP request loop pinned to the reactor thread. Drop-in via UseIoxide().</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/Ioxide.Tests.Unit/Http2StreamedBodyTests.cs
+++ b/tests/Ioxide.Tests.Unit/Http2StreamedBodyTests.cs
@@ -204,6 +204,58 @@ internal static class Http2StreamedBodyTests
 
             client.Close(run);
         });
+
+        runner.Test("h2 body: credit arriving while the pre-park flush is in flight is not lost", () =>
+        {
+            // Before parking on credit the writer flushes what it has staged, because the peer only
+            // sends WINDOW_UPDATE once it has consumed DATA. That flush is an await, so the credit
+            // can arrive while the writer is inside it - before it has registered as a waiter. The
+            // wake-up then has nowhere to be recorded, and the writer parks on a message that has
+            // already been and gone.
+            //
+            // DrainWithCredit cannot see this: it only credits once the flush has been released and
+            // the writer is already registered. So this drains the other way round - credit first,
+            // release second - which puts every WINDOW_UPDATE inside the window that loses it.
+            byte[] file = Pattern(200_000);   // past the 65535-byte initial window, so it must park
+
+            using var client = new StrictClient();
+            Task run = client.Connection.RunAsync(async (_, writer) =>
+            {
+                writer.WriteHeaders(new Http2Response { Status = 200 });
+                await WriteChunked(writer, file);
+            });
+
+            client.ReleaseFlush();
+            client.SendRequests(1);
+
+            var frames = new List<Frame>();
+
+            for (int turn = 0; turn < 4096; turn++)
+            {
+                if (client.PendingFlushes == 0)
+                {
+                    // Nothing left in flight. Either the stream finished, or the writer is parked on
+                    // a wake-up that was dropped - the assertions below say which.
+                    break;
+                }
+
+                // Deliberately small. A window big enough to carry the rest of the file would let
+                // the writer finish without ever parking, which is the case this is not about.
+                client.SendWindowUpdate(1, 8 * 1024);
+                client.SendWindowUpdate(0, 8 * 1024);
+
+                frames.AddRange(Frame.Walk(client.ReleaseFlush()));
+
+                if (frames.Any(f => f is { Type: Frame.Data, EndStream: true } && f.StreamId == 1))
+                {
+                    break;
+                }
+            }
+
+            AssertBody(file, frames, streamId: 1);
+
+            client.Close(run);
+        });
     }
 
     // The IoxideFiles copy loop: stage at most Chunk bytes, drain, repeat - then end the stream.


### PR DESCRIPTION
## The bug

A streamed HTTP/2 writer that runs out of window flushes what it has staged before parking, because WINDOW_UPDATE is what a peer sends once it has consumed DATA — parking with those bytes still buffered waits for a message that the wait itself prevents.

That flush is an `await`, and the WINDOW_UPDATE it exists to provoke can arrive while the writer is still inside it:

```
credit == 0
  -> await FlushOutboundAsync()      <- WINDOW_UPDATE lands here
  -> WaitForSendCreditAsync(stream)  <- registers only now
```

`ReleaseCreditWaiters` runs during the flush, finds no waiter for the stream, and drops the wake-up. The writer then registers and parks on a message that has already been and gone. The response stops mid-body and the client stalls until its own timeout.

Registering before the flush closes it: credit arriving during the flush completes that task, and the await after it returns at once. It is the only call site.

## How it showed up

Intermittent 10-second `TaskCanceledException` timeouts in GenHTTP's acceptance suite, on the two tests that push a body past the initial 65535-byte window. Roughly one run in eight, and never in isolation — 22 consecutive runs of those tests alone passed, including pinned to two CPUs.

## The test

`h2 body: credit arriving while the pre-park flush is in flight is not lost` drives it deterministically. Two details matter, both learned the hard way:

- It credits **while a flush is still in flight**, then releases. `DrainWithCredit` credits only once `PendingFlushes` is 0 — after the flush has been released and the writer is already registered — which is why the existing coverage never saw this.
- It credits **8 KiB at a time**. An earlier draft credited 1 MiB up front and passed against the bug, because a window big enough to carry the rest of the body lets the writer finish without ever parking.

It fails on `main` (`DATA with END_STREAM for stream 1` never arrives) and passes with the fix.

## Validation

Unit 43, E2E 180, Chaos 47, Http 44, File 4 — 0 failed.